### PR TITLE
feat(agent): Gate AI endpoints behind beancounter:ai / beancounter:preview

### DIFF
--- a/jar-auth/src/main/kotlin/com/beancounter/auth/model/AuthConstants.kt
+++ b/jar-auth/src/main/kotlin/com/beancounter/auth/model/AuthConstants.kt
@@ -11,11 +11,15 @@ object AuthConstants {
     const val USER = "$APP_NAME:user"
     const val SYSTEM = "$APP_NAME:system"
     const val ADMIN = "$APP_NAME:admin"
+    const val AI = "$APP_NAME:ai"
+    const val PREVIEW = "$APP_NAME:preview"
 
     const val SCOPE_BC = "SCOPE_$APP_NAME"
     const val SCOPE_USER = "SCOPE_$USER"
     const val SCOPE_SYSTEM = "SCOPE_$SYSTEM"
     const val SCOPE_ADMIN = "SCOPE_$ADMIN"
+    const val SCOPE_AI = "SCOPE_$AI"
+    const val SCOPE_PREVIEW = "SCOPE_$PREVIEW"
 
     val authSystem = SystemUser(id = SYSTEM)
 

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -1,5 +1,6 @@
 package com.beancounter.agent
 
+import com.beancounter.agent.config.AgentScopeAuthorizer
 import com.beancounter.agent.health.AgentHealthResponse
 import com.beancounter.agent.health.ServiceHealthChecker
 import com.beancounter.agent.tools.ToolSelector
@@ -48,7 +49,8 @@ class AgentController(
     private val chatModelSelector: ChatModelSelector,
     private val environment: Environment,
     private val objectMapper: ObjectMapper,
-    private val llmMetrics: LlmMetrics
+    private val llmMetrics: LlmMetrics,
+    private val scopeAuthorizer: AgentScopeAuthorizer
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
 
@@ -82,6 +84,7 @@ class AgentController(
     fun query(
         @RequestBody request: AgentQuery
     ): ResponseEntity<AgentResponse> {
+        scopeAuthorizer.authorize(request.context)
         val safeQuery = HtmlUtils.htmlEscape(request.query)
         if (chatClient == null) {
             return ResponseEntity
@@ -177,6 +180,7 @@ class AgentController(
     fun stream(
         @RequestBody request: AgentQuery
     ): Flux<ServerSentEvent<String>> {
+        scopeAuthorizer.authorize(request.context)
         if (chatClient == null) return errorEvent("No LLM is configured.")
         // Wrap the pipeline in Flux.defer so setup-time exceptions (selector
         // failures, options builder failures) become Flux errors and reach

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/config/AgentScopeAuthorizer.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/config/AgentScopeAuthorizer.kt
@@ -1,0 +1,66 @@
+package com.beancounter.agent.config
+
+import com.beancounter.auth.model.AuthConstants
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+/**
+ * Per-call authorization for the agent endpoints.
+ *
+ * The single `/agent/query` endpoint serves two tiers:
+ *
+ *  - Default tier — full AI review (portfolio overview, chat, retirement, rebalance, etc.)
+ *    requires `beancounter:ai` (or `beancounter:system` for M2M).
+ *  - Preview tier — single-asset surfaces (Asset Review popup and the per-holding
+ *    News & Sentiment popup) additionally accept `beancounter:preview` so default users
+ *    can sample the AI features without a paid upgrade.
+ *
+ * The split is body-driven (the LLM tool routing already keys off `context.page`,
+ * see [com.beancounter.agent.tools.ToolSelector]), so authz is applied programmatically
+ * inside the controller rather than via `@PreAuthorize`.
+ */
+@Component
+class AgentScopeAuthorizer {
+    fun authorize(context: Map<String, Any>?) {
+        val required = requiredFor(context)
+        val granted =
+            SecurityContextHolder
+                .getContext()
+                .authentication
+                ?.authorities
+                ?.map { it.authority }
+                ?.toSet()
+                .orEmpty()
+        if (granted.intersect(required).isEmpty()) {
+            throw AccessDeniedException(
+                "Agent query requires one of: ${required.joinToString(", ")}"
+            )
+        }
+    }
+
+    internal fun requiredFor(context: Map<String, Any>?): Set<String> {
+        val page =
+            context
+                ?.get("page")
+                ?.toString()
+                ?.lowercase()
+                .orEmpty()
+        val previewEligible =
+            page.contains("asset review") ||
+                page.contains("asset-review") ||
+                (page.contains("news") && page.contains("sentiment"))
+        return if (previewEligible) {
+            setOf(
+                AuthConstants.SCOPE_AI,
+                AuthConstants.SCOPE_PREVIEW,
+                AuthConstants.SCOPE_SYSTEM
+            )
+        } else {
+            setOf(
+                AuthConstants.SCOPE_AI,
+                AuthConstants.SCOPE_SYSTEM
+            )
+        }
+    }
+}

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/config/AgentScopeAuthorizer.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/config/AgentScopeAuthorizer.kt
@@ -40,17 +40,16 @@ class AgentScopeAuthorizer {
     }
 
     internal fun requiredFor(context: Map<String, Any>?): Set<String> {
-        val page =
+        val normalizedPage =
             context
                 ?.get("page")
                 ?.toString()
+                ?.trim()
                 ?.lowercase()
+                ?.replace('-', ' ')
+                ?.replace(WHITESPACE, " ")
                 .orEmpty()
-        val previewEligible =
-            page.contains("asset review") ||
-                page.contains("asset-review") ||
-                (page.contains("news") && page.contains("sentiment"))
-        return if (previewEligible) {
+        return if (normalizedPage in PREVIEW_PAGES) {
             setOf(
                 AuthConstants.SCOPE_AI,
                 AuthConstants.SCOPE_PREVIEW,
@@ -62,5 +61,16 @@ class AgentScopeAuthorizer {
                 AuthConstants.SCOPE_SYSTEM
             )
         }
+    }
+
+    companion object {
+        // Exact-match allowlist of preview-eligible page values. The
+        // normalisation step (trim, lowercase, hyphen→space, whitespace
+        // collapse) lets the bc-view side send "Asset Review" / "asset-review"
+        // and have authz still resolve to the same key. Substring matching
+        // is deliberately avoided — a page literal like "asset review notes"
+        // would otherwise grant preview access to a non-preview surface.
+        private val PREVIEW_PAGES = setOf("asset review", "news sentiment")
+        private val WHITESPACE = Regex("\\s+")
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerAuthzTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerAuthzTest.kt
@@ -23,6 +23,10 @@ import org.springframework.security.core.context.SecurityContextHolder
  *
  * News & Sentiment popup is also preview-eligible (single-asset surface).
  */
+private const val PAGE_ASSET_REVIEW = "Asset Review"
+private const val PAGE_NEWS_SENTIMENT = "News Sentiment"
+private const val PAGE_PORTFOLIO_AI = "Portfolio AI Overview"
+
 class AgentControllerAuthzTest {
     private val authorizer = AgentScopeAuthorizer()
 
@@ -45,15 +49,15 @@ class AgentControllerAuthzTest {
     @Test
     fun `ai scope authorizes any agent context`() {
         authenticateAs(AuthConstants.SCOPE_AI)
-        authorizer.authorize(mapOf("page" to "Asset Review"))
-        authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+        authorizer.authorize(mapOf("page" to PAGE_ASSET_REVIEW))
+        authorizer.authorize(mapOf("page" to PAGE_PORTFOLIO_AI))
         authorizer.authorize(null)
     }
 
     @Test
     fun `system scope authorizes any agent context`() {
         authenticateAs(AuthConstants.SCOPE_SYSTEM)
-        authorizer.authorize(mapOf("page" to "Asset Review"))
+        authorizer.authorize(mapOf("page" to PAGE_ASSET_REVIEW))
         authorizer.authorize(mapOf("page" to "Independence"))
         authorizer.authorize(null)
     }
@@ -63,12 +67,12 @@ class AgentControllerAuthzTest {
         authenticateAs(AuthConstants.SCOPE_PREVIEW)
 
         // Allowed surfaces — case-insensitive, both spellings accepted.
-        authorizer.authorize(mapOf("page" to "Asset Review"))
+        authorizer.authorize(mapOf("page" to PAGE_ASSET_REVIEW))
         authorizer.authorize(mapOf("page" to "asset-review"))
-        authorizer.authorize(mapOf("page" to "News Sentiment"))
+        authorizer.authorize(mapOf("page" to PAGE_NEWS_SENTIMENT))
 
         assertThatThrownBy {
-            authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+            authorizer.authorize(mapOf("page" to PAGE_PORTFOLIO_AI))
         }.isInstanceOf(AccessDeniedException::class.java)
 
         assertThatThrownBy {
@@ -85,11 +89,11 @@ class AgentControllerAuthzTest {
         authenticateAs(AuthConstants.SCOPE_USER, AuthConstants.SCOPE_BC)
 
         assertThatThrownBy {
-            authorizer.authorize(mapOf("page" to "Asset Review"))
+            authorizer.authorize(mapOf("page" to PAGE_ASSET_REVIEW))
         }.isInstanceOf(AccessDeniedException::class.java)
 
         assertThatThrownBy {
-            authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+            authorizer.authorize(mapOf("page" to PAGE_PORTFOLIO_AI))
         }.isInstanceOf(AccessDeniedException::class.java)
 
         assertThatThrownBy {
@@ -101,22 +105,35 @@ class AgentControllerAuthzTest {
     fun `unauthenticated context is rejected`() {
         SecurityContextHolder.clearContext()
         assertThatThrownBy {
-            authorizer.authorize(mapOf("page" to "Asset Review"))
+            authorizer.authorize(mapOf("page" to PAGE_ASSET_REVIEW))
         }.isInstanceOf(AccessDeniedException::class.java)
     }
 
     @Test
     fun `requiredFor returns preview-tier set for asset and news surfaces only`() {
-        assertThat(authorizer.requiredFor(mapOf("page" to "Asset Review")))
+        assertThat(authorizer.requiredFor(mapOf("page" to PAGE_ASSET_REVIEW)))
             .contains(AuthConstants.SCOPE_PREVIEW)
         assertThat(authorizer.requiredFor(mapOf("page" to "asset-review")))
             .contains(AuthConstants.SCOPE_PREVIEW)
-        assertThat(authorizer.requiredFor(mapOf("page" to "News Sentiment")))
+        assertThat(authorizer.requiredFor(mapOf("page" to PAGE_NEWS_SENTIMENT)))
             .contains(AuthConstants.SCOPE_PREVIEW)
 
-        assertThat(authorizer.requiredFor(mapOf("page" to "Portfolio AI Overview")))
+        assertThat(authorizer.requiredFor(mapOf("page" to PAGE_PORTFOLIO_AI)))
             .doesNotContain(AuthConstants.SCOPE_PREVIEW)
         assertThat(authorizer.requiredFor(null))
             .doesNotContain(AuthConstants.SCOPE_PREVIEW)
+    }
+
+    @Test
+    fun `partial keyword matches do not grant preview access`() {
+        authenticateAs(AuthConstants.SCOPE_PREVIEW)
+        // Substring matches like "asset review notes" or "weekly news + sentiment summary"
+        // must NOT be treated as preview-eligible — only exact normalised pages do.
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "asset review notes"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "weekly news and sentiment summary"))
+        }.isInstanceOf(AccessDeniedException::class.java)
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerAuthzTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerAuthzTest.kt
@@ -1,0 +1,122 @@
+package com.beancounter.agent
+
+import com.beancounter.agent.config.AgentScopeAuthorizer
+import com.beancounter.auth.model.AuthConstants
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+
+/**
+ * Contract for [AgentScopeAuthorizer]:
+ *
+ *  | Caller scope            | `context.page = "Asset Review"` | `context.page = "Portfolio AI"` |
+ *  |-------------------------|--------------------------------|--------------------------------|
+ *  | beancounter:ai          | allow                          | allow                          |
+ *  | beancounter:preview     | allow                          | DENY                           |
+ *  | beancounter:system      | allow                          | allow                          |
+ *  | beancounter:user (only) | DENY                           | DENY                           |
+ *
+ * News & Sentiment popup is also preview-eligible (single-asset surface).
+ */
+class AgentControllerAuthzTest {
+    private val authorizer = AgentScopeAuthorizer()
+
+    @AfterEach
+    fun clearContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun authenticateAs(vararg authorities: String) {
+        SecurityContextHolder
+            .getContext()
+            .authentication =
+            TestingAuthenticationToken(
+                "test-user",
+                "n/a",
+                authorities.map(::SimpleGrantedAuthority)
+            )
+    }
+
+    @Test
+    fun `ai scope authorizes any agent context`() {
+        authenticateAs(AuthConstants.SCOPE_AI)
+        authorizer.authorize(mapOf("page" to "Asset Review"))
+        authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+        authorizer.authorize(null)
+    }
+
+    @Test
+    fun `system scope authorizes any agent context`() {
+        authenticateAs(AuthConstants.SCOPE_SYSTEM)
+        authorizer.authorize(mapOf("page" to "Asset Review"))
+        authorizer.authorize(mapOf("page" to "Independence"))
+        authorizer.authorize(null)
+    }
+
+    @Test
+    fun `preview scope authorizes only the single-asset surfaces`() {
+        authenticateAs(AuthConstants.SCOPE_PREVIEW)
+
+        // Allowed surfaces — case-insensitive, both spellings accepted.
+        authorizer.authorize(mapOf("page" to "Asset Review"))
+        authorizer.authorize(mapOf("page" to "asset-review"))
+        authorizer.authorize(mapOf("page" to "News Sentiment"))
+
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "Independence"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+
+        assertThatThrownBy {
+            authorizer.authorize(null)
+        }.isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `user-only scope is rejected on every agent surface`() {
+        authenticateAs(AuthConstants.SCOPE_USER, AuthConstants.SCOPE_BC)
+
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "Asset Review"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "Portfolio AI Overview"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+
+        assertThatThrownBy {
+            authorizer.authorize(null)
+        }.isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `unauthenticated context is rejected`() {
+        SecurityContextHolder.clearContext()
+        assertThatThrownBy {
+            authorizer.authorize(mapOf("page" to "Asset Review"))
+        }.isInstanceOf(AccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `requiredFor returns preview-tier set for asset and news surfaces only`() {
+        assertThat(authorizer.requiredFor(mapOf("page" to "Asset Review")))
+            .contains(AuthConstants.SCOPE_PREVIEW)
+        assertThat(authorizer.requiredFor(mapOf("page" to "asset-review")))
+            .contains(AuthConstants.SCOPE_PREVIEW)
+        assertThat(authorizer.requiredFor(mapOf("page" to "News Sentiment")))
+            .contains(AuthConstants.SCOPE_PREVIEW)
+
+        assertThat(authorizer.requiredFor(mapOf("page" to "Portfolio AI Overview")))
+            .doesNotContain(AuthConstants.SCOPE_PREVIEW)
+        assertThat(authorizer.requiredFor(null))
+            .doesNotContain(AuthConstants.SCOPE_PREVIEW)
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -1,5 +1,6 @@
 package com.beancounter.agent
 
+import com.beancounter.agent.config.AgentScopeAuthorizer
 import com.beancounter.agent.health.AgentHealthResponse
 import com.beancounter.agent.health.ServiceHealthChecker
 import com.beancounter.agent.health.ServiceStatus
@@ -9,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -67,9 +69,18 @@ class AgentControllerTest {
     // path. Tests that need ollama / openai branching can override.
     private val environment = MockEnvironment()
 
+    // Default to a no-op authorizer so existing tests (that don't set up a
+    // SecurityContext) aren't affected by the scope check. The authz contract
+    // itself is verified in AgentControllerAuthzTest.
+    private val permissiveAuthorizer =
+        mock<AgentScopeAuthorizer> {
+            on { authorize(anyOrNull()) } doAnswer { }
+        }
+
     private fun controller(
         chatClient: ChatClient? = null,
-        healthChecker: ServiceHealthChecker = stubChecker()
+        healthChecker: ServiceHealthChecker = stubChecker(),
+        scopeAuthorizer: AgentScopeAuthorizer = permissiveAuthorizer
     ): AgentController =
         AgentController(
             chatClient,
@@ -82,7 +93,8 @@ class AgentControllerTest {
             chatModelSelector,
             environment,
             ObjectMapper(),
-            LlmMetrics()
+            LlmMetrics(),
+            scopeAuthorizer
         )
 
     private fun stubChecker(): ServiceHealthChecker =


### PR DESCRIPTION
## Summary

- Add two Auth0 API permissions (`beancounter:ai`, `beancounter:preview`) on the wire side: new `AI` / `PREVIEW` + `SCOPE_AI` / `SCOPE_PREVIEW` constants in `jar-auth/AuthConstants.kt`.
- New `AgentScopeAuthorizer` runs at the top of `AgentController.query` and `stream`. It accepts `beancounter:ai` or `beancounter:system` for any context; for `context.page` matching `asset review` / `asset-review` / news + sentiment it also accepts `beancounter:preview`.
- `AgentControllerAuthzTest` covers the AI / PREVIEW / SYSTEM / USER / unauthenticated matrix. Existing `AgentControllerTest` uses a no-op authorizer mock so its behaviour is unchanged.

## Pairs with

- bc-view: https://github.com/monowai/bc-view/pull/new/feat/auth0-ai-permissions

## Auth0 dashboard work (manual, not in this PR)

1. Beancounter API → add permissions `beancounter:ai`, `beancounter:preview`.
2. Add `beancounter:preview` to the default `beancounter` role.
3. Create `beancounter-ai` role; assign permission `beancounter:ai`; assign role to test users.

Documentation update lives in `bc-claude/AUTH0.md` (separate, not git-tracked here).

## Test plan

- [x] `./gradlew :svc-agent:check :jar-auth:check` green
- [ ] Token holding `beancounter:ai` → 200 on `/agent/query` for any `context.page`
- [ ] Token holding only `beancounter:preview` → 200 for `context.page = "Asset Review"` / `"News Sentiment"`, 403 for `"Portfolio AI Overview"`
- [ ] Token holding only `beancounter:user` → 403 on any agent call
- [ ] M2M token (carries `beancounter:system`) → 200 always

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new AI and Preview permission tiers to control access to agent features.
  * Agent query endpoints now enforce scope-based authorization so users only access permitted capabilities.
  * Preview access is restricted to specific single-asset surfaces (e.g., asset review, news sentiment).

* **Tests**
  * Added authorization tests covering AI, system, preview, user-only, unauthenticated, and edge-case behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->