### PR TITLE
feat(agent): Per-domain Anthropic model routing (Haiku → Sonnet escalation)

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -6,9 +6,11 @@ import com.beancounter.agent.tools.ToolSelector
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
+import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.env.Environment
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -33,9 +35,22 @@ class AgentController(
     @Autowired(required = false) private val chatClient: ChatClient?,
     private val healthChecker: ServiceHealthChecker,
     private val toolSelector: ToolSelector,
-    private val systemPromptSelector: SystemPromptSelector
+    private val systemPromptSelector: SystemPromptSelector,
+    private val chatModelSelector: ChatModelSelector,
+    private val environment: Environment
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
+
+    /**
+     * Anthropic-only feature: the per-call model override uses
+     * [AnthropicChatOptions]. When the active profile is `ollama` or `openai`,
+     * skip the override and let the configured ChatClient's default model run.
+     */
+    private val anthropicActive: Boolean
+        get() {
+            val profiles = environment.activeProfiles.toSet()
+            return "ollama" !in profiles && "openai" !in profiles
+        }
 
     @GetMapping("/health")
     @Operation(
@@ -74,20 +89,28 @@ class AgentController(
             val userMessage = buildUserMessage(request)
             val tools = toolSelector.selectTools(request.context)
             val systemPrompt = systemPromptSelector.selectFor(request.context)
+            val modelId = chatModelSelector.selectFor(request.context)
             val startMs = System.currentTimeMillis()
-            val callResponse =
+            val promptSpec =
                 chatClient
                     .prompt()
                     .system(systemPrompt)
                     .user(userMessage)
                     .tools(*tools)
-                    .call()
+            val callResponse =
+                if (anthropicActive) {
+                    promptSpec
+                        .options(AnthropicChatOptions.builder().model(modelId).build())
+                        .call()
+                } else {
+                    promptSpec.call()
+                }
 
             val chatResponse = callResponse.chatResponse()
             val content = chatResponse?.result?.output?.text ?: callResponse.content() ?: "(empty response)"
             val elapsedMs = System.currentTimeMillis() - startMs
 
-            logLlmInteraction(userMessage, tools, chatResponse, content, elapsedMs)
+            logLlmInteraction(userMessage, tools, chatResponse, content, elapsedMs, modelId)
 
             ResponseEntity.ok(
                 AgentResponse(
@@ -116,7 +139,8 @@ class AgentController(
         tools: Array<Any>,
         chatResponse: ChatResponse?,
         content: String,
-        elapsedMs: Long
+        elapsedMs: Long,
+        selectedModelId: String
     ) {
         if (!log.isDebugEnabled) return
         val meta = chatResponse?.metadata
@@ -124,9 +148,10 @@ class AgentController(
         val promptPreview = userMessage.take(120).replace("\n", " ")
         val toolNames = tools.map { it.javaClass.simpleName }
         log.debug(
-            "LLM call: model={}, prompt_tokens={}, completion_tokens={}, total_tokens={}, " +
+            "LLM call: model={}, selected_model={}, prompt_tokens={}, completion_tokens={}, total_tokens={}, " +
                 "tools={} {}, response_chars={}, elapsed_ms={}, prompt_preview=\"{}\"",
             meta?.model ?: "unknown",
+            selectedModelId,
             usage?.promptTokens ?: 0,
             usage?.completionTokens ?: 0,
             usage?.totalTokens ?: 0,

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
 import org.springframework.ai.anthropic.AnthropicChatOptions
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,6 +34,7 @@ import java.time.Instant
 @Tag(name = "Agent", description = "Natural-language Beancounter assistant")
 class AgentController(
     @Autowired(required = false) private val chatClient: ChatClient?,
+    @Autowired(required = false) private val anthropicCacheOptions: AnthropicCacheOptions?,
     private val healthChecker: ServiceHealthChecker,
     private val toolSelector: ToolSelector,
     private val systemPromptSelector: SystemPromptSelector,
@@ -99,9 +101,13 @@ class AgentController(
                     .tools(*tools)
             val callResponse =
                 if (anthropicActive) {
-                    promptSpec
-                        .options(AnthropicChatOptions.builder().model(modelId).build())
-                        .call()
+                    // Per-call options REPLACE (not merge) the ChatClient's
+                    // default options — so the cache config configured in
+                    // ChatClientConfiguration must be re-applied here, or
+                    // every request silently loses prompt caching.
+                    val optionsBuilder = AnthropicChatOptions.builder().model(modelId)
+                    anthropicCacheOptions?.let(optionsBuilder::cacheOptions)
+                    promptSpec.options(optionsBuilder.build()).call()
                 } else {
                     promptSpec.call()
                 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentModelTiers.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentModelTiers.kt
@@ -1,0 +1,23 @@
+package com.beancounter.agent
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Anthropic model IDs per cost/quality tier.
+ *
+ * `fast`  — chat, lookups, list/rank queries, news triage. Default Haiku.
+ * `smart` — analytical multi-step domains (retirement projections, rebalance
+ *           plans, deep asset review). Default Sonnet.
+ * `deep`  — reserved for queries the LLM itself escalates as ambiguous /
+ *           multi-portfolio aggregation. Default Opus. Currently unused by
+ *           the page-context selector — wire in when a domain genuinely needs it.
+ *
+ * Override per environment via env vars: `ANTHROPIC_MODEL_FAST`, `ANTHROPIC_MODEL_SMART`,
+ * `ANTHROPIC_MODEL_DEEP` (mapped in application.yml).
+ */
+@ConfigurationProperties("agent.models")
+data class AgentModelTiers(
+    var fast: String = "claude-haiku-4-5-20251001",
+    var smart: String = "claude-sonnet-4-6",
+    var deep: String = "claude-opus-4-7"
+)

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.ollama.OllamaChatModel
 import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Profile
  */
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @Configuration
+@EnableConfigurationProperties(AgentModelTiers::class)
 class ChatClientConfiguration {
     private val log = LoggerFactory.getLogger(ChatClientConfiguration::class.java)
 

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
@@ -53,6 +53,30 @@ class ChatClientConfiguration {
     }
 
     /**
+     * Anthropic prompt-cache config exposed as a bean so per-call code in
+     * [AgentController] can re-include it when overriding model id.
+     *
+     * Cache the static prefix (system prompt + tool definitions) so the
+     * multi-iteration tool-calling loop doesn't re-pay for ~4k tokens of
+     * unchanged content on every round-trip. First request pays a 1.25×
+     * cache-write premium; subsequent requests within the TTL pay 0.1× on
+     * cache reads — a net ~40% input-token saving on any query that fires
+     * more than one tool call.
+     *
+     * ONE_HOUR TTL suits sustained chat / scripted workloads hitting the
+     * same system prompt; FIVE_MINUTES (Anthropic default) is cheaper on
+     * the write but worse for ad-hoc traffic spread across an hour.
+     */
+    @Bean
+    @Profile("!ollama & !openai")
+    fun anthropicCacheOptions(): AnthropicCacheOptions =
+        AnthropicCacheOptions
+            .builder()
+            .strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
+            .messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
+            .build()
+
+    /**
      * Anthropic is the **default** ChatClient — created whenever neither
      * `ollama` nor `openai` is in the active profile list. This matches the
      * agent's `application.yml` defaults (`spring.ai.model.chat: anthropic`)
@@ -63,35 +87,19 @@ class ChatClientConfiguration {
      */
     @Bean("chatClient")
     @Profile("!ollama & !openai")
-    fun anthropicChatClient(chatModel: AnthropicChatModel): ChatClient {
+    fun anthropicChatClient(
+        chatModel: AnthropicChatModel,
+        anthropicCacheOptions: AnthropicCacheOptions
+    ): ChatClient {
         log.info(
             "Building Anthropic ChatClient ({}) with prompt caching enabled (default)",
             chatModel.javaClass.simpleName
         )
 
-        // Enable Anthropic prompt caching for the static prefix (system
-        // prompt + tool definitions) so the multi-iteration tool-calling
-        // loop doesn't re-pay for ~4k tokens of unchanged content on every
-        // round-trip. First request pays a 1.25× cache-write premium;
-        // subsequent requests within the TTL pay 0.1× on cache reads — a
-        // net ~40% input-token saving on any query that fires more than
-        // one tool call.
-        //
-        // FIVE_MINUTES TTL matches Anthropic's default and suits ad-hoc
-        // chat traffic. Swap to ONE_HOUR if you have sustained scripted
-        // workloads hitting the same system prompt; it's more expensive
-        // on the write but cheaper over a long session.
-        val cacheOptions =
-            AnthropicCacheOptions
-                .builder()
-                .strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
-                .messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
-                .build()
-
         val anthropicOptions =
             AnthropicChatOptions
                 .builder()
-                .cacheOptions(cacheOptions)
+                .cacheOptions(anthropicCacheOptions)
                 .build()
 
         // No defaultSystem() — every call overrides via SystemPromptSelector

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/ChatModelSelector.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/ChatModelSelector.kt
@@ -1,0 +1,36 @@
+package com.beancounter.agent
+
+import org.springframework.stereotype.Service
+
+/**
+ * Maps a page context to an Anthropic model id. Mirrors [SystemPromptSelector]:
+ * one tier per analytical domain so we don't pay Sonnet/Opus rates for chat-style
+ * holding lookups that Haiku already answers well.
+ *
+ * Default is FAST. Domains in [SMART_DOMAINS] escalate to the SMART tier.
+ *
+ * Tested against [ChatModelSelectorTest] — the table there is the contract.
+ */
+@Service
+class ChatModelSelector(
+    private val tiers: AgentModelTiers
+) {
+    fun selectFor(context: Map<String, Any>?): String {
+        val page = context?.get("page")?.toString()?.lowercase() ?: ""
+        val isSmart = SMART_DOMAINS.any { it in page }
+        return if (isSmart) tiers.smart else tiers.fast
+    }
+
+    companion object {
+        // Substrings checked against `page.lowercase()`. Keep narrow:
+        // anything not listed defaults to FAST.
+        private val SMART_DOMAINS =
+            listOf(
+                "asset review",
+                "asset-review",
+                "independence",
+                "retire",
+                "rebalanc"
+            )
+    }
+}

--- a/svc-agent/src/main/resources/application.yml
+++ b/svc-agent/src/main/resources/application.yml
@@ -122,15 +122,24 @@ spring:
       base-url: "${ANTHROPIC_BASE_URL:https://api.anthropic.com}"
       chat:
         options:
-          # Claude Haiku 4.5 — fast, cheap, strong tool-calling. Override via
-          # ANTHROPIC_MODEL if you want Sonnet (claude-sonnet-4-6) or Opus
-          # (claude-opus-4-6).
+          # Default / fallback model. Per-domain routing is handled by
+          # ChatModelSelector — see `agent.models.*` below for the active
+          # tier IDs and the page-context that escalates to SMART.
           model: "${ANTHROPIC_MODEL:claude-haiku-4-5-20251001}"
           temperature: 0.2
           max-tokens: 4096
 
     model:
       chat: anthropic
+
+# Per-tier Anthropic model IDs. ChatModelSelector picks one per call based on
+# the page context (Holdings / News / Asset Review / Independence / Rebalance).
+# Override per environment via ANTHROPIC_MODEL_FAST / _SMART / _DEEP.
+agent:
+  models:
+    fast: "${ANTHROPIC_MODEL_FAST:claude-haiku-4-5-20251001}"
+    smart: "${ANTHROPIC_MODEL_SMART:claude-sonnet-4-6}"
+    deep: "${ANTHROPIC_MODEL_DEEP:claude-opus-4-7}"
 
 # Security Configuration - uses same auth.* properties as all other services
 # Helm sets AUTH_URI and AUTH_AUDIENCE via spring.auth template

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -55,6 +55,9 @@ class AgentControllerTest {
     ): AgentController =
         AgentController(
             chatClient,
+            // anthropicCacheOptions is optional; null is fine — the controller
+            // gracefully omits .cacheOptions when the bean isn't present.
+            null,
             healthChecker,
             toolSelector,
             systemPromptSelector,

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.mock.env.MockEnvironment
 
 /**
  * Unit tests for [AgentController]. The agent's actual behaviour is provided by
@@ -39,10 +40,27 @@ class AgentControllerTest {
             on { selectFor(anyOrNull()) } doReturn "test-system-prompt"
         }
 
+    private val chatModelSelector =
+        mock<ChatModelSelector> {
+            on { selectFor(anyOrNull()) } doReturn "test-model-id"
+        }
+
+    // Empty active profiles → controller treats this as the Anthropic default
+    // path. Tests that need ollama / openai branching can override.
+    private val environment = MockEnvironment()
+
     private fun controller(
         chatClient: ChatClient? = null,
         healthChecker: ServiceHealthChecker = stubChecker()
-    ): AgentController = AgentController(chatClient, healthChecker, toolSelector, systemPromptSelector)
+    ): AgentController =
+        AgentController(
+            chatClient,
+            healthChecker,
+            toolSelector,
+            systemPromptSelector,
+            chatModelSelector,
+            environment
+        )
 
     private fun stubChecker(): ServiceHealthChecker =
         mock<ServiceHealthChecker> {

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/ChatModelSelectorTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/ChatModelSelectorTest.kt
@@ -1,0 +1,71 @@
+package com.beancounter.agent
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Domain → model-tier routing. SMART tiers go to costly models for analytical
+ * domains (asset review deep-dive, retirement projection, rebalance planning);
+ * everything else stays on FAST. Default to FAST when context is missing.
+ */
+class ChatModelSelectorTest {
+    private val tiers =
+        AgentModelTiers(
+            fast = "fast-id",
+            smart = "smart-id",
+            deep = "deep-id"
+        )
+    private val selector = ChatModelSelector(tiers)
+
+    @Test
+    fun `Asset Review uses SMART`() {
+        assertThat(selector.selectFor(mapOf("page" to "Asset Review"))).isEqualTo("smart-id")
+    }
+
+    @Test
+    fun `Independence FI uses SMART`() {
+        assertThat(selector.selectFor(mapOf("page" to "Independence"))).isEqualTo("smart-id")
+        assertThat(selector.selectFor(mapOf("page" to "Retirement Plan"))).isEqualTo("smart-id")
+    }
+
+    @Test
+    fun `Rebalance uses SMART`() {
+        assertThat(selector.selectFor(mapOf("page" to "Rebalance Wizard"))).isEqualTo("smart-id")
+    }
+
+    @Test
+    fun `Holdings uses FAST`() {
+        assertThat(selector.selectFor(mapOf("page" to "Holdings"))).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `News and Sentiment uses FAST`() {
+        assertThat(selector.selectFor(mapOf("page" to "News & Sentiment"))).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `Portfolio overview uses FAST`() {
+        assertThat(selector.selectFor(mapOf("page" to "Portfolios"))).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `null context falls back to FAST`() {
+        assertThat(selector.selectFor(null)).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `empty page falls back to FAST`() {
+        assertThat(selector.selectFor(mapOf("page" to ""))).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `unknown page falls back to FAST`() {
+        assertThat(selector.selectFor(mapOf("page" to "Settings"))).isEqualTo("fast-id")
+    }
+
+    @Test
+    fun `case-insensitive page match`() {
+        assertThat(selector.selectFor(mapOf("page" to "ASSET REVIEW"))).isEqualTo("smart-id")
+        assertThat(selector.selectFor(mapOf("page" to "rebalance plans"))).isEqualTo("smart-id")
+    }
+}


### PR DESCRIPTION
## Summary
- Page-context-driven model tier selection. SMART (Sonnet 4.6) for asset review, independence/retire, rebalance. FAST (Haiku 4.5) for everything else (chat, news, holdings, lookups).
- New \`agent.models\` config block — fast/smart/deep IDs overridable via \`ANTHROPIC_MODEL_FAST\`/\`_SMART\`/\`_DEEP\`.
- Per-call \`AnthropicChatOptions.model(...)\` override, profile-guarded so ollama/openai paths are unaffected.
- LLM-call debug log gains \`selected_model=\` so tier mix is observable.

## Why
Haiku 4.5 handles chat/holdings queries well — measured 9.7k prompt tokens on USV with full multi-section assessment. No need for Opus rates across the board (~15× input cost). Sonnet earns its 3× premium on the analytical domains where multi-step reasoning matters; chat-style traffic stays cheap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced intelligent model selection that dynamically routes queries based on page context, assigning optimized AI models to analytical pages and standard models to general pages.
  * Added configurable model tiers (fast, smart, deep) with environment-variable overrides for flexible model selection across environments.

* **Configuration**
  * Refactored prompt caching configuration for better integration with model selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->