### PR TITLE
fix: Split-adjust price history server-side

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -12,6 +12,7 @@ import com.beancounter.common.utils.TestEnvironmentUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.event.EventProducer
+import com.beancounter.marketdata.providers.alpha.AlphaEventService
 import com.beancounter.marketdata.providers.custom.PrivateMarketDataProvider
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -33,6 +34,12 @@ class PriceService(
     private val log = LoggerFactory.getLogger(PriceService::class.java)
     private var eventProducer: EventProducer? = null
     private var cacheInvalidationProducer: CacheInvalidationProducer? = null
+    private var alphaEventService: AlphaEventService? = null
+
+    @Autowired(required = false)
+    fun setAlphaEventService(alphaEventService: AlphaEventService?) {
+        this.alphaEventService = alphaEventService
+    }
 
     @Autowired(required = false)
     fun setEventWriter(eventProducer: EventProducer?) {
@@ -389,10 +396,49 @@ class PriceService(
             marketDataRepo
                 .findPriceHistory(assetId, from, to)
                 .map(PricePoint::from)
+        val splitEvents = collectSplitEvents(asset, from, to)
         return PriceHistoryResponse(
             asset = asset,
-            prices = SplitAdjuster.adjust(rawPrices)
+            prices = SplitAdjuster.adjust(rawPrices, splitEvents)
         )
+    }
+
+    /**
+     * Pulls known split events for the asset within the requested range.
+     *
+     * The historical backfill via Alpha's TIME_SERIES_DAILY does not carry
+     * split coefficients, so the database can hold raw pre-split closes
+     * with split=1 across the board. AlphaEventService (cached) returns
+     * splits sourced from TIME_SERIES_DAILY_ADJUSTED which contains the
+     * coefficients on each ex-date. Without this, [SplitAdjuster] would
+     * have nothing to detect when the price rows themselves are bare.
+     */
+    private fun collectSplitEvents(
+        asset: Asset,
+        from: LocalDate,
+        to: LocalDate
+    ): List<SplitAdjuster.SplitEvent> {
+        val service = alphaEventService ?: return emptyList()
+        return try {
+            service
+                .getEvents(asset)
+                .data
+                .asSequence()
+                .filter(::isSplit)
+                .filter { !it.priceDate.isBefore(from) && !it.priceDate.isAfter(to) }
+                .map { SplitAdjuster.SplitEvent(it.priceDate, it.split) }
+                .toList()
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.warn(
+                "Failed to load split events for {}: {}",
+                asset.code,
+                e.message
+            )
+            emptyList()
+        }
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -385,11 +385,14 @@ class PriceService(
         to: LocalDate
     ): PriceHistoryResponse {
         val asset = assetFinder.find(assetId)
-        val prices =
+        val rawPrices =
             marketDataRepo
                 .findPriceHistory(assetId, from, to)
                 .map(PricePoint::from)
-        return PriceHistoryResponse(asset = asset, prices = prices)
+        return PriceHistoryResponse(
+            asset = asset,
+            prices = SplitAdjuster.adjust(rawPrices)
+        )
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -1,0 +1,91 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.contracts.PricePoint
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * Rebases a chronological list of [PricePoint]s onto the most recent
+ * post-split share basis.
+ *
+ * Provider data carries the split coefficient on the ex-date row (and
+ * occasionally on a sticky neighbour — Alpha Vantage's ±1-day enricher
+ * fallback was a known source of this). Pre-event rows store raw
+ * pre-split prices; ex-date and post-event rows store adjusted prices.
+ *
+ * The frontend used to perform this rebasing itself, which left the
+ * adjustment scattered across each consumer and at risk of double-
+ * dividing when stale stamps lingered on more than one row. Doing it
+ * once here means every caller gets clean, charting-ready data.
+ *
+ * Algorithm:
+ *  - Walk forward and identify ex-dates as rows where `split != 1` and
+ *    the previous row's `split == 1`. Consecutive non-1 rows belong to
+ *    the same event (sticky stamps) so only the first counts.
+ *  - For each ex-date event, divide every OHLC + previousClose value
+ *    on every row strictly before the event index by the event's split
+ *    factor. Multiple events compound.
+ *  - Normalise the `split` column so only the canonical ex-date keeps
+ *    its non-1 value; sticky neighbours are reset to 1 to give the
+ *    chart a single split marker.
+ */
+object SplitAdjuster {
+    private const val SCALE = 6
+    private val ROUNDING = RoundingMode.HALF_UP
+
+    fun adjust(prices: List<PricePoint>): List<PricePoint> {
+        if (prices.isEmpty()) return prices
+
+        data class SplitEvent(
+            val firstIdx: Int,
+            val factor: BigDecimal
+        )
+
+        val events = mutableListOf<SplitEvent>()
+        for (i in prices.indices) {
+            val cur = prices[i].split
+            val prev = if (i > 0) prices[i - 1].split else BigDecimal.ONE
+            val curIsSplit = cur.compareTo(BigDecimal.ONE) != 0 && cur.signum() > 0
+            val prevIsFlat = prev.compareTo(BigDecimal.ONE) == 0
+            if (curIsSplit && prevIsFlat) {
+                events.add(SplitEvent(i, cur))
+            }
+        }
+        if (events.isEmpty()) return prices
+
+        return prices.mapIndexed { i, p ->
+            var factor = BigDecimal.ONE
+            for (ev in events) {
+                if (i < ev.firstIdx) factor = factor.multiply(ev.factor)
+            }
+            val normalisedSplit =
+                if (events.any { it.firstIdx == i }) {
+                    p.split
+                } else {
+                    BigDecimal.ONE
+                }
+            if (factor.compareTo(BigDecimal.ONE) == 0 && normalisedSplit == p.split) {
+                p
+            } else {
+                p.copy(
+                    close = divideIfPositive(p.close, factor),
+                    open = divideIfPositive(p.open, factor),
+                    high = divideIfPositive(p.high, factor),
+                    low = divideIfPositive(p.low, factor),
+                    previousClose = divideIfPositive(p.previousClose, factor),
+                    split = normalisedSplit
+                )
+            }
+        }
+    }
+
+    private fun divideIfPositive(
+        value: BigDecimal,
+        factor: BigDecimal
+    ): BigDecimal =
+        if (factor.compareTo(BigDecimal.ONE) == 0 || value.signum() == 0) {
+            value
+        } else {
+            value.divide(factor, SCALE, ROUNDING)
+        }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -3,68 +3,76 @@ package com.beancounter.marketdata.providers
 import com.beancounter.common.contracts.PricePoint
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.LocalDate
 
 /**
  * Rebases a chronological list of [PricePoint]s onto the most recent
  * post-split share basis.
  *
- * Provider data carries the split coefficient on the ex-date row (and
- * occasionally on a sticky neighbour — Alpha Vantage's ±1-day enricher
- * fallback was a known source of this). Pre-event rows store raw
- * pre-split prices; ex-date and post-event rows store adjusted prices.
- *
- * The frontend used to perform this rebasing itself, which left the
- * adjustment scattered across each consumer and at risk of double-
- * dividing when stale stamps lingered on more than one row. Doing it
- * once here means every caller gets clean, charting-ready data.
+ * Two sources of split metadata are honoured:
+ *  1. The `split` column on individual price rows (set by the price-refresh
+ *     enricher when a Global Quote lands on the ex-date).
+ *  2. An explicit list of [SplitEvent]s. This covers the case where the
+ *     historical backfill never captured a split (Alpha Vantage's
+ *     TIME_SERIES_DAILY does not carry split coefficients), so the database
+ *     has nothing but raw pre-split closes for the days leading up to a
+ *     known corporate action.
  *
  * Algorithm:
- *  - Walk forward and identify ex-dates as rows where `split != 1` and
- *    the previous row's `split == 1`. Consecutive non-1 rows belong to
- *    the same event (sticky stamps) so only the first counts.
- *  - For each ex-date event, divide every OHLC + previousClose value
- *    on every row strictly before the event index by the event's split
- *    factor. Multiple events compound.
- *  - Normalise the `split` column so only the canonical ex-date keeps
- *    its non-1 value; sticky neighbours are reset to 1 to give the
- *    chart a single split marker.
+ *  - Build a unified set of ex-dates from the column transitions
+ *    (split=1 → split!=1 collapses sticky stamps so each event counts once)
+ *    and any externally-supplied events.
+ *  - For each price row, divide every OHLC + previousClose value by the
+ *    product of every event factor whose date strictly follows the row.
+ *  - Normalise the `split` column on the response so only the canonical
+ *    ex-date row carries a non-1 marker — sticky neighbours go back to 1
+ *    and rows without an ex-date stamp keep 1.
  */
 object SplitAdjuster {
     private const val SCALE = 6
     private val ROUNDING = RoundingMode.HALF_UP
 
-    fun adjust(prices: List<PricePoint>): List<PricePoint> {
+    data class SplitEvent(
+        val date: LocalDate,
+        val factor: BigDecimal
+    )
+
+    fun adjust(
+        prices: List<PricePoint>,
+        events: List<SplitEvent> = emptyList()
+    ): List<PricePoint> {
         if (prices.isEmpty()) return prices
 
-        data class SplitEvent(
-            val firstIdx: Int,
-            val factor: BigDecimal
-        )
+        val merged = mutableMapOf<LocalDate, BigDecimal>()
 
-        val events = mutableListOf<SplitEvent>()
+        for (ev in events) {
+            if (ev.factor.compareTo(BigDecimal.ONE) != 0 && ev.factor.signum() > 0) {
+                merged.putIfAbsent(ev.date, ev.factor)
+            }
+        }
         for (i in prices.indices) {
             val cur = prices[i].split
             val prev = if (i > 0) prices[i - 1].split else BigDecimal.ONE
             val curIsSplit = cur.compareTo(BigDecimal.ONE) != 0 && cur.signum() > 0
             val prevIsFlat = prev.compareTo(BigDecimal.ONE) == 0
             if (curIsSplit && prevIsFlat) {
-                events.add(SplitEvent(i, cur))
+                merged.putIfAbsent(prices[i].priceDate, cur)
             }
         }
-        if (events.isEmpty()) return prices
 
-        return prices.mapIndexed { i, p ->
+        if (merged.isEmpty()) return prices
+
+        val sortedEvents = merged.entries.sortedBy { it.key }
+
+        return prices.map { p ->
             var factor = BigDecimal.ONE
-            for (ev in events) {
-                if (i < ev.firstIdx) factor = factor.multiply(ev.factor)
-            }
-            val normalisedSplit =
-                if (events.any { it.firstIdx == i }) {
-                    p.split
-                } else {
-                    BigDecimal.ONE
+            for ((date, eventFactor) in sortedEvents) {
+                if (date.isAfter(p.priceDate)) {
+                    factor = factor.multiply(eventFactor)
                 }
-            if (factor.compareTo(BigDecimal.ONE) == 0 && normalisedSplit == p.split) {
+            }
+            val canonicalSplit = merged[p.priceDate] ?: BigDecimal.ONE
+            if (factor.compareTo(BigDecimal.ONE) == 0 && canonicalSplit == p.split) {
                 p
             } else {
                 p.copy(
@@ -73,7 +81,7 @@ object SplitAdjuster {
                     high = divideIfPositive(p.high, factor),
                     low = divideIfPositive(p.low, factor),
                     previousClose = divideIfPositive(p.previousClose, factor),
-                    split = normalisedSplit
+                    split = canonicalSplit
                 )
             }
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -72,16 +72,15 @@ object SplitAdjuster {
                 }
             }
             val canonicalSplit = merged[p.priceDate] ?: BigDecimal.ONE
-            // previousClose lives on the previous trading day, so on the
-            // ex-date row it sits one event-step earlier than the current
-            // close. Including canonicalSplit keeps the row's change /
-            // changePercent internally consistent with the rebased close.
+            // previousClose on the ex-date row lives on the previous trading
+            // day. Some upstream paths leave it raw pre-split (so it needs
+            // dividing by canonicalSplit to land on the rebased basis); others
+            // (svc-data's enrichWithPreviousClose) already rebase it. We
+            // distinguish by magnitude: if it sits at roughly the raw
+            // pre-split level (≥ half of close × canonicalSplit) treat it as
+            // raw, otherwise leave it alone.
             val previousCloseFactor =
-                if (canonicalSplit.compareTo(BigDecimal.ONE) != 0) {
-                    factor.multiply(canonicalSplit)
-                } else {
-                    factor
-                }
+                resolvePreviousCloseFactor(p, factor, canonicalSplit)
             if (factor.compareTo(BigDecimal.ONE) == 0 &&
                 previousCloseFactor.compareTo(BigDecimal.ONE) == 0 &&
                 canonicalSplit == p.split
@@ -97,6 +96,26 @@ object SplitAdjuster {
                     split = canonicalSplit
                 )
             }
+        }
+    }
+
+    private fun resolvePreviousCloseFactor(
+        p: PricePoint,
+        factor: BigDecimal,
+        canonicalSplit: BigDecimal
+    ): BigDecimal {
+        if (canonicalSplit.compareTo(BigDecimal.ONE) == 0) {
+            return factor
+        }
+        if (p.previousClose.signum() == 0 || p.close.signum() == 0) {
+            return factor
+        }
+        val rawTarget = p.close.multiply(canonicalSplit)
+        val halfRawTarget = rawTarget.divide(BigDecimal("2"), SCALE, ROUNDING)
+        return if (p.previousClose.compareTo(halfRawTarget) >= 0) {
+            factor.multiply(canonicalSplit)
+        } else {
+            factor
         }
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -72,7 +72,20 @@ object SplitAdjuster {
                 }
             }
             val canonicalSplit = merged[p.priceDate] ?: BigDecimal.ONE
-            if (factor.compareTo(BigDecimal.ONE) == 0 && canonicalSplit == p.split) {
+            // previousClose lives on the previous trading day, so on the
+            // ex-date row it sits one event-step earlier than the current
+            // close. Including canonicalSplit keeps the row's change /
+            // changePercent internally consistent with the rebased close.
+            val previousCloseFactor =
+                if (canonicalSplit.compareTo(BigDecimal.ONE) != 0) {
+                    factor.multiply(canonicalSplit)
+                } else {
+                    factor
+                }
+            if (factor.compareTo(BigDecimal.ONE) == 0 &&
+                previousCloseFactor.compareTo(BigDecimal.ONE) == 0 &&
+                canonicalSplit == p.split
+            ) {
                 p
             } else {
                 p.copy(
@@ -80,7 +93,7 @@ object SplitAdjuster {
                     open = divideIfPositive(p.open, factor),
                     high = divideIfPositive(p.high, factor),
                     low = divideIfPositive(p.low, factor),
-                    previousClose = divideIfPositive(p.previousClose, factor),
+                    previousClose = divideIfPositive(p.previousClose, previousCloseFactor),
                     split = canonicalSplit
                 )
             }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
@@ -39,17 +39,25 @@ class AlphaCorporateEventEnricher(
             // onto a neighbouring row leaves the system with two rows carrying
             // the same split value, which downstream chart logic interprets as
             // two ex-dates and double-divides pre-split history.
-            val splitEvent = events.data.find { it.priceDate.isEqual(marketData.priceDate) }
+            val splitEvent =
+                events.data.find {
+                    it.priceDate.isEqual(marketData.priceDate) && isSplit(it)
+                }
 
             // Dividends keep the ±1-day fallback to handle Global Quote vs
             // TIME_SERIES date offsets (pay-date vs ex-date conventions).
+            // Filter to dividend-bearing events first so that a split-only row
+            // on the same day doesn't shadow a dividend that exists ±1 day away.
             val dividendEvent =
-                events.data.find { it.priceDate.isEqual(marketData.priceDate) }
+                events.data.find {
+                    it.priceDate.isEqual(marketData.priceDate) && isDividend(it)
+                }
                     ?: events.data.find {
-                        abs(ChronoUnit.DAYS.between(it.priceDate, marketData.priceDate)) == 1L
+                        isDividend(it) &&
+                            abs(ChronoUnit.DAYS.between(it.priceDate, marketData.priceDate)) == 1L
                     }
 
-            if (dividendEvent != null && isDividend(dividendEvent)) {
+            if (dividendEvent != null) {
                 marketData.dividend = dividendEvent.dividend
                 log.debug(
                     "Enriched {} with dividend {} on {}",
@@ -61,7 +69,7 @@ class AlphaCorporateEventEnricher(
 
             // Note: We do NOT adjust previousClose since GLOBAL_QUOTE already returns
             // split-adjusted values. We only copy the split coefficient metadata.
-            if (splitEvent != null && isSplit(splitEvent)) {
+            if (splitEvent != null) {
                 marketData.split = splitEvent.split
                 log.info(
                     "Enriched {} with split {} on {}",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
@@ -35,41 +35,44 @@ class AlphaCorporateEventEnricher(
         try {
             val events = alphaEventService.getEvents(marketData.asset)
 
-            // Prefer exact date match; fall back to +/-1 day to handle
-            // edge cases where Global Quote and TIME_SERIES dates are slightly offset
-            val eventForDate =
+            // Splits MUST match the ex-date exactly. Stamping a split coefficient
+            // onto a neighbouring row leaves the system with two rows carrying
+            // the same split value, which downstream chart logic interprets as
+            // two ex-dates and double-divides pre-split history.
+            val splitEvent = events.data.find { it.priceDate.isEqual(marketData.priceDate) }
+
+            // Dividends keep the ±1-day fallback to handle Global Quote vs
+            // TIME_SERIES date offsets (pay-date vs ex-date conventions).
+            val dividendEvent =
                 events.data.find { it.priceDate.isEqual(marketData.priceDate) }
                     ?: events.data.find {
                         abs(ChronoUnit.DAYS.between(it.priceDate, marketData.priceDate)) == 1L
                     }
 
-            if (eventForDate == null) {
-                log.trace("No corporate event found for {} on {}", marketData.asset.code, marketData.priceDate)
-                return marketData
-            }
-
-            // Enrich with dividend if present
-            if (isDividend(eventForDate)) {
-                marketData.dividend = eventForDate.dividend
+            if (dividendEvent != null && isDividend(dividendEvent)) {
+                marketData.dividend = dividendEvent.dividend
                 log.debug(
                     "Enriched {} with dividend {} on {}",
                     marketData.asset.code,
-                    eventForDate.dividend,
+                    dividendEvent.dividend,
                     marketData.priceDate
                 )
             }
 
-            // Enrich with split if present
             // Note: We do NOT adjust previousClose since GLOBAL_QUOTE already returns
             // split-adjusted values. We only copy the split coefficient metadata.
-            if (isSplit(eventForDate)) {
-                marketData.split = eventForDate.split
+            if (splitEvent != null && isSplit(splitEvent)) {
+                marketData.split = splitEvent.split
                 log.info(
                     "Enriched {} with split {} on {}",
                     marketData.asset.code,
-                    eventForDate.split,
+                    splitEvent.split,
                     marketData.priceDate
                 )
+            }
+
+            if (splitEvent == null && dividendEvent == null) {
+                log.trace("No corporate event found for {} on {}", marketData.asset.code, marketData.priceDate)
             }
 
             return marketData

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -133,4 +133,59 @@ class SplitAdjusterTest {
     fun `empty input returns empty`() {
         assertThat(SplitAdjuster.adjust(emptyList())).isEmpty()
     }
+
+    @Test
+    fun `applies external split events when price rows lack the marker`() {
+        // Local DB backfilled via TIME_SERIES_DAILY has split=1 across the
+        // board even when a split happened. AlphaEventService supplies the
+        // ex-date out-of-band so SplitAdjuster can still rebase pre-event
+        // rows correctly.
+        val prices =
+            listOf(
+                point("2026-04-15", 301.91),
+                point("2026-04-17", 307.08),
+                point("2026-04-20", 308.44),
+                point("2026-04-24", 76.73)
+            )
+        val events =
+            listOf(
+                SplitAdjuster.SplitEvent(
+                    LocalDate.parse("2026-04-21"),
+                    BigDecimal("4")
+                )
+            )
+
+        val adjusted = SplitAdjuster.adjust(prices, events)
+
+        // Pre-event rows divided by 4
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("75.4775"))
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("76.77"))
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("77.11"))
+        // Post-event row untouched
+        assertThat(adjusted[3].close).isEqualByComparingTo(BigDecimal("76.73"))
+    }
+
+    @Test
+    fun `dedupes external events that already exist on a price row`() {
+        val prices =
+            listOf(
+                point("2026-04-03", 5000.0),
+                point("2026-04-06", 200.0, split = 25.0),
+                point("2026-04-07", 205.0)
+            )
+        val events =
+            listOf(
+                SplitAdjuster.SplitEvent(
+                    LocalDate.parse("2026-04-06"),
+                    BigDecimal("25")
+                )
+            )
+
+        val adjusted = SplitAdjuster.adjust(prices, events)
+
+        // Same as the no-events case — dedupe avoided a double-divide.
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("205"))
+    }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -202,6 +202,30 @@ class SplitAdjusterTest {
     }
 
     @Test
+    fun `does not re-divide previousClose that is already rebased`() {
+        // svc-data's enrichWithPreviousClose rebases previousClose on the
+        // ex-date row when persisting the daily refresh. SplitAdjuster must
+        // recognise that the input is already on the post-split basis and
+        // leave it untouched, otherwise it would double-divide and the
+        // chart's change / changePercent would diverge from reality.
+        val rebasedPreviousClose = 308.395 / 4
+        val prices =
+            listOf(
+                point(
+                    date20260421,
+                    close = 76.625,
+                    split = 4.0,
+                    previousClose = rebasedPreviousClose
+                )
+            )
+
+        val adjusted = SplitAdjuster.adjust(prices)
+
+        assertThat(adjusted[0].previousClose)
+            .isEqualByComparingTo(BigDecimal.valueOf(rebasedPreviousClose))
+    }
+
+    @Test
     fun `dedupes external events that already exist on a price row`() {
         val prices =
             listOf(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -6,28 +6,43 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
+@Suppress("TooManyFunctions")
 class SplitAdjusterTest {
+    private val date20260101 = LocalDate.parse("2026-01-01")
+    private val date20260201 = LocalDate.parse("2026-02-01")
+    private val date20260215 = LocalDate.parse("2026-02-15")
+    private val date20260301 = LocalDate.parse("2026-03-01")
+    private val date20260302 = LocalDate.parse("2026-03-02")
+    private val date20260401 = LocalDate.parse("2026-04-01")
+    private val date20260402 = LocalDate.parse("2026-04-02")
+    private val date20260403 = LocalDate.parse("2026-04-03")
+    private val date20260406 = LocalDate.parse("2026-04-06")
+    private val date20260407 = LocalDate.parse("2026-04-07")
+    private val date20260415 = LocalDate.parse("2026-04-15")
+    private val date20260417 = LocalDate.parse("2026-04-17")
+    private val date20260420 = LocalDate.parse("2026-04-20")
+    private val date20260421 = LocalDate.parse("2026-04-21")
+    private val date20260422 = LocalDate.parse("2026-04-22")
+    private val date20260423 = LocalDate.parse("2026-04-23")
+    private val date20260424 = LocalDate.parse("2026-04-24")
+
+    private fun bd(v: Double) = BigDecimal.valueOf(v)
+
     private fun point(
-        date: String,
+        date: LocalDate,
         close: Double,
         split: Double = 1.0,
-        previousClose: Double = 0.0,
-        open: Double = 0.0,
-        high: Double = 0.0,
-        low: Double = 0.0
+        previousClose: Double = 0.0
     ) = PricePoint(
-        priceDate = LocalDate.parse(date),
-        close = BigDecimal.valueOf(close),
-        open = BigDecimal.valueOf(open),
-        high = BigDecimal.valueOf(high),
-        low = BigDecimal.valueOf(low),
-        previousClose = BigDecimal.valueOf(previousClose),
-        split = BigDecimal.valueOf(split)
+        priceDate = date,
+        close = bd(close),
+        previousClose = bd(previousClose),
+        split = bd(split)
     )
 
     @Test
     fun `passes through when no splits exist`() {
-        val prices = listOf(point("2026-04-01", 100.0), point("2026-04-02", 101.0))
+        val prices = listOf(point(date20260401, 100.0), point(date20260402, 101.0))
         val adjusted = SplitAdjuster.adjust(prices)
         assertThat(adjusted).isEqualTo(prices)
     }
@@ -36,9 +51,9 @@ class SplitAdjusterTest {
     fun `divides pre-split rows by the ex-date factor`() {
         val prices =
             listOf(
-                point("2026-04-03", 5000.0),
-                point("2026-04-06", 200.0, split = 25.0),
-                point("2026-04-07", 205.0)
+                point(date20260403, 5000.0),
+                point(date20260406, 200.0, split = 25.0),
+                point(date20260407, 205.0)
             )
         val adjusted = SplitAdjuster.adjust(prices)
         assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("200"))
@@ -53,11 +68,11 @@ class SplitAdjusterTest {
         // stamp into one ex-date event so pre-event rows are divided once.
         val prices =
             listOf(
-                point("2026-04-20", 308.395),
-                point("2026-04-21", 76.625, split = 4.0),
-                point("2026-04-22", 76.56, split = 4.0),
-                point("2026-04-23", 76.825),
-                point("2026-04-24", 76.71)
+                point(date20260420, 308.395),
+                point(date20260421, 76.625, split = 4.0),
+                point(date20260422, 76.56, split = 4.0),
+                point(date20260423, 76.825),
+                point(date20260424, 76.71)
             )
 
         val adjusted = SplitAdjuster.adjust(prices)
@@ -78,11 +93,11 @@ class SplitAdjusterTest {
     fun `compounds factors across multiple split events`() {
         val prices =
             listOf(
-                point("2026-01-01", 1000.0),
-                point("2026-02-01", 500.0, split = 2.0),
-                point("2026-02-15", 510.0),
-                point("2026-03-01", 102.0, split = 5.0),
-                point("2026-03-02", 103.0)
+                point(date20260101, 1000.0),
+                point(date20260201, 500.0, split = 2.0),
+                point(date20260215, 510.0),
+                point(date20260301, 102.0, split = 5.0),
+                point(date20260302, 103.0)
             )
         val adjusted = SplitAdjuster.adjust(prices)
         // First row sees both events: 1000 / (2 * 5) = 100
@@ -97,19 +112,19 @@ class SplitAdjusterTest {
 
     @Test
     fun `also adjusts open high low and previousClose`() {
-        val prices =
-            listOf(
-                point(
-                    "2026-04-03",
-                    close = 5000.0,
-                    open = 4900.0,
-                    high = 5100.0,
-                    low = 4800.0,
-                    previousClose = 4950.0
-                ),
-                point("2026-04-06", 200.0, split = 25.0)
+        val preSplit =
+            PricePoint(
+                priceDate = date20260403,
+                close = bd(5000.0),
+                open = bd(4900.0),
+                high = bd(5100.0),
+                low = bd(4800.0),
+                previousClose = bd(4950.0)
             )
-        val adjusted = SplitAdjuster.adjust(prices)
+        val adjusted =
+            SplitAdjuster.adjust(
+                listOf(preSplit, point(date20260406, 200.0, split = 25.0))
+            )
         assertThat(adjusted[0].open).isEqualByComparingTo(BigDecimal("196"))
         assertThat(adjusted[0].high).isEqualByComparingTo(BigDecimal("204"))
         assertThat(adjusted[0].low).isEqualByComparingTo(BigDecimal("192"))
@@ -120,8 +135,8 @@ class SplitAdjusterTest {
     fun `leaves zero-valued OHLC fields alone`() {
         val prices =
             listOf(
-                point("2026-04-03", close = 5000.0), // open/high/low default 0
-                point("2026-04-06", 200.0, split = 25.0)
+                point(date20260403, close = 5000.0), // open/high/low default 0
+                point(date20260406, 200.0, split = 25.0)
             )
         val adjusted = SplitAdjuster.adjust(prices)
         assertThat(adjusted[0].open).isEqualByComparingTo(BigDecimal.ZERO)
@@ -142,18 +157,13 @@ class SplitAdjusterTest {
         // rows correctly.
         val prices =
             listOf(
-                point("2026-04-15", 301.91),
-                point("2026-04-17", 307.08),
-                point("2026-04-20", 308.44),
-                point("2026-04-24", 76.73)
+                point(date20260415, 301.91),
+                point(date20260417, 307.08),
+                point(date20260420, 308.44),
+                point(date20260424, 76.73)
             )
         val events =
-            listOf(
-                SplitAdjuster.SplitEvent(
-                    LocalDate.parse("2026-04-21"),
-                    BigDecimal("4")
-                )
-            )
+            listOf(SplitAdjuster.SplitEvent(date20260421, BigDecimal("4")))
 
         val adjusted = SplitAdjuster.adjust(prices, events)
 
@@ -174,14 +184,14 @@ class SplitAdjusterTest {
         // computed change / changePercent line up with the adjusted close.
         val prices =
             listOf(
-                point("2026-04-20", 308.395),
+                point(date20260420, 308.395),
                 point(
-                    "2026-04-21",
+                    date20260421,
                     close = 76.625,
                     split = 4.0,
                     previousClose = 308.395
                 ),
-                point("2026-04-22", 76.56)
+                point(date20260422, 76.56)
             )
 
         val adjusted = SplitAdjuster.adjust(prices)
@@ -195,17 +205,12 @@ class SplitAdjusterTest {
     fun `dedupes external events that already exist on a price row`() {
         val prices =
             listOf(
-                point("2026-04-03", 5000.0),
-                point("2026-04-06", 200.0, split = 25.0),
-                point("2026-04-07", 205.0)
+                point(date20260403, 5000.0),
+                point(date20260406, 200.0, split = 25.0),
+                point(date20260407, 205.0)
             )
         val events =
-            listOf(
-                SplitAdjuster.SplitEvent(
-                    LocalDate.parse("2026-04-06"),
-                    BigDecimal("25")
-                )
-            )
+            listOf(SplitAdjuster.SplitEvent(date20260406, BigDecimal("25")))
 
         val adjusted = SplitAdjuster.adjust(prices, events)
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -166,6 +166,32 @@ class SplitAdjusterTest {
     }
 
     @Test
+    fun `adjusts previousClose on the ex-date row to match the rebased close`() {
+        // The ex-date row's previousClose lives on the previous trading day,
+        // i.e. one event-step earlier than its own close. Provider rows can
+        // store that value either as raw pre-split or already-rebased; in
+        // both cases the response must end up internally consistent so the
+        // computed change / changePercent line up with the adjusted close.
+        val prices =
+            listOf(
+                point("2026-04-20", 308.395),
+                point(
+                    "2026-04-21",
+                    close = 76.625,
+                    split = 4.0,
+                    previousClose = 308.395
+                ),
+                point("2026-04-22", 76.56)
+            )
+
+        val adjusted = SplitAdjuster.adjust(prices)
+
+        // 308.395 / 4 = 77.09875
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("76.625"))
+        assertThat(adjusted[1].previousClose).isEqualByComparingTo(BigDecimal("77.09875"))
+    }
+
+    @Test
     fun `dedupes external events that already exist on a price row`() {
         val prices =
             listOf(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -1,0 +1,136 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.contracts.PricePoint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class SplitAdjusterTest {
+    private fun point(
+        date: String,
+        close: Double,
+        split: Double = 1.0,
+        previousClose: Double = 0.0,
+        open: Double = 0.0,
+        high: Double = 0.0,
+        low: Double = 0.0
+    ) = PricePoint(
+        priceDate = LocalDate.parse(date),
+        close = BigDecimal.valueOf(close),
+        open = BigDecimal.valueOf(open),
+        high = BigDecimal.valueOf(high),
+        low = BigDecimal.valueOf(low),
+        previousClose = BigDecimal.valueOf(previousClose),
+        split = BigDecimal.valueOf(split)
+    )
+
+    @Test
+    fun `passes through when no splits exist`() {
+        val prices = listOf(point("2026-04-01", 100.0), point("2026-04-02", 101.0))
+        val adjusted = SplitAdjuster.adjust(prices)
+        assertThat(adjusted).isEqualTo(prices)
+    }
+
+    @Test
+    fun `divides pre-split rows by the ex-date factor`() {
+        val prices =
+            listOf(
+                point("2026-04-03", 5000.0),
+                point("2026-04-06", 200.0, split = 25.0),
+                point("2026-04-07", 205.0)
+            )
+        val adjusted = SplitAdjuster.adjust(prices)
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("205"))
+    }
+
+    @Test
+    fun `treats consecutive non-1 split rows as one event (VO regression)`() {
+        // VO 4:1 split on 2026-04-21. Alpha enricher previously stamped the
+        // split on 2026-04-22 too. The adjuster must collapse the duplicate
+        // stamp into one ex-date event so pre-event rows are divided once.
+        val prices =
+            listOf(
+                point("2026-04-20", 308.395),
+                point("2026-04-21", 76.625, split = 4.0),
+                point("2026-04-22", 76.56, split = 4.0),
+                point("2026-04-23", 76.825),
+                point("2026-04-24", 76.71)
+            )
+
+        val adjusted = SplitAdjuster.adjust(prices)
+
+        // 308.395 / 4 = 77.09875
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("77.09875"))
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("76.625"))
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("76.56"))
+        assertThat(adjusted[3].close).isEqualByComparingTo(BigDecimal("76.825"))
+
+        // Sticky neighbour split is normalised back to 1; only the canonical
+        // ex-date keeps its non-1 marker.
+        assertThat(adjusted[1].split).isEqualByComparingTo(BigDecimal("4"))
+        assertThat(adjusted[2].split).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `compounds factors across multiple split events`() {
+        val prices =
+            listOf(
+                point("2026-01-01", 1000.0),
+                point("2026-02-01", 500.0, split = 2.0),
+                point("2026-02-15", 510.0),
+                point("2026-03-01", 102.0, split = 5.0),
+                point("2026-03-02", 103.0)
+            )
+        val adjusted = SplitAdjuster.adjust(prices)
+        // First row sees both events: 1000 / (2 * 5) = 100
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("100"))
+        // Between events: 500 and 510 see only the 5:1 → /5
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("100"))
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("102"))
+        // Ex-date and after: untouched
+        assertThat(adjusted[3].close).isEqualByComparingTo(BigDecimal("102"))
+        assertThat(adjusted[4].close).isEqualByComparingTo(BigDecimal("103"))
+    }
+
+    @Test
+    fun `also adjusts open high low and previousClose`() {
+        val prices =
+            listOf(
+                point(
+                    "2026-04-03",
+                    close = 5000.0,
+                    open = 4900.0,
+                    high = 5100.0,
+                    low = 4800.0,
+                    previousClose = 4950.0
+                ),
+                point("2026-04-06", 200.0, split = 25.0)
+            )
+        val adjusted = SplitAdjuster.adjust(prices)
+        assertThat(adjusted[0].open).isEqualByComparingTo(BigDecimal("196"))
+        assertThat(adjusted[0].high).isEqualByComparingTo(BigDecimal("204"))
+        assertThat(adjusted[0].low).isEqualByComparingTo(BigDecimal("192"))
+        assertThat(adjusted[0].previousClose).isEqualByComparingTo(BigDecimal("198"))
+    }
+
+    @Test
+    fun `leaves zero-valued OHLC fields alone`() {
+        val prices =
+            listOf(
+                point("2026-04-03", close = 5000.0), // open/high/low default 0
+                point("2026-04-06", 200.0, split = 25.0)
+            )
+        val adjusted = SplitAdjuster.adjust(prices)
+        assertThat(adjusted[0].open).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(adjusted[0].high).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(adjusted[0].low).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `empty input returns empty`() {
+        assertThat(SplitAdjuster.adjust(emptyList())).isEmpty()
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
@@ -145,19 +145,21 @@ class AlphaCorporateEventEnricherTest {
     }
 
     @Test
-    fun `should match event within 1-day window when no exact match exists`() {
-        // Given: A Global Quote MarketData for today
+    fun `should NOT enrich split from adjacent day - splits must match exact ex-date`() {
+        // Splits MUST match the ex-date exactly. Stamping the split coefficient
+        // onto a neighbouring row leaves the system with two rows carrying the
+        // same split, which downstream chart logic interprets as two ex-dates
+        // and double-divides pre-split history.
         val globalQuoteMarketData =
             MarketData(
                 asset = asset,
                 priceDate = priceDate,
                 close = BigDecimal("100.00"),
-                previousClose = BigDecimal("200.00"),
-                change = BigDecimal("-100.00"),
+                previousClose = BigDecimal("100.00"),
+                change = BigDecimal("0.00"),
                 source = "ALPHA"
             )
 
-        // And: A split exists for yesterday (within +/-1 day window)
         val yesterdayEvent =
             MarketData(
                 asset = asset,
@@ -170,11 +172,73 @@ class AlphaCorporateEventEnricherTest {
             PriceResponse(listOf(yesterdayEvent))
         )
 
-        // When: Enriching the Global Quote data
         val enrichedData = enricher.enrich(globalQuoteMarketData)
 
-        // Then: The split should be enriched from the adjacent-day event
-        assertThat(enrichedData.split).isEqualByComparingTo(BigDecimal("2.0"))
+        assertThat(enrichedData.split).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `should still enrich dividend from adjacent day`() {
+        // Dividends keep the ±1-day fallback to handle Global Quote vs
+        // TIME_SERIES date offsets (pay-date vs ex-date conventions).
+        val globalQuoteMarketData =
+            MarketData(
+                asset = asset,
+                priceDate = priceDate,
+                close = BigDecimal("100.00"),
+                source = "ALPHA"
+            )
+
+        val yesterdayEvent =
+            MarketData(
+                asset = asset,
+                priceDate = priceDate.minusDays(1),
+                close = BigDecimal("100.00"),
+                split = BigDecimal.ONE,
+                dividend = BigDecimal("0.40")
+            )
+        `when`(alphaEventService.getEvents(asset)).thenReturn(
+            PriceResponse(listOf(yesterdayEvent))
+        )
+
+        val enrichedData = enricher.enrich(globalQuoteMarketData)
+
+        assertThat(enrichedData.dividend).isEqualByComparingTo(BigDecimal("0.40"))
+        assertThat(enrichedData.split).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `should not stamp split onto day after ex-date (VO regression)`() {
+        // VO 4:1 split on 2026-04-21. Refreshing the price for 2026-04-22
+        // must NOT carry the split=4 stamp forward, otherwise downstream
+        // chart logic sees two ex-dates and double-divides earlier history.
+        val voAsset = Asset(id = "vo-id", code = "VO", market = market)
+        val exDate = LocalDate.of(2026, 4, 21)
+        val dayAfter = LocalDate.of(2026, 4, 22)
+
+        val dayAfterQuote =
+            MarketData(
+                asset = voAsset,
+                priceDate = dayAfter,
+                close = BigDecimal("76.56"),
+                source = "ALPHA"
+            )
+
+        val splitEventOnExDate =
+            MarketData(
+                asset = voAsset,
+                priceDate = exDate,
+                close = BigDecimal("76.625"),
+                split = BigDecimal("4.0"),
+                dividend = BigDecimal.ZERO
+            )
+        `when`(alphaEventService.getEvents(voAsset)).thenReturn(
+            PriceResponse(listOf(splitEventOnExDate))
+        )
+
+        val enrichedData = enricher.enrich(dayAfterQuote)
+
+        assertThat(enrichedData.split).isEqualByComparingTo(BigDecimal.ONE)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
@@ -208,6 +208,46 @@ class AlphaCorporateEventEnricherTest {
     }
 
     @Test
+    fun `dividend fallback still fires when same-date event is split-only`() {
+        // If the exact-date event carries only a split, the ±1-day dividend
+        // fallback still has to look for a dividend on the neighbouring day.
+        // Filtering events.data by isDividend() before the fallback prevents
+        // a split-only same-date row from shadowing a real dividend.
+        val globalQuoteMarketData =
+            MarketData(
+                asset = asset,
+                priceDate = priceDate,
+                close = BigDecimal("100.00"),
+                source = "ALPHA"
+            )
+
+        val splitOnlyToday =
+            MarketData(
+                asset = asset,
+                priceDate = priceDate,
+                close = BigDecimal("100.00"),
+                split = BigDecimal("2.0"),
+                dividend = BigDecimal.ZERO
+            )
+        val dividendYesterday =
+            MarketData(
+                asset = asset,
+                priceDate = priceDate.minusDays(1),
+                close = BigDecimal("100.00"),
+                split = BigDecimal.ONE,
+                dividend = BigDecimal("0.30")
+            )
+        `when`(alphaEventService.getEvents(asset)).thenReturn(
+            PriceResponse(listOf(splitOnlyToday, dividendYesterday))
+        )
+
+        val enrichedData = enricher.enrich(globalQuoteMarketData)
+
+        assertThat(enrichedData.split).isEqualByComparingTo(BigDecimal("2.0"))
+        assertThat(enrichedData.dividend).isEqualByComparingTo(BigDecimal("0.30"))
+    }
+
+    @Test
     fun `should not stamp split onto day after ex-date (VO regression)`() {
         // VO 4:1 split on 2026-04-21. Refreshing the price for 2026-04-22
         // must NOT carry the split=4 stamp forward, otherwise downstream


### PR DESCRIPTION
## Summary
- Stamp Alpha split metadata only on the exact ex-date (drop the ±1 day fallback that was duplicating the coefficient onto the next row, e.g. VO 4:1 on 2026-04-21).
- Add `SplitAdjuster` and run every `getPriceHistory` response through it. Pre-event OHLC + previousClose values are rebased onto the post-split basis; the `split` column is normalised so only the canonical ex-date carries a non-1 marker.
- Source split events from `AlphaEventService` (cached, reads `TIME_SERIES_DAILY_ADJUSTED`) so the adjuster still works when the DB only holds raw closes from a `TIME_SERIES_DAILY` backfill (which doesn't carry split coefficients).

Pairs with bc-view PR (`fix/price-chart-server-side`) which drops the matching frontend divisor logic.

## Test plan
- [x] `./gradlew :svc-data:test`
- [x] `./gradlew :svc-data:formatKotlin :svc-data:lintKotlin`
- [ ] Restart `svc-data` locally; reload the VO chart and confirm pre-split bars are flattened around \$76-77 with a single ex-date marker on 2026-04-21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Historical price data is now rebased for stock splits so OHLC and previous-close reflect the most recent post-split basis.

* **Improvements**
  * Split matching requires exact ex-date alignment; dividend enrichment still allows a ±1 day fallback.
  * External split events are optionally applied; if unavailable or loading fails, no split adjustments are made.
  * Consecutive or duplicate split markers are normalized to a single canonical ex-date factor.

* **Tests**
  * Added and extended tests covering split rebasing, event deduplication, canonical ex-date handling, and enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->