### PR TITLE
feat(agent): Asset Review domain for assets/lookup deep dive

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -315,6 +315,63 @@ object DomainSystemPrompts {
         """.trimIndent()
 
     /**
+     * Asset Review domain — single-asset deep dive triggered from the
+     * assets/lookup screen. Wider than News & Sentiment (covers fundamentals,
+     * sector context, corporate-event history) but narrower than Wealth
+     * (no portfolio aggregation). Tools: wealth baseline + news + events.
+     */
+    val ASSET_REVIEW =
+        """
+        $PREAMBLE
+
+        ## Domain: Asset Review
+
+        You produce a research-style brief on a single asset chosen from the
+        assets/lookup screen. Goal: help the user decide whether to buy,
+        hold, or watch the ticker.
+
+        ### Tools
+
+        - `getNews(ticker, market?, topics?)` — recent news + sentiment.
+        - `getAssetEvents(ticker)` — dividends, splits, other corporate
+          actions on this ticker.
+        - `listMarkets`, `listCurrencies`, `getFxRate(from, to, date?)` —
+          market metadata for context.
+        - `getPortfolio(code)`, `getPositions(code)` — only if the user
+          asks about their own existing exposure to this asset.
+
+        ### Workflow
+
+        1. Always call `getNews(ticker, market)` first — anchors the brief
+           in current sentiment. If `{status: "no_coverage"}`, fall back to
+           general knowledge clearly labelled.
+        2. Call `getAssetEvents(ticker)` to surface recent dividend / split
+           cadence — useful for income-focused users.
+        3. Synthesise: company + sector summary, what's happening now,
+           recent corporate-action pattern, qualitative risk callouts.
+
+        ### Output
+
+        - Short executive sentiment line (Bullish / Bearish / Neutral / Mixed)
+          based on the news result.
+        - **Company & sector** — one sentence each.
+        - **Recent news** — 3–5 bullets.
+        - **Corporate actions** — list dividends/splits in the last 12
+          months, or "none" if the events tool returns empty.
+        - **Risk notes** — 2–3 bullets covering volatility drivers,
+          concentration risk, regulatory/macro exposure.
+        - Always close with: "Not financial advice — your own diligence
+          required."
+        - Label any general-knowledge content clearly when live data is
+          unavailable.
+
+        ### Privacy
+
+        The user has not selected a portfolio context — do not invent or
+        guess existing positions. Stay at the ticker level.
+        """.trimIndent()
+
+    /**
      * Used when no page context pins a domain. Routes by intent rather
      * than dumping every capability — the user's query drives disambiguation.
      */

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/SystemPromptSelector.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/SystemPromptSelector.kt
@@ -14,6 +14,11 @@ class SystemPromptSelector {
     fun selectFor(context: Map<String, Any>?): String {
         val page = context?.get("page")?.toString()?.lowercase() ?: ""
         return when {
+            // Asset Review — match before the trade/event branch so we don't
+            // fall through to DomainSystemPrompts.ASSET on the word "asset".
+            page.contains("asset review") || page.contains("asset-review") -> {
+                DomainSystemPrompts.ASSET_REVIEW
+            }
             page.contains("news") && page.contains("sentiment") -> {
                 DomainSystemPrompts.NEWS_SENTIMENT
             }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ToolSelector.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ToolSelector.kt
@@ -30,6 +30,12 @@ class ToolSelector(
         val page = context?.get("page")?.toString()?.lowercase() ?: ""
 
         return when {
+            // Asset Review — single-asset deep dive from assets/lookup.
+            // Match before the trade/event branch so the word "asset" doesn't
+            // trip a fall-through.
+            page.contains("asset review") || page.contains("asset-review") -> {
+                (wealthTools + eventTools + newsTools).toTypedArray()
+            }
             // News & Sentiment — focused lookup, nothing else.
             page.contains("news") && page.contains("sentiment") -> {
                 arrayOf(newsTools)

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/SystemPromptSelectorTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/SystemPromptSelectorTest.kt
@@ -43,6 +43,12 @@ class SystemPromptSelectorTest {
     }
 
     @Test
+    fun `asset review page returns the asset review prompt`() {
+        val prompt = selector.selectFor(mapOf("page" to "Asset Review"))
+        assertThat(prompt).isEqualTo(DomainSystemPrompts.ASSET_REVIEW)
+    }
+
+    @Test
     fun `null or unknown context falls back to the general prompt`() {
         assertThat(selector.selectFor(null)).isEqualTo(DomainSystemPrompts.GENERAL)
         assertThat(selector.selectFor(emptyMap())).isEqualTo(DomainSystemPrompts.GENERAL)

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ToolSelectorTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ToolSelectorTest.kt
@@ -83,6 +83,22 @@ class ToolSelectorTest {
     }
 
     @Test
+    fun `asset review page ships wealth baseline plus event and news tools`() {
+        // Asset Review is a deep-dive on a single ticker triggered from
+        // the assets/lookup screen — needs market context, news, and
+        // corporate-event history. No retire/rebalance.
+        val tools = selector.selectTools(mapOf("page" to "Asset Review"))
+        assertThat(tools).containsExactlyInAnyOrder(
+            portfolioTools,
+            positionTools,
+            marketTools,
+            eventTools,
+            newsTools
+        )
+        assertThat(tools).doesNotContain(retireTools, rebalanceTools)
+    }
+
+    @Test
     fun `no context ships every tool`() {
         val tools = selector.selectTools(null)
         assertThat(tools).containsExactlyInAnyOrder(


### PR DESCRIPTION
## Summary

- Adds an **Asset Review** LLM domain in svc-agent — wider than News & Sentiment (covers fundamentals, sector context, corporate-action history, risk callouts) but narrower than Wealth (no portfolio aggregation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Asset Review capability to analyze individual assets with automated research-style briefs, including sentiment assessment, company and sector information, recent news summaries, corporate action history, and risk analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->