### PR TITLE
test: Dedupe repeated literals in BcRowAdapterTest and ValuationServiceTest

### DIFF
--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/Constants.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/Constants.kt
@@ -35,6 +35,8 @@ class Constants {
         val CASH_MARKET = Market("CASH")
         val NYSE = Market("NYSE")
         val ASX = Market("ASX")
+        val PRIVATE_MARKET = Market("PRIVATE")
+        const val PRIVATE = "PRIVATE"
 
         val AAPL =
             getTestAsset(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchServiceTest.kt
@@ -4,6 +4,8 @@ import com.beancounter.auth.AuthUtilService
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.Constants.Companion.PRIVATE
+import com.beancounter.marketdata.Constants.Companion.PRIVATE_MARKET
 import com.beancounter.marketdata.SpringMvcDbTest
 import com.beancounter.marketdata.registration.SystemUserService
 import org.assertj.core.api.Assertions.assertThat
@@ -48,7 +50,7 @@ class AssetSearchServiceTest {
     fun `search PRIVATE finds assets by code`() {
         createPrivateAsset("MY-PROP", "My Investment Property")
 
-        val results = assetSearchService.search("MY-PROP", "PRIVATE")
+        val results = assetSearchService.search("MY-PROP", PRIVATE)
 
         assertThat(results.data).isNotEmpty
         assertThat(results.data.first().symbol).isEqualTo("MY-PROP")
@@ -58,7 +60,7 @@ class AssetSearchServiceTest {
     fun `search PRIVATE finds assets by name`() {
         createPrivateAsset("MY-PROP", "My Investment Property")
 
-        val results = assetSearchService.search("Investment", "PRIVATE")
+        val results = assetSearchService.search("Investment", PRIVATE)
 
         assertThat(results.data).isNotEmpty
         assertThat(results.data.first().name).isEqualTo("My Investment Property")
@@ -73,7 +75,7 @@ class AssetSearchServiceTest {
         authUtilService.authenticate(otherUser, AuthUtilService.AuthProvider.AUTH0)
         systemUserService.register()
 
-        val results = assetSearchService.search("SECRET", "PRIVATE")
+        val results = assetSearchService.search("SECRET", PRIVATE)
 
         assertThat(results.data).isEmpty()
     }
@@ -82,14 +84,14 @@ class AssetSearchServiceTest {
     fun `search handles asset with null priceSymbol resolving currency from market`() {
         // market is @Transient so JPA won't populate it on read.
         // When priceSymbol is also null, currency should be resolved via MarketService.
-        val market = Market("PRIVATE")
+        val market = PRIVATE_MARKET
         assetRepository.save(
             Asset(
                 id = "local-nps-test",
                 code = "${user.id}.NOPRICE",
                 name = "No PriceSymbol Asset",
                 market = market,
-                marketCode = "PRIVATE",
+                marketCode = PRIVATE,
                 priceSymbol = null,
                 category = "Equity",
                 systemUser = user
@@ -107,14 +109,14 @@ class AssetSearchServiceTest {
         code: String,
         name: String
     ) {
-        val privateMarket = Market("PRIVATE")
+        val privateMarket = PRIVATE_MARKET
         assetRepository.save(
             Asset(
                 id = "pvt-${code.lowercase()}",
                 code = "${user.id}.$code",
                 name = name,
                 market = privateMarket,
-                marketCode = "PRIVATE",
+                marketCode = PRIVATE,
                 category = "RE",
                 systemUser = user
             )

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationServiceTest.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.model.ClassificationItem
 import com.beancounter.common.model.ClassificationLevel
 import com.beancounter.common.model.ClassificationStandard
 import com.beancounter.common.utils.KeyGenUtils
+import com.beancounter.marketdata.providers.alpha.AlphaPriceService
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -70,14 +71,14 @@ class ClassificationServiceTest {
         val existingStandard =
             ClassificationStandard(
                 id = STD_ID,
-                key = "ALPHA",
+                key = AlphaPriceService.ID,
                 name = "AlphaVantage",
                 version = "1.0",
                 provider = "ALPHAVANTAGE"
             )
-        whenever(standardRepository.findByKey("ALPHA")).thenReturn(Optional.of(existingStandard))
+        whenever(standardRepository.findByKey(AlphaPriceService.ID)).thenReturn(Optional.of(existingStandard))
 
-        val result = service.getOrCreateStandard("ALPHA", "AlphaVantage")
+        val result = service.getOrCreateStandard(AlphaPriceService.ID, "AlphaVantage")
 
         assertThat(result).isEqualTo(existingStandard)
         verify(standardRepository, never()).save(any())
@@ -134,7 +135,7 @@ class ClassificationServiceTest {
         val standard =
             ClassificationStandard(
                 id = STD_ID,
-                key = "ALPHA",
+                key = AlphaPriceService.ID,
                 name = "Alpha Classification"
             )
         // "TECHNOLOGY" normalizes to "Information Technology" -> code "INFORMATION_TECHNOLOGY"
@@ -252,7 +253,7 @@ class ClassificationServiceTest {
         val standard =
             ClassificationStandard(
                 id = STD_ID,
-                key = "ALPHA",
+                key = AlphaPriceService.ID,
                 name = "Alpha Classification"
             )
         whenever(
@@ -351,7 +352,7 @@ class ClassificationServiceTest {
         val standard =
             ClassificationStandard(
                 id = STD_ID,
-                key = "ALPHA",
+                key = AlphaPriceService.ID,
                 name = "Alpha"
             )
         val sectors =

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProcessorTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProcessorTest.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.MarketData
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.providers.alpha.AlphaPriceService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -62,7 +63,7 @@ class MarketDataPriceProcessorTest {
         `when`(providerUtils.splitProviders(priceRequest.assets))
             .thenReturn(mutableMapOf(mockProvider to mutableListOf(asset)))
 
-        `when`(mockProvider.getId()).thenReturn("ALPHA")
+        `when`(mockProvider.getId()).thenReturn(AlphaPriceService.ID)
         `when`(mockProvider.isApiSupported()).thenReturn(true)
 
         `when`(utilityService.getMarketDate(mockProvider, asset, priceRequest))
@@ -114,7 +115,7 @@ class MarketDataPriceProcessorTest {
         `when`(providerUtils.splitProviders(priceRequest.assets))
             .thenReturn(mutableMapOf(mockProvider to mutableListOf(asset)))
 
-        `when`(mockProvider.getId()).thenReturn("ALPHA")
+        `when`(mockProvider.getId()).thenReturn(AlphaPriceService.ID)
         `when`(mockProvider.isApiSupported()).thenReturn(true)
 
         `when`(utilityService.getMarketDate(mockProvider, asset, priceRequest))
@@ -172,7 +173,7 @@ class MarketDataPriceProcessorTest {
         `when`(providerUtils.splitProviders(priceRequest.assets))
             .thenReturn(mutableMapOf(mockProvider to mutableListOf(asset)))
 
-        `when`(mockProvider.getId()).thenReturn("ALPHA")
+        `when`(mockProvider.getId()).thenReturn(AlphaPriceService.ID)
         `when`(mockProvider.isApiSupported()).thenReturn(true)
 
         `when`(utilityService.getMarketDate(mockProvider, asset, priceRequest))
@@ -224,7 +225,7 @@ class MarketDataPriceProcessorTest {
         `when`(providerUtils.splitProviders(priceRequest.assets))
             .thenReturn(mutableMapOf(mockProvider to mutableListOf(asset)))
 
-        `when`(mockProvider.getId()).thenReturn("ALPHA")
+        `when`(mockProvider.getId()).thenReturn(AlphaPriceService.ID)
 
         `when`(utilityService.getMarketDate(mockProvider, asset, priceRequest))
             .thenReturn(tradingDay)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
@@ -46,7 +46,7 @@ class AlphaCorporateEventEnricherTest {
                 change = BigDecimal("0.50"), // Already correct
                 changePercent = BigDecimal("0.005"),
                 volume = 1000000,
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: The TIME_SERIES_DAILY_ADJUSTED shows a 2:1 split on the same date
@@ -85,7 +85,7 @@ class AlphaCorporateEventEnricherTest {
                 close = BigDecimal("100.00"),
                 previousClose = BigDecimal("100.50"),
                 change = BigDecimal("-0.50"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: The TIME_SERIES_DAILY_ADJUSTED shows a dividend on the same date
@@ -127,7 +127,7 @@ class AlphaCorporateEventEnricherTest {
                 changePercent = BigDecimal("0.0101"),
                 split = BigDecimal.ONE,
                 dividend = BigDecimal.ZERO,
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: No corporate events exist
@@ -157,7 +157,7 @@ class AlphaCorporateEventEnricherTest {
                 close = BigDecimal("100.00"),
                 previousClose = BigDecimal("100.00"),
                 change = BigDecimal("0.00"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         val yesterdayEvent =
@@ -186,7 +186,7 @@ class AlphaCorporateEventEnricherTest {
                 asset = asset,
                 priceDate = priceDate,
                 close = BigDecimal("100.00"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         val yesterdayEvent =
@@ -218,7 +218,7 @@ class AlphaCorporateEventEnricherTest {
                 asset = asset,
                 priceDate = priceDate,
                 close = BigDecimal("100.00"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         val splitOnlyToday =
@@ -261,7 +261,7 @@ class AlphaCorporateEventEnricherTest {
                 asset = voAsset,
                 priceDate = dayAfter,
                 close = BigDecimal("76.56"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         val splitEventOnExDate =
@@ -291,7 +291,7 @@ class AlphaCorporateEventEnricherTest {
                 close = BigDecimal("100.00"),
                 previousClose = BigDecimal("200.00"),
                 change = BigDecimal("-100.00"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: A split exists but 2 days ago (outside the +/-1 day window)
@@ -322,7 +322,7 @@ class AlphaCorporateEventEnricherTest {
                 asset = asset,
                 priceDate = priceDate,
                 close = BigDecimal("100.00"),
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: Both an exact-date dividend and an adjacent-day dividend exist
@@ -362,7 +362,7 @@ class AlphaCorporateEventEnricherTest {
                 close = BigDecimal("66.67"),
                 previousClose = BigDecimal("66.00"), // Already split-adjusted by GLOBAL_QUOTE
                 change = BigDecimal("0.67"), // Already correct
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: A 3:2 split (1.5 coefficient) on the same date
@@ -411,7 +411,7 @@ class AlphaCorporateEventEnricherTest {
                 change = BigDecimal("0.50"),
                 changePercent = BigDecimal("0.0058"),
                 volume = 15000000,
-                source = "ALPHA"
+                source = AlphaPriceService.ID
             )
 
         // And: The TIME_SERIES_DAILY_ADJUSTED shows a 2:1 split on the same date

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
@@ -61,7 +61,7 @@ class AlphaPriceDeserializerTest {
         assertEquals(BigDecimal("6.0600"), marketData.change)
         assertEquals(BigDecimal("0.013450"), marketData.changePercent) // 1.3450% as decimal
         assertEquals(1000000, marketData.volume)
-        assertEquals("ALPHA", marketData.source)
+        assertEquals(AlphaPriceService.ID, marketData.source)
     }
 
     @Test
@@ -102,7 +102,7 @@ class AlphaPriceDeserializerTest {
         assertEquals(BigDecimal("0.0000"), marketData.change)
         assertEquals(BigDecimal.ZERO, marketData.changePercent)
         assertEquals(1000000, marketData.volume)
-        assertEquals("ALPHA", marketData.source)
+        assertEquals(AlphaPriceService.ID, marketData.source)
     }
 
     @Test
@@ -143,7 +143,7 @@ class AlphaPriceDeserializerTest {
         assertEquals(BigDecimal("-5.0000"), marketData.change)
         assertEquals(BigDecimal("-0.011111"), marketData.changePercent) // -1.1111% as decimal
         assertEquals(1000000, marketData.volume)
-        assertEquals("ALPHA", marketData.source)
+        assertEquals(AlphaPriceService.ID, marketData.source)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
@@ -37,6 +37,7 @@ class BcRowAdapterTest {
         const val CALLER_ID = "Kt-1jW3x1g"
         const val ASSET_NAME = "Caredx"
         const val TRADE_DATE = "2021-08-11"
+        const val PRIVATE = "PRIVATE"
     }
 
     @Mock
@@ -140,15 +141,15 @@ class BcRowAdapterTest {
                 BATCH_USX,
                 CALLER_ID,
                 "BUY",
-                "NASDAQ",
+                NASDAQ.code,
                 assetCode,
                 ASSET_NAME,
-                "USD",
-                "USD",
+                USD.code,
+                USD.code,
                 TRADE_DATE,
                 "200.000000",
                 "1.000000",
-                "USD",
+                USD.code,
                 "77.780000",
                 "0.00",
                 "1.386674",
@@ -174,15 +175,15 @@ class BcRowAdapterTest {
                 BATCH_USX,
                 CALLER_ID,
                 "BUY",
-                "NASDAQ",
+                NASDAQ.code,
                 "INVALID",
                 ASSET_NAME,
-                "USD",
-                "USD",
+                USD.code,
+                USD.code,
                 TRADE_DATE,
                 "200.000000",
                 "1.000000",
-                "USD",
+                USD.code,
                 "77.780000",
                 "0.00",
                 "1.386674",
@@ -218,15 +219,15 @@ class BcRowAdapterTest {
                 BATCH_USX,
                 CALLER_ID,
                 "BUY",
-                "NASDAQ",
+                NASDAQ.code,
                 assetCode,
                 ASSET_NAME,
-                "USD",
-                "USD",
+                USD.code,
+                USD.code,
                 "invalid-date",
                 "200.000000",
                 "1.000000",
-                "USD",
+                USD.code,
                 "77.780000",
                 "0.00",
                 "1.386674",
@@ -249,15 +250,15 @@ class BcRowAdapterTest {
                 BATCH_USX,
                 CALLER_ID,
                 "SELL",
-                "NASDAQ",
+                NASDAQ.code,
                 assetCode,
                 ASSET_NAME,
-                "USD",
-                "USD",
+                USD.code,
+                USD.code,
                 TRADE_DATE,
                 "200.000000",
                 "1.000000",
-                "USD",
+                USD.code,
                 "77.780000",
                 "0.00",
                 "1.386674",
@@ -275,7 +276,7 @@ class BcRowAdapterTest {
 
     @Test
     fun `INCOME on private account should settle to same account`() {
-        val privateMarket = Market("PRIVATE")
+        val privateMarket = Market(PRIVATE)
         val privateCash =
             Asset(
                 code = "e2e-test.SGD-SAVINGS",
@@ -290,7 +291,7 @@ class BcRowAdapterTest {
             .`when`(
                 ais.resolveAsset(
                     AssetInput(
-                        "PRIVATE",
+                        PRIVATE,
                         "SGD-SAVINGS",
                         name = "",
                         owner = portfolio.owner.id
@@ -304,7 +305,7 @@ class BcRowAdapterTest {
                 "20250115", // Batch
                 "", // CallerId
                 "INCOME", // Type
-                "PRIVATE", // Market
+                PRIVATE, // Market
                 "SGD-SAVINGS", // Code
                 "", // Name
                 "", // CashAccount (empty — should auto-resolve to asset)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
@@ -12,6 +12,8 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.Constants.Companion.CASH_MARKET
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.Constants.Companion.NZD
+import com.beancounter.marketdata.Constants.Companion.PRIVATE
+import com.beancounter.marketdata.Constants.Companion.PRIVATE_MARKET
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.Constants.Companion.nzdCashBalance
 import com.beancounter.marketdata.Constants.Companion.usdCashBalance
@@ -37,7 +39,6 @@ class BcRowAdapterTest {
         const val CALLER_ID = "Kt-1jW3x1g"
         const val ASSET_NAME = "Caredx"
         const val TRADE_DATE = "2021-08-11"
-        const val PRIVATE = "PRIVATE"
     }
 
     @Mock
@@ -276,7 +277,7 @@ class BcRowAdapterTest {
 
     @Test
     fun `INCOME on private account should settle to same account`() {
-        val privateMarket = Market(PRIVATE)
+        val privateMarket = PRIVATE_MARKET
         val privateCash =
             Asset(
                 code = "e2e-test.SGD-SAVINGS",

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/FxBetweenPrivateAccountsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/FxBetweenPrivateAccountsTest.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.model.Market
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants.Companion.PRIVATE
 import com.beancounter.marketdata.Constants.Companion.SGD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.assets.AssetFinder
@@ -48,7 +49,7 @@ class FxBetweenPrivateAccountsTest {
     private val owner = SystemUser(id = ownerId)
     private val portfolio = Portfolio(id = "portfolio-1", code = "SGD", owner = owner, currency = SGD)
 
-    private val privateMarket = Market(code = "PRIVATE", currency = USD)
+    private val privateMarket = Market(code = PRIVATE, currency = USD)
 
     // Bank account assets with owner prefix in code (as stored in DB)
     private val scbUsdCode = "$ownerId.SCB-USD"
@@ -60,7 +61,7 @@ class FxBetweenPrivateAccountsTest {
             code = scbUsdCode,
             name = "SCB USD Account",
             market = privateMarket,
-            marketCode = "PRIVATE",
+            marketCode = PRIVATE,
             priceSymbol = USD.code,
             category = "ACCOUNT",
             assetCategory = AssetCategory("ACCOUNT", "Bank Account"),
@@ -73,7 +74,7 @@ class FxBetweenPrivateAccountsTest {
             code = scbSgdCode,
             name = "SCB SGD Account",
             market = privateMarket,
-            marketCode = "PRIVATE",
+            marketCode = PRIVATE,
             priceSymbol = SGD.code,
             category = "ACCOUNT",
             assetCategory = AssetCategory("ACCOUNT", "Bank Account"),
@@ -99,7 +100,7 @@ class FxBetweenPrivateAccountsTest {
             .`when`(
                 ais.resolveAsset(
                     AssetInput(
-                        market = "PRIVATE",
+                        market = PRIVATE,
                         code = scbUsdCode, // Full code with owner prefix
                         name = "",
                         owner = ownerId
@@ -116,7 +117,7 @@ class FxBetweenPrivateAccountsTest {
                 "20260121", // Batch
                 "", // CallerId
                 "FX_BUY", // Type - Buy USD
-                "PRIVATE", // Market
+                PRIVATE, // Market
                 scbUsdCode, // Code - the USD account (with owner prefix)
                 "", // Name
                 "", // CashAccount (settlement account)
@@ -159,7 +160,7 @@ class FxBetweenPrivateAccountsTest {
             .`when`(
                 ais.resolveAsset(
                     AssetInput(
-                        market = "PRIVATE",
+                        market = PRIVATE,
                         code = scbUsdCode,
                         name = "",
                         owner = ownerId
@@ -182,7 +183,7 @@ class FxBetweenPrivateAccountsTest {
             .`when`(
                 assetFinder.findLocally(
                     AssetInput(
-                        market = "PRIVATE",
+                        market = PRIVATE,
                         code = "SCB-SGD", // Code without owner prefix
                         owner = ownerId
                     )
@@ -195,7 +196,7 @@ class FxBetweenPrivateAccountsTest {
                 "20260121", // Batch
                 "", // CallerId
                 "FX_BUY", // Type - Buy USD
-                "PRIVATE", // Market
+                PRIVATE, // Market
                 scbUsdCode, // Code - the USD account (buy side)
                 "", // Name
                 "SCB-SGD", // CashAccount - SELL ASSET CODE (human readable!)
@@ -238,7 +239,7 @@ class FxBetweenPrivateAccountsTest {
             .`when`(
                 ais.resolveAsset(
                     AssetInput(
-                        market = "PRIVATE",
+                        market = PRIVATE,
                         code = scbUsdCode,
                         name = "",
                         owner = ownerId
@@ -257,7 +258,7 @@ class FxBetweenPrivateAccountsTest {
                 "20260121", // Batch
                 "", // CallerId
                 "FX_BUY", // Type - Buy USD
-                "PRIVATE", // Market
+                PRIVATE, // Market
                 scbUsdCode, // Code - the USD account (buy side)
                 "", // Name
                 scbSgdAccount.id, // CashAccount - SELL ASSET UUID (backward compat)
@@ -303,7 +304,7 @@ class FxBetweenPrivateAccountsTest {
             .`when`(
                 ais.resolveAsset(
                     AssetInput(
-                        market = "PRIVATE",
+                        market = PRIVATE,
                         code = cleanCode, // Clean code without owner prefix
                         name = "",
                         owner = ownerId
@@ -316,7 +317,7 @@ class FxBetweenPrivateAccountsTest {
                 "20260121", // Batch
                 "", // CallerId
                 "FX_BUY", // Type
-                "PRIVATE", // Market
+                PRIVATE, // Market
                 cleanCode, // Code - just "SCB-USD" without owner prefix
                 "", // Name
                 "", // CashAccount

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -43,6 +43,11 @@ import java.time.LocalDate
  */
 @ExtendWith(MockitoExtension::class)
 class ValuationServiceTest {
+    companion object {
+        private val MV_10K = BigDecimal("10000.00")
+        private val PRICE_150 = BigDecimal("150.00")
+    }
+
     @Mock
     private lateinit var positionValuationService: PositionValuationService
 
@@ -128,13 +133,13 @@ class ValuationServiceTest {
 
         // Set up PORTFOLIO totals (in portfolio currency)
         val portfolioTotals = Totals(portfolio.currency)
-        portfolioTotals.marketValue = BigDecimal("10000.00")
+        portfolioTotals.marketValue = MV_10K
         portfolioTotals.irr = BigDecimal("0.15")
         positions.setTotal(Position.In.PORTFOLIO, portfolioTotals)
 
         // Set up BASE totals (in user's base currency) - this is what gets sent
         val baseTotals = Totals(portfolio.base)
-        baseTotals.marketValue = BigDecimal("10000.00")
+        baseTotals.marketValue = MV_10K
         baseTotals.irr = BigDecimal("0.15")
         positions.setTotal(Position.In.BASE, baseTotals)
 
@@ -210,7 +215,7 @@ class ValuationServiceTest {
                 portfolio = portfolio,
                 trnType = TrnType.BUY,
                 quantity = BigDecimal("10"),
-                price = BigDecimal("150.00"),
+                price = PRICE_150,
                 tradeDate = LocalDate.of(2024, 1, 15)
             )
         val trn2 =
@@ -255,7 +260,7 @@ class ValuationServiceTest {
                 portfolio = portfolio,
                 trnType = TrnType.BUY,
                 quantity = BigDecimal("10"),
-                price = BigDecimal("150.00"),
+                price = PRICE_150,
                 tradeDate = LocalDate.of(2024, 1, 15)
             )
 
@@ -466,7 +471,7 @@ class ValuationServiceTest {
 
         // Set up BASE totals (in USD) with a DIFFERENT value (converted at FX rate)
         val baseTotals = Totals(usdCurrency)
-        baseTotals.marketValue = BigDecimal("10000.00") // 10000 USD (GBP->USD converted)
+        baseTotals.marketValue = MV_10K // 10000 USD (GBP->USD converted)
         baseTotals.irr = BigDecimal("0.12")
         positions.setTotal(Position.In.BASE, baseTotals)
 
@@ -482,7 +487,7 @@ class ValuationServiceTest {
         // Assert the marketValue sent is from BASE totals (10000 USD), not PORTFOLIO totals (8000 GBP)
         assertThat(sentPortfolio.marketValue)
             .describedAs("Market value should be from BASE totals (10000 USD), not PORTFOLIO totals (8000 GBP)")
-            .isEqualTo(BigDecimal("10000.00"))
+            .isEqualTo(MV_10K)
 
         // Also verify IRR is from BASE totals
         assertThat(sentPortfolio.irr)
@@ -502,7 +507,7 @@ class ValuationServiceTest {
         position1.quantityValues.purchased = BigDecimal.TEN
         position1.moneyValues[Position.In.BASE] =
             MoneyValues(portfolio.base).apply {
-                gainOnDay = BigDecimal("150.00")
+                gainOnDay = PRICE_150
                 marketValue = BigDecimal("1500.00")
             }
         positions.add(position1)


### PR DESCRIPTION
## Summary

First sweep at the test-fixture \`StringLiteralDuplication\` hits Codacy flagged. Deferred from PR #804 where the in-file detekt excludes for \`TooManyFunctions\`/\`LongMethod\` were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced hard-coded market/currency/provider literals with shared constants for PRIVATE, provider IDs, and numeric values to improve consistency.
  * Added centralized test constants for private market references.
  * Updated multiple test suites to use canonical identifiers and shared numeric constants, reducing duplication and aligning expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->