### PR TITLE
fix(agent): Propagate SecurityContext into stream() tool callbacks

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -178,6 +178,12 @@ class AgentController(
         // Wrap the pipeline in Flux.defer so setup-time exceptions (selector
         // failures, options builder failures) become Flux errors and reach
         // onErrorResume rather than escaping out of the controller as a 500.
+        //
+        // .contextCapture() snapshots the request thread's ThreadLocals
+        // (incl. SecurityContext via SecurityContextPropagationConfig) so
+        // tool callbacks invoked on Reactor scheduler threads still see the
+        // caller's JWT — without it, TokenService.jwt would throw
+        // "Not authorised" on every tool call.
         return Flux
             .defer { runStream(request) }
             .onErrorResume { e ->
@@ -185,7 +191,7 @@ class AgentController(
                 // server-side; client gets a stable opaque code.
                 log.error("Agent stream failed: {}", e.message, e)
                 errorEvent("agent-error")
-            }
+            }.contextCapture()
     }
 
     private fun runStream(request: AgentQuery): Flux<ServerSentEvent<String>> {

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/SecurityContextPropagationConfig.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/SecurityContextPropagationConfig.kt
@@ -1,0 +1,54 @@
+package com.beancounter.agent
+
+import io.micrometer.context.ContextRegistry
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import reactor.core.publisher.Hooks
+
+/**
+ * Bridges Spring Security's thread-local [SecurityContextHolder] into
+ * Project Reactor's context so values populated on the inbound request
+ * thread survive scheduler hops inside [ChatClient.stream()].
+ *
+ * Without this, Spring AI's stream-mode tool callbacks run on Reactor
+ * IO/parallel threads with an empty [SecurityContextHolder] — and shared
+ * [TokenService.jwt] (`jar-auth`) throws `UnauthorizedException("Not
+ * authorised")` because there's no authentication object to read. The
+ * non-streaming `/agent/query` path didn't hit this because `.call()`
+ * runs synchronously on the request thread.
+ *
+ * [Hooks.enableAutomaticContextPropagation] makes Reactor capture and
+ * restore registered ThreadLocals at every operator boundary. We register
+ * `SecurityContextHolder` against `ContextRegistry` so Reactor knows what
+ * to copy. Spring Security 6.5+ does not auto-register a
+ * `ThreadLocalAccessor` for the servlet `SecurityContextHolder`, so this
+ * config wires it up explicitly.
+ */
+@Configuration
+class SecurityContextPropagationConfig {
+    private val log = LoggerFactory.getLogger(SecurityContextPropagationConfig::class.java)
+
+    @PostConstruct
+    fun enablePropagation() {
+        ContextRegistry
+            .getInstance()
+            .registerThreadLocalAccessor(
+                SECURITY_CONTEXT_KEY,
+                { SecurityContextHolder.getContext() },
+                { ctx -> SecurityContextHolder.setContext(ctx as SecurityContext) },
+                { SecurityContextHolder.clearContext() }
+            )
+        Hooks.enableAutomaticContextPropagation()
+        log.info(
+            "Reactor automatic context propagation enabled — SecurityContext " +
+                "will travel into ChatClient.stream() tool callbacks."
+        )
+    }
+
+    companion object {
+        const val SECURITY_CONTEXT_KEY = "spring.security.context"
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/SecurityContextPropagationTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/SecurityContextPropagationTest.kt
@@ -2,6 +2,7 @@ package com.beancounter.agent
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.Authentication
@@ -28,6 +29,20 @@ import java.util.concurrent.atomic.AtomicReference
  * + `.contextCapture()`, the original Authentication is restored.
  */
 class SecurityContextPropagationTest {
+    companion object {
+        // Reactor's automatic-context-propagation hook and the
+        // ContextRegistry accessor are global, process-wide state. Enable
+        // them exactly once for the whole test class — invoking the same
+        // setup per-test would re-register the accessor on every run, which
+        // is wasted work at best and a state-leak at worst when JUnit
+        // parallelises classes that touch the same ContextRegistry.
+        @BeforeAll
+        @JvmStatic
+        fun enableContextPropagationOnce() {
+            SecurityContextPropagationConfig().enablePropagation()
+        }
+    }
+
     @AfterEach
     fun clearSecurityContext() {
         SecurityContextHolder.clearContext()
@@ -35,10 +50,6 @@ class SecurityContextPropagationTest {
 
     @Test
     fun `Authentication survives Reactor parallel-scheduler hop with contextCapture`() {
-        // Make sure the application's @PostConstruct propagation hooks have
-        // been wired — production code lives in SecurityContextPropagationConfig.
-        SecurityContextPropagationConfig().enablePropagation()
-
         val original: Authentication =
             TestingAuthenticationToken("user@example.com", "creds", "ROLE_USER")
         SecurityContextHolder.getContext().authentication = original

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/SecurityContextPropagationTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/SecurityContextPropagationTest.kt
@@ -1,0 +1,62 @@
+package com.beancounter.agent
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Regression test for the bug observed on the new `/agent/query/stream`
+ * endpoint where `TokenService.jwt` (which reads
+ * `SecurityContextHolder.getContext().authentication`) returns null because
+ * Spring AI's `ChatClient.stream()` runs tool callbacks on a Reactor scheduler
+ * thread — *not* the original request thread.
+ *
+ * Reproduces the threading model in isolation:
+ *   1. Populate SecurityContextHolder on the calling thread.
+ *   2. Run a Flux on Schedulers.parallel() (the same family of pool that
+ *      backs Reactor's IO operators that Spring AI uses internally).
+ *   3. Read SecurityContextHolder from inside that operator.
+ *
+ * Without context propagation enabled, step 3 sees `null`.
+ * With the configuration introduced by [SecurityContextPropagationConfig]
+ * + `.contextCapture()`, the original Authentication is restored.
+ */
+class SecurityContextPropagationTest {
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `Authentication survives Reactor parallel-scheduler hop with contextCapture`() {
+        // Make sure the application's @PostConstruct propagation hooks have
+        // been wired — production code lives in SecurityContextPropagationConfig.
+        SecurityContextPropagationConfig().enablePropagation()
+
+        val original: Authentication =
+            TestingAuthenticationToken("user@example.com", "creds", "ROLE_USER")
+        SecurityContextHolder.getContext().authentication = original
+
+        val captured = AtomicReference<Authentication?>()
+        Flux
+            .just(1)
+            .publishOn(Schedulers.parallel())
+            .doOnNext {
+                captured.set(SecurityContextHolder.getContext().authentication)
+            }.contextCapture()
+            .blockLast()
+
+        assertThat(captured.get())
+            .`as`(
+                "SecurityContext must travel from the request thread into Reactor " +
+                    "scheduler threads, otherwise tool callbacks during ChatClient.stream() " +
+                    "see an empty SecurityContextHolder and TokenService.jwt throws."
+            ).isSameAs(original)
+    }
+}


### PR DESCRIPTION
## Summary
- Register a `ThreadLocalAccessor` for `SecurityContextHolder` against Micrometer's `ContextRegistry` and enable `Hooks.enableAutomaticContextPropagation()` on startup.
- Terminate the `/agent/query/stream` pipeline with `.contextCapture()` so the request-thread SecurityContext travels into Reactor scheduler threads.
- New `SecurityContextPropagationTest` reproduces the threading bug in isolation (populate context → hop to `Schedulers.parallel()` → assert restored).

## Why
On `/agent/query/stream` (PR #808), every tool callback returned **"Not authorised"** to the LLM. Root cause: Spring AI's `ChatClient.stream()` runs tool callbacks on Reactor scheduler threads, not the inbound request thread. `TokenService.jwt` reads `SecurityContextHolder.getContext().authentication` (thread-local) — null on those scheduler threads → `UnauthorizedException`. The non-streaming `/agent/query` path is unaffected because `.call()` runs synchronously on the request thread.

Symptom (mobile UI): "Both the plan list and your independence settings are returning 'Not authorised'."

## Test plan
- [x] `:svc-agent:test` (new `SecurityContextPropagationTest` + existing tests passing)
- [x] `:svc-agent:formatKotlin :svc-agent:lintKotlin`
- [ ] Deploy to kauri and re-run Independence "Review plan details" stream — should return real plan data, not the auth-error apology

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Security context now reliably propagates into streaming tool callbacks, preserving user authentication across async scheduler hops and preventing authorization failures during streaming.

* **Tests**
  * Added a regression test to validate security context propagation across Reactor scheduler boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->