### PR TITLE
feat(agent): Stream /agent/query/stream as Server-Sent Events

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -154,9 +154,14 @@ class AgentController(
      * idle-timeout, surfacing as "Load failed" in [useChat]).
      *
      * Event protocol:
-     *   - `event: token` `data: <text-chunk>`  — one per emitted text fragment
-     *   - `event: done`  `data: {tokens, model, elapsed_ms}` — final summary
-     *   - `event: error` `data: <message>`     — terminal, sent on failure
+     *   - `event: token` `data: <text-chunk>` — one per emitted text fragment
+     *   - `event: done`  `data: {chars, elapsed_ms[, model]}` — final summary;
+     *                    `model` is only present when the per-call Anthropic
+     *                    override was applied (i.e. the active profile is
+     *                    Anthropic), since on `ollama`/`openai` the underlying
+     *                    ChatClient picks the model and we don't surface it.
+     *   - `event: error` `data: <opaque-code>` — terminal; payload is a stable
+     *                    code (e.g. `"agent-error"`), never the raw exception.
      */
     @PostMapping("/query/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     @Operation(
@@ -250,13 +255,19 @@ class AgentController(
         // Build via Jackson rather than string interpolation so a future
         // modelId / metric value containing a quote, backslash or newline can
         // never produce malformed SSE.
+        //
+        // `model` is only meaningful when the per-call Anthropic override was
+        // applied — on `ollama` / `openai` profiles the underlying ChatClient
+        // picks the model and `chatModelSelector.selectFor(...)` doesn't
+        // reflect what actually answered the request. Omit the field rather
+        // than report a misleading id.
         val payload =
             objectMapper.writeValueAsString(
-                mapOf(
-                    "model" to modelId,
-                    "chars" to totalChars,
-                    "elapsed_ms" to elapsedMs
-                )
+                buildMap {
+                    put("chars", totalChars)
+                    put("elapsed_ms", elapsedMs)
+                    if (anthropicActive) put("model", modelId)
+                }
             )
         return Flux.just(ServerSentEvent.builder(payload).event("done").build())
     }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -3,6 +3,7 @@ package com.beancounter.agent
 import com.beancounter.agent.health.AgentHealthResponse
 import com.beancounter.agent.health.ServiceHealthChecker
 import com.beancounter.agent.tools.ToolSelector
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
@@ -43,7 +44,8 @@ class AgentController(
     private val toolSelector: ToolSelector,
     private val systemPromptSelector: SystemPromptSelector,
     private val chatModelSelector: ChatModelSelector,
-    private val environment: Environment
+    private val environment: Environment,
+    private val objectMapper: ObjectMapper
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
 
@@ -167,7 +169,6 @@ class AgentController(
     fun stream(
         @RequestBody request: AgentQuery
     ): Flux<ServerSentEvent<String>> {
-        val safeQuery = HtmlUtils.htmlEscape(request.query)
         if (chatClient == null) {
             return Flux.just(
                 ServerSentEvent
@@ -176,74 +177,95 @@ class AgentController(
                     .build()
             )
         }
-        val userMessage = buildUserMessage(request)
-        val tools = toolSelector.selectTools(request.context)
-        val systemPrompt = systemPromptSelector.selectFor(request.context)
-        val modelId = chatModelSelector.selectFor(request.context)
-        val startMs = System.currentTimeMillis()
+        // Wrap the entire pipeline in Flux.defer so setup-time exceptions
+        // (selector failures, options builder failures) become Flux errors
+        // and reach onErrorResume rather than escaping out of the controller
+        // method as raw 500s with no SSE envelope.
+        return Flux
+            .defer {
+                val safeQuery = HtmlUtils.htmlEscape(request.query)
+                val userMessage = buildUserMessage(request)
+                val tools = toolSelector.selectTools(request.context)
+                val systemPrompt = systemPromptSelector.selectFor(request.context)
+                val modelId = chatModelSelector.selectFor(request.context)
+                val startMs = System.currentTimeMillis()
 
-        val promptSpec =
-            chatClient
-                .prompt()
-                .system(systemPrompt)
-                .user(userMessage)
-                .tools(*tools)
-        val streamSpec =
-            if (anthropicActive) {
-                val builder = AnthropicChatOptions.builder().model(modelId)
-                anthropicCacheOptions?.let(builder::cacheOptions)
-                promptSpec.options(builder.build()).stream()
-            } else {
-                promptSpec.stream()
-            }
+                val promptSpec =
+                    chatClient
+                        .prompt()
+                        .system(systemPrompt)
+                        .user(userMessage)
+                        .tools(*tools)
+                val streamSpec =
+                    if (anthropicActive) {
+                        val builder = AnthropicChatOptions.builder().model(modelId)
+                        anthropicCacheOptions?.let(builder::cacheOptions)
+                        promptSpec.options(builder.build()).stream()
+                    } else {
+                        promptSpec.stream()
+                    }
 
-        // Track byte count for the final log line — Spring AI's stream() Flux
-        // doesn't surface token usage on the per-chunk events, so we count
-        // characters as a proxy for visibility.
-        val totalChars = AtomicLong(0)
+                // Track byte count for the final log line — Spring AI's stream() Flux
+                // doesn't surface token usage on the per-chunk events, so we count
+                // characters as a proxy for visibility.
+                val totalChars = AtomicLong(0)
 
-        val tokenEvents =
-            streamSpec
-                .content()
-                .map { chunk ->
-                    totalChars.addAndGet(chunk.length.toLong())
-                    ServerSentEvent
-                        .builder(chunk)
-                        .event("token")
-                        .build()
-                }
+                val tokenEvents =
+                    streamSpec
+                        .content()
+                        .map { chunk ->
+                            totalChars.addAndGet(chunk.length.toLong())
+                            ServerSentEvent
+                                .builder(chunk)
+                                .event("token")
+                                .build()
+                        }
 
-        val doneEvent =
-            Flux.defer {
-                val elapsedMs = System.currentTimeMillis() - startMs
-                if (log.isDebugEnabled) {
-                    val toolNames = tools.map { it.javaClass.simpleName }
-                    log.debug(
-                        "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
-                            "elapsed_ms={}, query=\"{}\"",
-                        modelId,
-                        totalChars.get(),
-                        tools.size,
-                        toolNames,
-                        elapsedMs,
-                        safeQuery.take(120)
-                    )
-                }
-                Flux.just(
-                    ServerSentEvent
-                        .builder("""{"model":"$modelId","chars":${totalChars.get()},"elapsed_ms":$elapsedMs}""")
-                        .event("done")
-                        .build()
-                )
-            }
+                val doneEvent =
+                    Flux.defer {
+                        val elapsedMs = System.currentTimeMillis() - startMs
+                        if (log.isDebugEnabled) {
+                            val toolNames = tools.map { it.javaClass.simpleName }
+                            log.debug(
+                                "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
+                                    "elapsed_ms={}, query=\"{}\"",
+                                modelId,
+                                totalChars.get(),
+                                tools.size,
+                                toolNames,
+                                elapsedMs,
+                                safeQuery.take(120)
+                            )
+                        }
+                        // Build the JSON via Jackson rather than string interpolation —
+                        // model id values are config-controlled today but escaping
+                        // defensively avoids a future surprise if any field carries
+                        // a quote, backslash, or newline.
+                        val payload =
+                            objectMapper.writeValueAsString(
+                                mapOf(
+                                    "model" to modelId,
+                                    "chars" to totalChars.get(),
+                                    "elapsed_ms" to elapsedMs
+                                )
+                            )
+                        Flux.just(
+                            ServerSentEvent
+                                .builder(payload)
+                                .event("done")
+                                .build()
+                        )
+                    }
 
-        return tokenEvents
-            .concatWith(doneEvent)
-            .onErrorResume { e ->
+                tokenEvents.concatWith(doneEvent)
+            }.onErrorResume { e ->
+                // Don't return e.message — leaks internals (stack details, host
+                // names, library exception text). Log full detail server-side
+                // and emit a stable opaque code to the client.
                 log.error("Agent stream failed: {}", e.message, e)
                 Flux.just(
                     ServerSentEvent
-                        .builder<String>(e.message ?: "agent-error")
+                        .builder<String>("agent-error")
                         .event("error")
                         .build()
                 )

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -12,14 +12,18 @@ import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.codec.ServerSentEvent
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.HtmlUtils
+import reactor.core.publisher.Flux
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Single natural-language entry point for the Beancounter agent.
@@ -138,6 +142,112 @@ class AgentController(
                     )
                 )
         }
+    }
+
+    /**
+     * Streaming variant of [query]. Returns a Server-Sent Events stream so
+     * the browser sees a first byte within ~1–2s instead of waiting for the
+     * full LLM + tool-call chain to complete (which can run 30–60s on the
+     * heavier Independence / Rebalance domains and trip mobile-Safari's
+     * idle-timeout, surfacing as "Load failed" in [useChat]).
+     *
+     * Event protocol:
+     *   - `event: token` `data: <text-chunk>`  — one per emitted text fragment
+     *   - `event: done`  `data: {tokens, model, elapsed_ms}` — final summary
+     *   - `event: error` `data: <message>`     — terminal, sent on failure
+     */
+    @PostMapping("/query/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    @Operation(
+        summary = "Streaming variant of /agent/query (Server-Sent Events).",
+        description =
+            "Same inputs as /agent/query but emits the LLM response token-by-token " +
+                "as `text/event-stream`. Use this from clients that risk hitting " +
+                "browser idle-timeouts on long queries."
+    )
+    fun stream(
+        @RequestBody request: AgentQuery
+    ): Flux<ServerSentEvent<String>> {
+        val safeQuery = HtmlUtils.htmlEscape(request.query)
+        if (chatClient == null) {
+            return Flux.just(
+                ServerSentEvent
+                    .builder<String>("No LLM is configured.")
+                    .event("error")
+                    .build()
+            )
+        }
+        val userMessage = buildUserMessage(request)
+        val tools = toolSelector.selectTools(request.context)
+        val systemPrompt = systemPromptSelector.selectFor(request.context)
+        val modelId = chatModelSelector.selectFor(request.context)
+        val startMs = System.currentTimeMillis()
+
+        val promptSpec =
+            chatClient
+                .prompt()
+                .system(systemPrompt)
+                .user(userMessage)
+                .tools(*tools)
+        val streamSpec =
+            if (anthropicActive) {
+                val builder = AnthropicChatOptions.builder().model(modelId)
+                anthropicCacheOptions?.let(builder::cacheOptions)
+                promptSpec.options(builder.build()).stream()
+            } else {
+                promptSpec.stream()
+            }
+
+        // Track byte count for the final log line — Spring AI's stream() Flux
+        // doesn't surface token usage on the per-chunk events, so we count
+        // characters as a proxy for visibility.
+        val totalChars = AtomicLong(0)
+
+        val tokenEvents =
+            streamSpec
+                .content()
+                .map { chunk ->
+                    totalChars.addAndGet(chunk.length.toLong())
+                    ServerSentEvent
+                        .builder(chunk)
+                        .event("token")
+                        .build()
+                }
+
+        val doneEvent =
+            Flux.defer {
+                val elapsedMs = System.currentTimeMillis() - startMs
+                if (log.isDebugEnabled) {
+                    val toolNames = tools.map { it.javaClass.simpleName }
+                    log.debug(
+                        "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
+                            "elapsed_ms={}, query=\"{}\"",
+                        modelId,
+                        totalChars.get(),
+                        tools.size,
+                        toolNames,
+                        elapsedMs,
+                        safeQuery.take(120)
+                    )
+                }
+                Flux.just(
+                    ServerSentEvent
+                        .builder("""{"model":"$modelId","chars":${totalChars.get()},"elapsed_ms":$elapsedMs}""")
+                        .event("done")
+                        .build()
+                )
+            }
+
+        return tokenEvents
+            .concatWith(doneEvent)
+            .onErrorResume { e ->
+                log.error("Agent stream failed: {}", e.message, e)
+                Flux.just(
+                    ServerSentEvent
+                        .builder<String>(e.message ?: "agent-error")
+                        .event("error")
+                        .build()
+                )
+            }
     }
 
     private fun logLlmInteraction(

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -169,108 +169,100 @@ class AgentController(
     fun stream(
         @RequestBody request: AgentQuery
     ): Flux<ServerSentEvent<String>> {
-        if (chatClient == null) {
-            return Flux.just(
-                ServerSentEvent
-                    .builder<String>("No LLM is configured.")
-                    .event("error")
-                    .build()
-            )
-        }
-        // Wrap the entire pipeline in Flux.defer so setup-time exceptions
-        // (selector failures, options builder failures) become Flux errors
-        // and reach onErrorResume rather than escaping out of the controller
-        // method as raw 500s with no SSE envelope.
+        if (chatClient == null) return errorEvent("No LLM is configured.")
+        // Wrap the pipeline in Flux.defer so setup-time exceptions (selector
+        // failures, options builder failures) become Flux errors and reach
+        // onErrorResume rather than escaping out of the controller as a 500.
         return Flux
-            .defer {
-                val safeQuery = HtmlUtils.htmlEscape(request.query)
-                val userMessage = buildUserMessage(request)
-                val tools = toolSelector.selectTools(request.context)
-                val systemPrompt = systemPromptSelector.selectFor(request.context)
-                val modelId = chatModelSelector.selectFor(request.context)
-                val startMs = System.currentTimeMillis()
-
-                val promptSpec =
-                    chatClient
-                        .prompt()
-                        .system(systemPrompt)
-                        .user(userMessage)
-                        .tools(*tools)
-                val streamSpec =
-                    if (anthropicActive) {
-                        val builder = AnthropicChatOptions.builder().model(modelId)
-                        anthropicCacheOptions?.let(builder::cacheOptions)
-                        promptSpec.options(builder.build()).stream()
-                    } else {
-                        promptSpec.stream()
-                    }
-
-                // Track byte count for the final log line — Spring AI's stream() Flux
-                // doesn't surface token usage on the per-chunk events, so we count
-                // characters as a proxy for visibility.
-                val totalChars = AtomicLong(0)
-
-                val tokenEvents =
-                    streamSpec
-                        .content()
-                        .map { chunk ->
-                            totalChars.addAndGet(chunk.length.toLong())
-                            ServerSentEvent
-                                .builder(chunk)
-                                .event("token")
-                                .build()
-                        }
-
-                val doneEvent =
-                    Flux.defer {
-                        val elapsedMs = System.currentTimeMillis() - startMs
-                        if (log.isDebugEnabled) {
-                            val toolNames = tools.map { it.javaClass.simpleName }
-                            log.debug(
-                                "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
-                                    "elapsed_ms={}, query=\"{}\"",
-                                modelId,
-                                totalChars.get(),
-                                tools.size,
-                                toolNames,
-                                elapsedMs,
-                                safeQuery.take(120)
-                            )
-                        }
-                        // Build the JSON via Jackson rather than string interpolation —
-                        // model id values are config-controlled today but escaping
-                        // defensively avoids a future surprise if any field carries
-                        // a quote, backslash, or newline.
-                        val payload =
-                            objectMapper.writeValueAsString(
-                                mapOf(
-                                    "model" to modelId,
-                                    "chars" to totalChars.get(),
-                                    "elapsed_ms" to elapsedMs
-                                )
-                            )
-                        Flux.just(
-                            ServerSentEvent
-                                .builder(payload)
-                                .event("done")
-                                .build()
-                        )
-                    }
-
-                tokenEvents.concatWith(doneEvent)
-            }.onErrorResume { e ->
-                // Don't return e.message — leaks internals (stack details, host
-                // names, library exception text). Log full detail server-side
-                // and emit a stable opaque code to the client.
+            .defer { runStream(request) }
+            .onErrorResume { e ->
+                // Never return e.message — leaks internals. Log full detail
+                // server-side; client gets a stable opaque code.
                 log.error("Agent stream failed: {}", e.message, e)
-                Flux.just(
-                    ServerSentEvent
-                        .builder<String>("agent-error")
-                        .event("error")
-                        .build()
-                )
+                errorEvent("agent-error")
             }
     }
+
+    private fun runStream(request: AgentQuery): Flux<ServerSentEvent<String>> {
+        val safeQuery = HtmlUtils.htmlEscape(request.query)
+        val tools = toolSelector.selectTools(request.context)
+        val modelId = chatModelSelector.selectFor(request.context)
+        val startMs = System.currentTimeMillis()
+
+        // Track byte count for the final log line — Spring AI's stream() Flux
+        // doesn't surface token usage on per-chunk events, so we count chars
+        // as a proxy for visibility.
+        val totalChars = AtomicLong(0)
+
+        val streamSpec = buildStreamSpec(request, tools, modelId)
+        val tokenEvents =
+            streamSpec
+                .content()
+                .map { chunk ->
+                    totalChars.addAndGet(chunk.length.toLong())
+                    ServerSentEvent.builder(chunk).event("token").build()
+                }
+        val doneEvent =
+            Flux.defer { doneEvent(modelId, tools, totalChars.get(), startMs, safeQuery) }
+        return tokenEvents.concatWith(doneEvent)
+    }
+
+    private fun buildStreamSpec(
+        request: AgentQuery,
+        tools: Array<Any>,
+        modelId: String
+    ): ChatClient.StreamResponseSpec {
+        val promptSpec =
+            chatClient!!
+                .prompt()
+                .system(systemPromptSelector.selectFor(request.context))
+                .user(buildUserMessage(request))
+                .tools(*tools)
+        return if (anthropicActive) {
+            val builder = AnthropicChatOptions.builder().model(modelId)
+            anthropicCacheOptions?.let(builder::cacheOptions)
+            promptSpec.options(builder.build()).stream()
+        } else {
+            promptSpec.stream()
+        }
+    }
+
+    private fun doneEvent(
+        modelId: String,
+        tools: Array<Any>,
+        totalChars: Long,
+        startMs: Long,
+        safeQuery: String
+    ): Flux<ServerSentEvent<String>> {
+        val elapsedMs = System.currentTimeMillis() - startMs
+        if (log.isDebugEnabled) {
+            log.debug(
+                "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
+                    "elapsed_ms={}, query=\"{}\"",
+                modelId,
+                totalChars,
+                tools.size,
+                tools.map { it.javaClass.simpleName },
+                elapsedMs,
+                safeQuery.take(120)
+            )
+        }
+        // Build via Jackson rather than string interpolation so a future
+        // modelId / metric value containing a quote, backslash or newline can
+        // never produce malformed SSE.
+        val payload =
+            objectMapper.writeValueAsString(
+                mapOf(
+                    "model" to modelId,
+                    "chars" to totalChars,
+                    "elapsed_ms" to elapsedMs
+                )
+            )
+        return Flux.just(ServerSentEvent.builder(payload).event("done").build())
+    }
+
+    private fun errorEvent(message: String): Flux<ServerSentEvent<String>> =
+        Flux.just(ServerSentEvent.builder<String>(message).event("error").build())
 
     private fun logLlmInteraction(
         userMessage: String,

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -16,6 +16,11 @@ import org.springframework.ai.chat.client.ChatClient
 import org.springframework.mock.env.MockEnvironment
 import reactor.core.publisher.Flux
 
+private const val EVENT_TOKEN = "token"
+private const val EVENT_DONE = "done"
+private const val EVENT_ERROR = "error"
+private const val OPAQUE_ERROR = "agent-error"
+
 /**
  * Unit tests for [AgentController]. The agent's actual behaviour is provided by
  * Spring AI tool calling, which is exercised end-to-end against a real LLM —
@@ -139,7 +144,7 @@ class AgentControllerTest {
         val response = controller(chatClient = client).query(AgentQuery("anything"))
 
         assertThat(response.statusCode.value()).isEqualTo(500)
-        assertThat(response.body?.error).isEqualTo("agent-error")
+        assertThat(response.body?.error).isEqualTo(OPAQUE_ERROR)
     }
 
     @Test
@@ -151,7 +156,7 @@ class AgentControllerTest {
                 .block()!!
 
         assertThat(events).hasSize(1)
-        assertThat(events[0].event()).isEqualTo("error")
+        assertThat(events[0].event()).isEqualTo(EVENT_ERROR)
         assertThat(events[0].data()).contains("No LLM")
     }
 
@@ -173,14 +178,14 @@ class AgentControllerTest {
                 .block()!!
 
         assertThat(events).hasSize(3)
-        assertThat(events[0].event()).isEqualTo("token")
+        assertThat(events[0].event()).isEqualTo(EVENT_TOKEN)
         assertThat(events[0].data()).isEqualTo("Hello")
-        assertThat(events[1].event()).isEqualTo("token")
+        assertThat(events[1].event()).isEqualTo(EVENT_TOKEN)
         assertThat(events[1].data()).isEqualTo(" world")
 
         // Parse the `done` payload as JSON instead of substring matching so
         // formatting / field-order changes can't quietly break the contract.
-        assertThat(events[2].event()).isEqualTo("done")
+        assertThat(events[2].event()).isEqualTo(EVENT_DONE)
         val done = ObjectMapper().readTree(events[2].data())
         assertThat(done["model"].asText()).isEqualTo("test-model-id")
         assertThat(done["chars"].asLong()).isEqualTo(11L)
@@ -234,8 +239,8 @@ class AgentControllerTest {
                 .block()!!
 
         assertThat(events).hasSize(1)
-        assertThat(events[0].event()).isEqualTo("error")
-        assertThat(events[0].data()).isEqualTo("agent-error")
+        assertThat(events[0].event()).isEqualTo(EVENT_ERROR)
+        assertThat(events[0].data()).isEqualTo(OPAQUE_ERROR)
         assertThat(events[0].data()).doesNotContain("boom")
     }
 
@@ -260,8 +265,8 @@ class AgentControllerTest {
         // we only care that the LAST event is the opaque error envelope.
         // The raw exception message is logged server-side, never returned.
         val last = events.last()
-        assertThat(last.event()).isEqualTo("error")
-        assertThat(last.data()).isEqualTo("agent-error")
+        assertThat(last.event()).isEqualTo(EVENT_ERROR)
+        assertThat(last.data()).isEqualTo(OPAQUE_ERROR)
         assertThat(last.data()).doesNotContain("boom")
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -188,6 +188,33 @@ class AgentControllerTest {
     }
 
     @Test
+    fun `done payload omits model when ollama profile is active`() {
+        // On ollama / openai profiles the per-call Anthropic model override is
+        // skipped and the configured ChatClient picks the model. Reporting
+        // `chatModelSelector.selectFor(...)` would mislead the client, so the
+        // field must be omitted from the done envelope on those profiles.
+        environment.setActiveProfiles("ollama")
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        whenever(streamResponse.content()).thenReturn(Flux.just("ok"))
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        val done = ObjectMapper().readTree(events.last().data())
+        assertThat(done.has("model")).isFalse()
+        assertThat(done["chars"].asLong()).isEqualTo(2L)
+    }
+
+    @Test
     fun `stream emits opaque error when stream setup itself throws before any Flux`() {
         // Regression test for the Flux.defer hardening: a synchronous
         // exception thrown by ChatClient.prompt().stream() must surface as

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -177,8 +177,39 @@ class AgentControllerTest {
         assertThat(events[0].data()).isEqualTo("Hello")
         assertThat(events[1].event()).isEqualTo("token")
         assertThat(events[1].data()).isEqualTo(" world")
+
+        // Parse the `done` payload as JSON instead of substring matching so
+        // formatting / field-order changes can't quietly break the contract.
         assertThat(events[2].event()).isEqualTo("done")
-        assertThat(events[2].data()).contains("\"chars\":11")
+        val done = ObjectMapper().readTree(events[2].data())
+        assertThat(done["model"].asText()).isEqualTo("test-model-id")
+        assertThat(done["chars"].asLong()).isEqualTo(11L)
+        assertThat(done["elapsed_ms"].asLong()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `stream emits opaque error when stream setup itself throws before any Flux`() {
+        // Regression test for the Flux.defer hardening: a synchronous
+        // exception thrown by ChatClient.prompt().stream() must surface as
+        // the same SSE error envelope as a Flux.error mid-stream, not as a
+        // raw 500 response without an SSE body.
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenThrow(IllegalStateException("boom"))
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(events).hasSize(1)
+        assertThat(events[0].event()).isEqualTo("error")
+        assertThat(events[0].data()).isEqualTo("agent-error")
+        assertThat(events[0].data()).doesNotContain("boom")
     }
 
     @Test

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -4,6 +4,7 @@ import com.beancounter.agent.health.AgentHealthResponse
 import com.beancounter.agent.health.ServiceHealthChecker
 import com.beancounter.agent.health.ServiceStatus
 import com.beancounter.agent.tools.ToolSelector
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -63,7 +64,8 @@ class AgentControllerTest {
             toolSelector,
             systemPromptSelector,
             chatModelSelector,
-            environment
+            environment,
+            ObjectMapper()
         )
 
     private fun stubChecker(): ServiceHealthChecker =
@@ -197,9 +199,11 @@ class AgentControllerTest {
                 .block()!!
 
         // Error path may emit a partial token chunk before the error fires —
-        // we only care that the LAST event is the error envelope.
+        // we only care that the LAST event is the opaque error envelope.
+        // The raw exception message is logged server-side, never returned.
         val last = events.last()
         assertThat(last.event()).isEqualTo("error")
-        assertThat(last.data()).contains("boom")
+        assertThat(last.data()).isEqualTo("agent-error")
+        assertThat(last.data()).doesNotContain("boom")
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.mock.env.MockEnvironment
+import reactor.core.publisher.Flux
 
 /**
  * Unit tests for [AgentController]. The agent's actual behaviour is provided by
@@ -137,5 +138,68 @@ class AgentControllerTest {
 
         assertThat(response.statusCode.value()).isEqualTo(500)
         assertThat(response.body?.error).isEqualTo("agent-error")
+    }
+
+    @Test
+    fun `stream emits a single error event when no LLM is configured`() {
+        val events =
+            controller(chatClient = null)
+                .stream(AgentQuery("hello"))
+                .collectList()
+                .block()!!
+
+        assertThat(events).hasSize(1)
+        assertThat(events[0].event()).isEqualTo("error")
+        assertThat(events[0].data()).contains("No LLM")
+    }
+
+    @Test
+    fun `stream emits token chunks then a done event`() {
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        whenever(streamResponse.content()).thenReturn(Flux.just("Hello", " world"))
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(events).hasSize(3)
+        assertThat(events[0].event()).isEqualTo("token")
+        assertThat(events[0].data()).isEqualTo("Hello")
+        assertThat(events[1].event()).isEqualTo("token")
+        assertThat(events[1].data()).isEqualTo(" world")
+        assertThat(events[2].event()).isEqualTo("done")
+        assertThat(events[2].data()).contains("\"chars\":11")
+    }
+
+    @Test
+    fun `stream emits an error event when the upstream Flux fails`() {
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        whenever(streamResponse.content()).thenReturn(Flux.error(RuntimeException("boom")))
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        // Error path may emit a partial token chunk before the error fires —
+        // we only care that the LAST event is the error envelope.
+        val last = events.last()
+        assertThat(last.event()).isEqualTo("error")
+        assertThat(last.data()).contains("boom")
     }
 }


### PR DESCRIPTION
## Summary
- Adds POST /agent/query/stream that emits Spring AI ChatClient.stream() output as SSE (event: token, event: done, event: error).
- Reuses the SystemPromptSelector / ChatModelSelector / ToolSelector pipeline and the cache + model AnthropicChatOptions override from #807.
- /agent/query is unchanged.

## Why
The heavier Independence / Rebalance domains chain 3–5 retire / rebalance tool calls per query and routinely run 30–50s end-to-end. Mobile Safari's idle-timeout (~30s on cellular) triggers, surfacing as "Load failed" in bc-view's chat panel. Streaming makes the first byte arrive in 1–2s so the connection never goes idle.

## Pairs with
- monowai/bc-view#NNN — bc-view useChat consumes the SSE stream.

## Test plan
- [x] :svc-agent:test (3 new stream tests + existing query tests passing)
- [x] :svc-agent:formatKotlin :svc-agent:lintKotlin
- [ ] Deploy to kauri, hit /agent/query/stream with curl -N, confirm token events arrive incrementally
- [ ] Test mobile Safari Independence query end-to-end after bc-view companion PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming query endpoint that delivers real-time token fragments, tracks character counts, and emits a final "done" event with JSON summary (chars, elapsed_ms, and model when applicable).
* **Bug Fixes**
  * Setup/streaming errors now produce controlled SSE error events without exposing raw exception details.
* **Tests**
  * Added tests for missing service, normal streaming, profile-specific payload differences, setup failures, and upstream stream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->