### PR TITLE
chore: Tame Codacy test noise + dedupe two main-code error messages

### DIFF
--- a/.codacy/tools-configs/detekt.yaml
+++ b/.codacy/tools-configs/detekt.yaml
@@ -1,0 +1,23 @@
+# Detekt overrides for Codacy server-side scanning.
+#
+# Two complexity rules are noisy in tests by design and not worth chasing:
+# - TooManyFunctions: tests are made of many small @Test methods.
+# - LongMethod: integration-test scenarios are inherently long.
+#
+# Other rules — including StringLiteralDuplication — stay enabled on tests
+# so the high-signal cases (cross-file fixture repetition, error message
+# drift) still surface.
+
+complexity:
+  TooManyFunctions:
+    excludes:
+      - "**/test/**"
+      - "**/*Test.kt"
+      - "**/*Tests.kt"
+      - "**/*Spec.kt"
+  LongMethod:
+    excludes:
+      - "**/test/**"
+      - "**/*Test.kt"
+      - "**/*Tests.kt"
+      - "**/*Spec.kt"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
@@ -30,7 +30,7 @@ class OwnedAssetService(
      */
     fun findByOwnerAndCategory(category: String): AssetUpdateResponse {
         val user =
-            systemUserService.getActiveUser()
+            systemUserService.requireActiveUser()
                 ?: return AssetUpdateResponse(emptyMap())
         val assets = assetRepository.findBySystemUserIdAndCategory(user.id, category.uppercase())
         return AssetUpdateResponse(
@@ -43,7 +43,7 @@ class OwnedAssetService(
      */
     fun findByOwner(): AssetUpdateResponse {
         val user =
-            systemUserService.getActiveUser()
+            systemUserService.requireActiveUser()
                 ?: return AssetUpdateResponse(emptyMap())
         val assets = assetRepository.findBySystemUserId(user.id)
         return AssetUpdateResponse(
@@ -68,8 +68,7 @@ class OwnedAssetService(
      */
     fun deleteOwnedAsset(assetId: String) {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
         val asset =
             assetRepository.findById(assetId).orElseThrow {
                 NotFoundException("Asset not found: $assetId")
@@ -92,8 +91,7 @@ class OwnedAssetService(
         assetInput: AssetInput
     ): Asset {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
         val asset =
             assetRepository.findById(assetId).orElseThrow {
                 NotFoundException("Asset not found: $assetId")
@@ -136,7 +134,5 @@ class OwnedAssetService(
      * Get the current user's ID for asset ownership.
      * @throws BusinessException if user not authenticated
      */
-    fun getCurrentOwnerId(): String =
-        systemUserService.getActiveUser()?.id
-            ?: throw BusinessException("User not authenticated")
+    fun getCurrentOwnerId(): String = systemUserService.requireActiveUser().id
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
@@ -30,7 +30,7 @@ class OwnedAssetService(
      */
     fun findByOwnerAndCategory(category: String): AssetUpdateResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
                 ?: return AssetUpdateResponse(emptyMap())
         val assets = assetRepository.findBySystemUserIdAndCategory(user.id, category.uppercase())
         return AssetUpdateResponse(
@@ -43,7 +43,7 @@ class OwnedAssetService(
      */
     fun findByOwner(): AssetUpdateResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
                 ?: return AssetUpdateResponse(emptyMap())
         val assets = assetRepository.findBySystemUserId(user.id)
         return AssetUpdateResponse(
@@ -68,7 +68,8 @@ class OwnedAssetService(
      */
     fun deleteOwnedAsset(assetId: String) {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
         val asset =
             assetRepository.findById(assetId).orElseThrow {
                 NotFoundException("Asset not found: $assetId")
@@ -91,7 +92,8 @@ class OwnedAssetService(
         assetInput: AssetInput
     ): Asset {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
         val asset =
             assetRepository.findById(assetId).orElseThrow {
                 NotFoundException("Asset not found: $assetId")
@@ -134,5 +136,7 @@ class OwnedAssetService(
      * Get the current user's ID for asset ownership.
      * @throws BusinessException if user not authenticated
      */
-    fun getCurrentOwnerId(): String = systemUserService.requireActiveUser().id
+    fun getCurrentOwnerId(): String =
+        systemUserService.getActiveUser()?.id
+            ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -34,7 +34,7 @@ class PrivateAssetConfigService(
      */
     fun getMyConfigs(excludePortfolioIds: Set<String>? = null): PrivateAssetConfigsResponse {
         val user =
-            systemUserService.getActiveUser()
+            systemUserService.requireActiveUser()
                 ?: return PrivateAssetConfigsResponse(emptyList())
         var configs = configRepository.findByUserId(user.id)
 
@@ -335,8 +335,7 @@ class PrivateAssetConfigService(
      */
     private fun verifyAssetOwnership(assetId: String) {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val asset =
             assetRepository.findById(assetId).orElseThrow {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -34,7 +34,7 @@ class PrivateAssetConfigService(
      */
     fun getMyConfigs(excludePortfolioIds: Set<String>? = null): PrivateAssetConfigsResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
                 ?: return PrivateAssetConfigsResponse(emptyList())
         var configs = configRepository.findByUserId(user.id)
 
@@ -335,7 +335,8 @@ class PrivateAssetConfigService(
      */
     private fun verifyAssetOwnership(assetId: String) {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val asset =
             assetRepository.findById(assetId).orElseThrow {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareService.kt
@@ -123,7 +123,7 @@ class PortfolioShareService(
         shareId: String
     ) {
         if (!isAuthorisedToAccept(share, currentUser, shareId)) {
-            throw NotFoundException("Share not found: $shareId")
+            throw NotFoundException(shareNotFoundMessage(shareId))
         }
     }
 
@@ -158,7 +158,7 @@ class PortfolioShareService(
         val isAdviser = share.sharedWith.id == currentUser.id
         val isTarget = share.targetUser?.id == currentUser.id
         if (!isOwner && !isAdviser && !isTarget) {
-            throw NotFoundException("Share not found: $shareId")
+            throw NotFoundException(shareNotFoundMessage(shareId))
         }
 
         share.status = ShareStatus.REVOKED
@@ -224,7 +224,7 @@ class PortfolioShareService(
 
     private fun findShareOrThrow(shareId: String): PortfolioShare =
         portfolioShareRepository.findById(shareId).orElseThrow {
-            NotFoundException("Share not found: $shareId")
+            NotFoundException(shareNotFoundMessage(shareId))
         }
 
     private fun resolveUserByEmail(email: String): SystemUser =
@@ -281,3 +281,5 @@ class PortfolioShareService(
         }
     }
 }
+
+private fun shareNotFoundMessage(shareId: String): String = "Share not found: $shareId"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -42,8 +42,7 @@ class OffboardingService(
      */
     fun getSummary(): OffboardingSummaryResponse {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val portfolios = portfolioRepository.findByOwner(user).toList()
         val assets = assetRepository.findBySystemUserId(user.id)
@@ -62,8 +61,7 @@ class OffboardingService(
      */
     fun deleteUserAssets(): OffboardingResult {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val assets = assetRepository.findBySystemUserId(user.id)
         if (assets.isEmpty()) {
@@ -96,8 +94,7 @@ class OffboardingService(
      */
     fun deleteUserPortfolios(): OffboardingResult {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val portfolios = portfolioRepository.findByOwner(user).toList()
         if (portfolios.isEmpty()) {
@@ -130,8 +127,7 @@ class OffboardingService(
      */
     fun deleteUserWealth(): OffboardingResult {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         var totalDeleted = 0
 
@@ -173,8 +169,7 @@ class OffboardingService(
      */
     fun deleteUserAccount(): OffboardingResult {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         // Delete in order of FK dependencies
         // 1. Delete portfolios and their transactions

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -42,7 +42,8 @@ class OffboardingService(
      */
     fun getSummary(): OffboardingSummaryResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val portfolios = portfolioRepository.findByOwner(user).toList()
         val assets = assetRepository.findBySystemUserId(user.id)
@@ -61,7 +62,8 @@ class OffboardingService(
      */
     fun deleteUserAssets(): OffboardingResult {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val assets = assetRepository.findBySystemUserId(user.id)
         if (assets.isEmpty()) {
@@ -94,7 +96,8 @@ class OffboardingService(
      */
     fun deleteUserPortfolios(): OffboardingResult {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val portfolios = portfolioRepository.findByOwner(user).toList()
         if (portfolios.isEmpty()) {
@@ -127,7 +130,8 @@ class OffboardingService(
      */
     fun deleteUserWealth(): OffboardingResult {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         var totalDeleted = 0
 
@@ -169,7 +173,8 @@ class OffboardingService(
      */
     fun deleteUserAccount(): OffboardingResult {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         // Delete in order of FK dependencies
         // 1. Delete portfolios and their transactions

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserService.kt
@@ -90,6 +90,7 @@ class SystemUserService(
     }
 
     companion object {
+        const val USER_NOT_AUTHENTICATED = "User not authenticated"
         private val log = LoggerFactory.getLogger(SystemUserService::class.java)
     }
 
@@ -124,6 +125,13 @@ class SystemUserService(
     fun findByEmail(email: String): SystemUser? = systemUserRepository.findByEmail(email).orElse(null)
 
     fun getActiveUser(): SystemUser? = find(tokenService.subject)
+
+    /**
+     * Resolve the caller's SystemUser or throw a uniform "not authenticated"
+     * BusinessException. Centralises the 8+ call sites that previously
+     * spelled the same message inline (Codacy StringLiteralDuplication).
+     */
+    fun requireActiveUser(): SystemUser = getActiveUser() ?: throw BusinessException(USER_NOT_AUTHENTICATED)
 
     fun getOrThrow(): SystemUser {
         if (isServiceAccount()) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserService.kt
@@ -126,13 +126,6 @@ class SystemUserService(
 
     fun getActiveUser(): SystemUser? = find(tokenService.subject)
 
-    /**
-     * Resolve the caller's SystemUser or throw a uniform "not authenticated"
-     * BusinessException. Centralises the 8+ call sites that previously
-     * spelled the same message inline (Codacy StringLiteralDuplication).
-     */
-    fun requireActiveUser(): SystemUser = getActiveUser() ?: throw BusinessException(USER_NOT_AUTHENTICATED)
-
     fun getOrThrow(): SystemUser {
         if (isServiceAccount()) {
             return AuthConstants.authSystem

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/share/ResourceShareService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/share/ResourceShareService.kt
@@ -114,7 +114,7 @@ class ResourceShareService(
         shareId: String
     ) {
         if (!isAuthorisedToAccept(share, currentUser, shareId)) {
-            throw NotFoundException("Share not found: $shareId")
+            throw NotFoundException(shareNotFoundMessage(shareId))
         }
     }
 
@@ -149,7 +149,7 @@ class ResourceShareService(
         val isAdviser = share.sharedWith.id == currentUser.id
         val isTarget = share.targetUser?.id == currentUser.id
         if (!isOwner && !isAdviser && !isTarget) {
-            throw NotFoundException("Share not found: $shareId")
+            throw NotFoundException(shareNotFoundMessage(shareId))
         }
 
         share.status = ShareStatus.REVOKED
@@ -221,7 +221,7 @@ class ResourceShareService(
 
     private fun findShareOrThrow(shareId: String): ResourceShare =
         resourceShareRepository.findById(shareId).orElseThrow {
-            NotFoundException("Share not found: $shareId")
+            NotFoundException(shareNotFoundMessage(shareId))
         }
 
     private fun resolveUserByEmail(email: String): SystemUser =
@@ -260,3 +260,5 @@ class ResourceShareService(
         )
     }
 }
+
+private fun shareNotFoundMessage(shareId: String): String = "Share not found: $shareId"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
@@ -32,7 +32,7 @@ class TaxRateService(
      */
     fun getMyTaxRates(): TaxRatesResponse {
         val user =
-            systemUserService.getActiveUser()
+            systemUserService.requireActiveUser()
                 ?: return TaxRatesResponse(emptyList())
         val rates = taxRateRepository.findAllByOwnerId(user.id)
         return TaxRatesResponse(rates.map { it.toDto() })
@@ -44,8 +44,7 @@ class TaxRateService(
      */
     fun getTaxRate(countryCode: String): TaxRateResponse? {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
         val normalizedCode = countryCode.uppercase()
         val rate =
             taxRateRepository
@@ -72,8 +71,7 @@ class TaxRateService(
      */
     fun saveTaxRate(request: TaxRateRequest): TaxRateResponse {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val normalizedCode = request.countryCode.uppercase()
         validateCountryCode(normalizedCode)
@@ -114,8 +112,7 @@ class TaxRateService(
      */
     fun deleteTaxRate(countryCode: String) {
         val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException("User not authenticated")
+            systemUserService.requireActiveUser()
 
         val normalizedCode = countryCode.uppercase()
         val existing =

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
@@ -32,7 +32,7 @@ class TaxRateService(
      */
     fun getMyTaxRates(): TaxRatesResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
                 ?: return TaxRatesResponse(emptyList())
         val rates = taxRateRepository.findAllByOwnerId(user.id)
         return TaxRatesResponse(rates.map { it.toDto() })
@@ -44,7 +44,8 @@ class TaxRateService(
      */
     fun getTaxRate(countryCode: String): TaxRateResponse? {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
         val normalizedCode = countryCode.uppercase()
         val rate =
             taxRateRepository
@@ -71,7 +72,8 @@ class TaxRateService(
      */
     fun saveTaxRate(request: TaxRateRequest): TaxRateResponse {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val normalizedCode = request.countryCode.uppercase()
         validateCountryCode(normalizedCode)
@@ -112,7 +114,8 @@ class TaxRateService(
      */
     fun deleteTaxRate(countryCode: String) {
         val user =
-            systemUserService.requireActiveUser()
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
 
         val normalizedCode = countryCode.uppercase()
         val existing =


### PR DESCRIPTION
### 1. Detekt test-file noise

Add `.codacy/tools-configs/detekt.yaml` excluding two complexity rules from \`**/*Test.kt\`:

- **\`TooManyFunctions\`** — tests are made of many small \`@Test\` methods by design.
- **\`LongMethod\`** — integration-test scenarios are inherently long.

### 2. Dedupe cross-file production strings

Two literals were repeated across multiple services and triggered \`StringLiteralDuplication\`:




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Standardized error message handling across authentication checks using shared constants.
- Centralized repeated error messages to reduce code duplication.
- Enhanced code quality tooling configuration for development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->