### PR TITLE
fix(svc-data): drop FIGI global search results with unmapped exchange codes

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -259,15 +259,22 @@ class AssetSearchService(
                     .filter { result ->
                         val type = result.securityType2?.uppercase()
                         type != null && ALLOWED_SECURITY_TYPES.contains(type)
-                    }.map { result ->
-                        val market = result.exchCode?.let { FigiConfig.getMarketCode(it) }
+                    }.mapNotNull { result ->
+                        // Drop results whose FIGI exchange code does not map to a BC
+                        // market — the UI would otherwise post the raw FIGI code to
+                        // /api/assets and trigger a 404 ("Unable to resolve market
+                        // code"). Matches the searchFigiByTicker path which also
+                        // requires a configured market.
+                        val market =
+                            result.exchCode?.let { FigiConfig.getMarketCode(it) }
+                                ?: return@mapNotNull null
                         AssetSearchResult(
                             symbol = result.ticker ?: keyword,
                             name = result.name ?: "",
                             type = result.securityType2 ?: "Equity",
-                            region = market ?: result.exchCode,
+                            region = market,
                             currency = null,
-                            market = market ?: result.exchCode
+                            market = market
                         )
                     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -265,17 +265,18 @@ class AssetSearchService(
                         // /api/assets and trigger a 404 ("Unable to resolve market
                         // code"). Matches the searchFigiByTicker path which also
                         // requires a configured market.
-                        val market =
-                            result.exchCode?.let { FigiConfig.getMarketCode(it) }
-                                ?: return@mapNotNull null
-                        AssetSearchResult(
-                            symbol = result.ticker ?: keyword,
-                            name = result.name ?: "",
-                            type = result.securityType2 ?: "Equity",
-                            region = market,
-                            currency = null,
-                            market = market
-                        )
+                        result.exchCode
+                            ?.let(FigiConfig::getMarketCode)
+                            ?.let { market ->
+                                AssetSearchResult(
+                                    symbol = result.ticker ?: keyword,
+                                    name = result.name ?: "",
+                                    type = result.securityType2 ?: "Equity",
+                                    region = market,
+                                    currency = null,
+                                    market = market
+                                )
+                            }
                     }
 
             AssetSearchResponse(results)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -110,19 +110,19 @@ class AssetSearchPublicFallbackTest {
                             ticker = "GCOW",
                             name = "PACER GLOBAL CASH COWS DIVID",
                             exchCode = "VG",
-                            securityType2 = "Mutual Fund"
+                            securityType2 = MUTUAL_FUND
                         ),
                         FigiFilterResult(
                             ticker = "GCOW",
                             name = "PACER GLOBAL CASH COWS DIVID",
                             exchCode = "UF",
-                            securityType2 = "Mutual Fund"
+                            securityType2 = MUTUAL_FUND
                         ),
                         FigiFilterResult(
                             ticker = "COWZ",
                             name = "PACER US CASH COWS 100 ETF",
                             exchCode = "US",
-                            securityType2 = "Mutual Fund"
+                            securityType2 = MUTUAL_FUND
                         )
                     )
             )
@@ -162,5 +162,9 @@ class AssetSearchPublicFallbackTest {
         assertThat(results.data).isNotEmpty
         assertThat(results.data.first().symbol).isEqualTo("COWZ")
         verify(alphaProxy, never()).search(any(), any())
+    }
+
+    companion object {
+        private const val MUTUAL_FUND = "Mutual Fund"
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -6,6 +6,7 @@ import com.beancounter.common.utils.BcJson
 import com.beancounter.marketdata.assets.figi.FigiAsset
 import com.beancounter.marketdata.assets.figi.FigiConfig
 import com.beancounter.marketdata.assets.figi.FigiFilterResponse
+import com.beancounter.marketdata.assets.figi.FigiFilterResult
 import com.beancounter.marketdata.assets.figi.FigiGateway
 import com.beancounter.marketdata.assets.figi.FigiResponse
 import com.beancounter.marketdata.markets.MarketService
@@ -94,6 +95,49 @@ class AssetSearchPublicFallbackTest {
             .extracting<String> { it.symbol }
             .containsExactly("COWZ")
         verify(alphaProxy).search(any(), any())
+    }
+
+    @Test
+    fun `searchFigiGlobal drops results whose exchCode does not map to a BC market`() {
+        val figiFilterHits =
+            FigiFilterResponse(
+                data =
+                    listOf(
+                        // VG / UF / UT / UC are not in FigiConfig.EXCHANGE_CODES.
+                        // Returning them raw made the lookup UI post unknown
+                        // market codes to /api/assets and trigger a 404.
+                        FigiFilterResult(
+                            ticker = "GCOW",
+                            name = "PACER GLOBAL CASH COWS DIVID",
+                            exchCode = "VG",
+                            securityType2 = "Mutual Fund"
+                        ),
+                        FigiFilterResult(
+                            ticker = "GCOW",
+                            name = "PACER GLOBAL CASH COWS DIVID",
+                            exchCode = "UF",
+                            securityType2 = "Mutual Fund"
+                        ),
+                        FigiFilterResult(
+                            ticker = "COWZ",
+                            name = "PACER US CASH COWS 100 ETF",
+                            exchCode = "US",
+                            securityType2 = "Mutual Fund"
+                        )
+                    )
+            )
+        val (service, _) =
+            buildService(
+                figiFilterHits = figiFilterHits,
+                alphaProxy = mock<AlphaProxy>()
+            )
+
+        val results = service.search("COW", "FIGI")
+
+        assertThat(results.data)
+            .extracting<String> { it.market }
+            .containsExactly("US")
+        assertThat(results.data.first().symbol).isEqualTo("COWZ")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Asset Lookup → Chart on results returned by FIGI global search (e.g. "GCOW") returned 404 because `searchFigiGlobal` leaked raw FIGI exchange codes (`VG`, `UF`, `UT`, `UC`) when no BC market mapping existed.
- Frontend then posted those codes to `/api/assets`, hitting `Unable to resolve market code VG`.
- Filter unmapped exchanges out of the response so users only see assets the rest of the system can hydrate and price.

## Test plan
- [x] New regression test `searchFigiGlobal drops results whose exchCode does not map to a BC market`
- [x] Existing AssetSearchPublicFallbackTest still passes
- [ ] Manual: search `GCOW` in Asset Lookup and click Chart on a returned result — should now produce a chart instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FIGI global search now excludes results from exchanges that don't map to a configured market, preventing invalid market/region entries.

* **Tests**
  * Added a test to verify FIGI search filtering correctly retains only entries from configured exchange codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->