### PR TITLE
feat(agent): Classify stream errors (provider-quota / rate / timeout)

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -309,9 +309,12 @@ class AgentController(
     ): Flux<ServerSentEvent<String>> {
         val elapsedMs = System.currentTimeMillis() - startMs
         // Sentry transaction measurements — same shape as the non-streaming
-        // path so dashboards can mix call+stream traffic.
+        // path so dashboards can mix call+stream traffic. Only attribute the
+        // model tag when the per-call Anthropic override was applied; on
+        // ollama / openai the configured ChatClient picks the model and our
+        // selectedModelId would mislead the metric.
         llmMetrics.capture(
-            modelId = modelId,
+            modelId = modelId.takeIf { anthropicActive },
             usage = usage,
             elapsedMs = elapsedMs,
             toolCount = tools.size,
@@ -367,9 +370,11 @@ class AgentController(
         val meta = chatResponse?.metadata
         val usage = meta?.usage
         // Sentry transaction measurements — runs even when DEBUG is off so
-        // production retains queryable token telemetry.
+        // production retains queryable token telemetry. Only tag the model
+        // when the per-call Anthropic override was applied; otherwise the
+        // selected id doesn't reflect the actual answering model.
         llmMetrics.capture(
-            modelId = selectedModelId,
+            modelId = selectedModelId.takeIf { anthropicActive },
             usage = usage,
             elapsedMs = elapsedMs,
             toolCount = tools.size,

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.anthropic.api.AnthropicCacheOptions
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.metadata.Usage
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
@@ -25,6 +26,7 @@ import org.springframework.web.util.HtmlUtils
 import reactor.core.publisher.Flux
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Single natural-language entry point for the Beancounter agent.
@@ -45,7 +47,8 @@ class AgentController(
     private val systemPromptSelector: SystemPromptSelector,
     private val chatModelSelector: ChatModelSelector,
     private val environment: Environment,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val llmMetrics: LlmMetrics
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
 
@@ -241,21 +244,38 @@ class AgentController(
         val modelId = chatModelSelector.selectFor(request.context)
         val startMs = System.currentTimeMillis()
 
-        // Track byte count for the final log line — Spring AI's stream() Flux
-        // doesn't surface token usage on per-chunk events, so we count chars
-        // as a proxy for visibility.
         val totalChars = AtomicLong(0)
+        // Spring AI's chatResponse() Flux surfaces ChatResponse per chunk; the
+        // final emission carries usage tokens. Capture it so doneEvent can
+        // ship token measurements to Sentry alongside char count + elapsed.
+        val capturedUsage = AtomicReference<Usage?>(null)
 
         val streamSpec = buildStreamSpec(request, tools, modelId)
         val tokenEvents =
             streamSpec
-                .content()
+                .chatResponse()
+                .doOnNext { resp -> resp.metadata?.usage?.let { capturedUsage.set(it) } }
+                .map { resp ->
+                    resp.result
+                        ?.output
+                        ?.text
+                        .orEmpty()
+                }.filter { it.isNotEmpty() }
                 .map { chunk ->
                     totalChars.addAndGet(chunk.length.toLong())
                     ServerSentEvent.builder(chunk).event("token").build()
                 }
         val doneEvent =
-            Flux.defer { doneEvent(modelId, tools, totalChars.get(), startMs, safeQuery) }
+            Flux.defer {
+                doneEvent(
+                    modelId = modelId,
+                    tools = tools,
+                    totalChars = totalChars.get(),
+                    usage = capturedUsage.get(),
+                    startMs = startMs,
+                    safeQuery = safeQuery
+                )
+            }
         return tokenEvents.concatWith(doneEvent)
     }
 
@@ -283,18 +303,32 @@ class AgentController(
         modelId: String,
         tools: Array<Any>,
         totalChars: Long,
+        usage: Usage?,
         startMs: Long,
         safeQuery: String
     ): Flux<ServerSentEvent<String>> {
         val elapsedMs = System.currentTimeMillis() - startMs
+        // Sentry transaction measurements — same shape as the non-streaming
+        // path so dashboards can mix call+stream traffic.
+        llmMetrics.capture(
+            modelId = modelId,
+            usage = usage,
+            elapsedMs = elapsedMs,
+            toolCount = tools.size,
+            mode = LlmMetrics.Mode.STREAM
+        )
         if (log.isDebugEnabled) {
             log.debug(
                 "LLM stream: selected_model={}, response_chars={}, tools={} {}, " +
+                    "prompt_tokens={}, completion_tokens={}, total_tokens={}, " +
                     "elapsed_ms={}, query=\"{}\"",
                 modelId,
                 totalChars,
                 tools.size,
                 tools.map { it.javaClass.simpleName },
+                usage?.promptTokens ?: 0,
+                usage?.completionTokens ?: 0,
+                usage?.totalTokens ?: 0,
                 elapsedMs,
                 safeQuery.take(120)
             )
@@ -330,9 +364,18 @@ class AgentController(
         elapsedMs: Long,
         selectedModelId: String
     ) {
-        if (!log.isDebugEnabled) return
         val meta = chatResponse?.metadata
         val usage = meta?.usage
+        // Sentry transaction measurements — runs even when DEBUG is off so
+        // production retains queryable token telemetry.
+        llmMetrics.capture(
+            modelId = selectedModelId,
+            usage = usage,
+            elapsedMs = elapsedMs,
+            toolCount = tools.size,
+            mode = LlmMetrics.Mode.CALL
+        )
+        if (!log.isDebugEnabled) return
         val promptPreview = userMessage.take(120).replace("\n", " ")
         val toolNames = tools.map { it.javaClass.simpleName }
         log.debug(

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -188,10 +188,51 @@ class AgentController(
             .defer { runStream(request) }
             .onErrorResume { e ->
                 // Never return e.message — leaks internals. Log full detail
-                // server-side; client gets a stable opaque code.
+                // server-side; client gets a stable, classified code so the
+                // UI can surface a real cause instead of generic
+                // "agent-error" when the failure is something the user can
+                // act on (e.g. provider quota, rate limit).
                 log.error("Agent stream failed: {}", e.message, e)
-                errorEvent("agent-error")
+                errorEvent(classifyError(e))
             }.contextCapture()
+    }
+
+    /**
+     * Map an upstream exception into a stable, opaque SSE error code. The
+     * client is free to render a friendly message keyed off the code; the
+     * raw exception text never reaches the client.
+     *
+     *   `provider-quota`   — Anthropic credit balance exhausted (HTTP 400
+     *                        invalid_request_error with "credit balance").
+     *   `provider-rate`    — Provider rate-limited the request (HTTP 429).
+     *   `provider-timeout` — Upstream took too long.
+     *   `agent-error`      — Anything else.
+     */
+    internal fun classifyError(e: Throwable): String {
+        val message = e.message.orEmpty()
+        // Anthropic returns 400 with the credit-balance text in the body.
+        // Match on the body string rather than the status code so we don't
+        // accidentally match unrelated 400s.
+        val isCreditBalance = message.contains("credit balance", ignoreCase = true)
+        val isBilling400 =
+            message.contains("billing", ignoreCase = true) &&
+                message.contains("400", ignoreCase = true)
+        if (isCreditBalance || isBilling400) {
+            return "provider-quota"
+        }
+        if (message.contains("429") ||
+            message.contains("rate limit", ignoreCase = true) ||
+            message.contains("rate_limit", ignoreCase = true)
+        ) {
+            return "provider-rate"
+        }
+        if (e is java.util.concurrent.TimeoutException ||
+            message.contains("timed out", ignoreCase = true) ||
+            message.contains("timeout", ignoreCase = true)
+        ) {
+            return "provider-timeout"
+        }
+        return "agent-error"
     }
 
     private fun runStream(request: AgentQuery): Flux<ServerSentEvent<String>> {

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
@@ -24,12 +24,17 @@ class LlmMetrics {
     private val log = LoggerFactory.getLogger(LlmMetrics::class.java)
 
     fun capture(
-        modelId: String,
+        modelId: String?,
         usage: Usage?,
         elapsedMs: Long,
         toolCount: Int,
         mode: Mode
     ) {
+        @Suppress("TooGenericExceptionCaught")
+        // Sentry's SDK can surface unexpected errors (uninitialised, IO, etc).
+        // Telemetry must never break the user-visible response, so we catch
+        // broadly and log at DEBUG. Narrowing the type would let an unfamiliar
+        // failure mode crash the request thread purely to satisfy the linter.
         try {
             val tx = Sentry.getCurrentScopes().transaction
             if (tx == null) {
@@ -37,7 +42,11 @@ class LlmMetrics {
                 // by profile). Bail silently — metrics are best-effort.
                 return
             }
-            tx.setTag(TAG_MODEL, modelId)
+            // Only tag the model when we actually know it. On ollama / openai
+            // profiles the per-call selected id doesn't reflect what answered
+            // the request, so attributing measurements to it would mislead
+            // dashboards. Skip the tag rather than poison the data.
+            if (!modelId.isNullOrBlank()) tx.setTag(TAG_MODEL, modelId)
             tx.setTag(TAG_TOOLS, toolCount.toString())
             tx.setTag(TAG_MODE, mode.tag)
             tx.setData(DATA_ELAPSED_MS, elapsedMs)
@@ -45,7 +54,6 @@ class LlmMetrics {
             usage?.completionTokens?.toLong()?.let { tx.setMeasurement(M_COMPLETION_TOKENS, it) }
             usage?.totalTokens?.toLong()?.let { tx.setMeasurement(M_TOTAL_TOKENS, it) }
         } catch (e: Exception) {
-            // Telemetry must never affect the user-visible response.
             log.debug("LlmMetrics.capture failed: {}", e.message)
         }
     }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
@@ -1,0 +1,69 @@
+package com.beancounter.agent
+
+import io.sentry.Sentry
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.metadata.Usage
+import org.springframework.stereotype.Component
+
+/**
+ * Publishes per-call LLM telemetry to Sentry so token usage is queryable
+ * from the events / measurements UI without parsing kauri pod stdout.
+ *
+ * Strategy: piggyback on the inbound HTTP request's Sentry transaction
+ * (Spring's Sentry integration auto-creates one per request). Each LLM
+ * call adds:
+ *   - tags    `agent.model`, `agent.tools`, `agent.mode` (call/stream)
+ *   - data    `agent.elapsed_ms`
+ *   - measurements `prompt_tokens`, `completion_tokens`, `total_tokens`
+ *
+ * Sentry's events search supports filtering on `measurements.total_tokens`
+ * and aggregating sum/avg per `agent.model` tag.
+ */
+@Component
+class LlmMetrics {
+    private val log = LoggerFactory.getLogger(LlmMetrics::class.java)
+
+    fun capture(
+        modelId: String,
+        usage: Usage?,
+        elapsedMs: Long,
+        toolCount: Int,
+        mode: Mode
+    ) {
+        try {
+            val tx = Sentry.getCurrentScopes().transaction
+            if (tx == null) {
+                // No active Sentry transaction (e.g. unit test, Sentry disabled
+                // by profile). Bail silently — metrics are best-effort.
+                return
+            }
+            tx.setTag(TAG_MODEL, modelId)
+            tx.setTag(TAG_TOOLS, toolCount.toString())
+            tx.setTag(TAG_MODE, mode.tag)
+            tx.setData(DATA_ELAPSED_MS, elapsedMs)
+            usage?.promptTokens?.toLong()?.let { tx.setMeasurement(M_PROMPT_TOKENS, it) }
+            usage?.completionTokens?.toLong()?.let { tx.setMeasurement(M_COMPLETION_TOKENS, it) }
+            usage?.totalTokens?.toLong()?.let { tx.setMeasurement(M_TOTAL_TOKENS, it) }
+        } catch (e: Exception) {
+            // Telemetry must never affect the user-visible response.
+            log.debug("LlmMetrics.capture failed: {}", e.message)
+        }
+    }
+
+    enum class Mode(
+        val tag: String
+    ) {
+        CALL("call"),
+        STREAM("stream")
+    }
+
+    companion object {
+        private const val TAG_MODEL = "agent.model"
+        private const val TAG_TOOLS = "agent.tools"
+        private const val TAG_MODE = "agent.mode"
+        private const val DATA_ELAPSED_MS = "agent.elapsed_ms"
+        private const val M_PROMPT_TOKENS = "prompt_tokens"
+        private const val M_COMPLETION_TOKENS = "completion_tokens"
+        private const val M_TOTAL_TOKENS = "total_tokens"
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -13,6 +13,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
 import org.springframework.mock.env.MockEnvironment
 import reactor.core.publisher.Flux
 
@@ -20,6 +23,14 @@ private const val EVENT_TOKEN = "token"
 private const val EVENT_DONE = "done"
 private const val EVENT_ERROR = "error"
 private const val OPAQUE_ERROR = "agent-error"
+
+/**
+ * Build a minimal Spring AI [ChatResponse] carrying a single text chunk —
+ * mirrors what `ChatClient.stream().chatResponse()` emits per LLM token
+ * batch in production. Tests prefer this over a Mockito mock so type
+ * changes in Spring AI surface as compile errors, not runtime NPEs.
+ */
+private fun textResponse(chunk: String): ChatResponse = ChatResponse(listOf(Generation(AssistantMessage(chunk))))
 
 /**
  * Unit tests for [AgentController]. The agent's actual behaviour is provided by
@@ -70,7 +81,8 @@ class AgentControllerTest {
             systemPromptSelector,
             chatModelSelector,
             environment,
-            ObjectMapper()
+            ObjectMapper(),
+            LlmMetrics()
         )
 
     private fun stubChecker(): ServiceHealthChecker =
@@ -169,7 +181,8 @@ class AgentControllerTest {
         val streamResponse = mock<ChatClient.StreamResponseSpec>()
         val client = mock<ChatClient> { on { prompt() } doReturn request }
         whenever(request.stream()).thenReturn(streamResponse)
-        whenever(streamResponse.content()).thenReturn(Flux.just("Hello", " world"))
+        whenever(streamResponse.chatResponse())
+            .thenReturn(Flux.just(textResponse("Hello"), textResponse(" world")))
 
         val events =
             controller(chatClient = client)
@@ -206,7 +219,7 @@ class AgentControllerTest {
         val streamResponse = mock<ChatClient.StreamResponseSpec>()
         val client = mock<ChatClient> { on { prompt() } doReturn request }
         whenever(request.stream()).thenReturn(streamResponse)
-        whenever(streamResponse.content()).thenReturn(Flux.just("ok"))
+        whenever(streamResponse.chatResponse()).thenReturn(Flux.just(textResponse("ok")))
 
         val events =
             controller(chatClient = client)
@@ -289,7 +302,8 @@ class AgentControllerTest {
         val streamResponse = mock<ChatClient.StreamResponseSpec>()
         val client = mock<ChatClient> { on { prompt() } doReturn request }
         whenever(request.stream()).thenReturn(streamResponse)
-        whenever(streamResponse.content()).thenReturn(Flux.error(RuntimeException("boom")))
+        whenever(streamResponse.chatResponse())
+            .thenReturn(Flux.error(RuntimeException("boom")))
 
         val events =
             controller(chatClient = client)

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -245,6 +245,42 @@ class AgentControllerTest {
     }
 
     @Test
+    fun `classifyError returns provider-quota for Anthropic credit balance errors`() {
+        val anthropicQuota =
+            RuntimeException(
+                "Response exception, Status: [400 BAD_REQUEST], " +
+                    "Body:[{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\"," +
+                    "\"message\":\"Your credit balance is too low to access the Anthropic API.\"}}]"
+            )
+        assertThat(controller().classifyError(anthropicQuota))
+            .isEqualTo("provider-quota")
+    }
+
+    @Test
+    fun `classifyError returns provider-rate for HTTP 429 and rate-limit text`() {
+        assertThat(controller().classifyError(RuntimeException("HTTP 429 Too Many Requests")))
+            .isEqualTo("provider-rate")
+        assertThat(controller().classifyError(RuntimeException("anthropic.rate_limit_exceeded")))
+            .isEqualTo("provider-rate")
+    }
+
+    @Test
+    fun `classifyError returns provider-timeout for TimeoutException and timeout text`() {
+        assertThat(controller().classifyError(java.util.concurrent.TimeoutException()))
+            .isEqualTo("provider-timeout")
+        assertThat(controller().classifyError(RuntimeException("Read timed out")))
+            .isEqualTo("provider-timeout")
+    }
+
+    @Test
+    fun `classifyError falls back to agent-error for unknown failures`() {
+        assertThat(controller().classifyError(RuntimeException("something exploded")))
+            .isEqualTo(OPAQUE_ERROR)
+        assertThat(controller().classifyError(RuntimeException(null as String?)))
+            .isEqualTo(OPAQUE_ERROR)
+    }
+
+    @Test
     fun `stream emits an error event when the upstream Flux fails`() {
         val request =
             mock<ChatClient.ChatClientRequestSpec>(

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
@@ -27,6 +27,21 @@ class LlmMetricsTest {
     }
 
     @Test
+    fun `capture accepts a null modelId and is a no-op`() {
+        // Controller passes null on ollama/openai profiles where the per-call
+        // model id would be misleading. The signature must accept null and
+        // not blow up downstream.
+        val metrics = LlmMetrics()
+        metrics.capture(
+            modelId = null,
+            usage = DefaultUsage(10, 5, 15),
+            elapsedMs = 0,
+            toolCount = 1,
+            mode = LlmMetrics.Mode.CALL
+        )
+    }
+
+    @Test
     fun `capture swallows null usage`() {
         val metrics = LlmMetrics()
         metrics.capture(

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
@@ -1,0 +1,64 @@
+package com.beancounter.agent
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.metadata.DefaultUsage
+
+/**
+ * LlmMetrics piggybacks on the active Sentry transaction, so when no
+ * transaction is bound (unit-test environment, Sentry disabled) it must
+ * silently no-op rather than throw and disturb the user-visible response.
+ */
+class LlmMetricsTest {
+    @Test
+    fun `capture is a no-op when no Sentry transaction is bound`() {
+        val metrics = LlmMetrics()
+
+        // Should not throw despite Sentry not being initialised in this test JVM.
+        metrics.capture(
+            modelId = "claude-haiku-4-5",
+            usage = DefaultUsage(100, 50, 150),
+            elapsedMs = 1234,
+            toolCount = 4,
+            mode = LlmMetrics.Mode.STREAM
+        )
+    }
+
+    @Test
+    fun `capture swallows null usage`() {
+        val metrics = LlmMetrics()
+        metrics.capture(
+            modelId = "claude-sonnet-4-6",
+            usage = null,
+            elapsedMs = 0,
+            toolCount = 0,
+            mode = LlmMetrics.Mode.CALL
+        )
+    }
+
+    @Test
+    fun `Mode tag value is stable wire contract`() {
+        // The string emitted as the agent.mode Sentry tag is part of the
+        // observability contract — pin it so dashboards keep working.
+        assertThat(LlmMetrics.Mode.CALL.tag).isEqualTo("call")
+        assertThat(LlmMetrics.Mode.STREAM.tag).isEqualTo("stream")
+    }
+
+    @Test
+    fun `capture survives an exception thrown by Sentry`() {
+        // Use a stub usage that throws when read — proves the try/catch
+        // around Sentry interaction shields the caller.
+        val brokenUsage = mock<org.springframework.ai.chat.metadata.Usage>()
+        whenever(brokenUsage.promptTokens).thenThrow(RuntimeException("simulated"))
+        val metrics = LlmMetrics()
+        metrics.capture(
+            modelId = "x",
+            usage = brokenUsage,
+            elapsedMs = 0,
+            toolCount = 0,
+            mode = LlmMetrics.Mode.CALL
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the catch-all "agent-error" SSE envelope with classified codes: \`provider-quota\`, \`provider-rate\`, \`provider-timeout\`, \`agent-error\`.
- bc-view renders user-actionable copy keyed off the code (separate PR).

## Why
The most recent failure on \`/agent/query/stream\` was Anthropic's "Your credit balance is too low" 400. Users saw "Sorry, I encountered an error: agent-error" — no signal to top up the billing account.

## Test plan
- [x] :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin
- [ ] After deploy: trigger a quota error in dev (revoke API key) → confirm SSE \`event: error\` data is \`provider-quota\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and publish LLM token metrics for both call and streaming modes; token counts are included in completion events and debug logs.

* **Bug Fixes**
  * Streaming now returns classified opaque error codes (quota, rate-limit, timeout) while logging full exception details server-side.
  * Streaming emits only non-empty output chunks and forwards captured usage into the completion path.

* **Tests**
  * Added tests for error classification and for LLM telemetry capture and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->