### PR TITLE
fix(svc-data): resolve shared portfolios in findByCode

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.Locale
+import java.util.Optional
 import java.util.function.Consumer
 
 /**
@@ -130,18 +131,30 @@ class PortfolioService(
             "Searching on behalf of {}",
             systemUser.id
         )
-        val found =
-            portfolioRepository.findByCodeAndOwner(
-                code.uppercase(Locale.getDefault()),
-                systemUser
-            )
-        val portfolio =
-            found.orElseThrow {
-                NotFoundException("Portfolio not found: $code")
+        val normalised = code.uppercase(Locale.getDefault())
+        val owned = portfolioRepository.findByCodeAndOwner(normalised, systemUser)
+        if (owned.isPresent) {
+            val portfolio = owned.get()
+            if (canView(portfolio)) {
+                return portfolio
             }
-        if (canView(portfolio)) {
-            return portfolio
         }
+
+        // Caller may be an adviser viewing a portfolio shared with them.
+        // The (code, owner_id) unique constraint means caller can't already
+        // own a portfolio with this code and the share carries a different
+        // owner — but we still verify canView() to honour share status.
+        val shared =
+            portfolioShareRepository.findByPortfolioCodeIgnoreCaseAndSharedWithAndStatus(
+                normalised,
+                systemUser,
+                ShareStatus.ACTIVE
+            )
+        val sharedPortfolio = shared.flatMap { Optional.ofNullable(it.portfolio) }
+        if (sharedPortfolio.isPresent && canView(sharedPortfolio.get())) {
+            return sharedPortfolio.get()
+        }
+
         throw NotFoundException("Portfolio not found: $code")
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareRepository.kt
@@ -34,6 +34,12 @@ interface PortfolioShareRepository : CrudRepository<PortfolioShare, String> {
         sharedWith: SystemUser
     ): Optional<PortfolioShare>
 
+    fun findByPortfolioCodeIgnoreCaseAndSharedWithAndStatus(
+        code: String,
+        sharedWith: SystemUser,
+        status: ShareStatus
+    ): Optional<PortfolioShare>
+
     fun findByTargetUserAndStatus(
         targetUser: SystemUser,
         status: ShareStatus

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareControllerTest.kt
@@ -226,6 +226,58 @@ internal class PortfolioShareControllerTest {
     }
 
     @Test
+    fun `adviser can view shared portfolio by code after acceptance`() {
+        val portfolio =
+            portfolioCreate(
+                PortfolioInput("VIEW_BY_CODE", "View By Code", USD.code, NZD.code),
+                mockMvc,
+                clientToken
+            ).data.first()
+
+        val inviteRequest =
+            ShareInviteRequest(
+                portfolioIds = listOf(portfolio.id),
+                adviserEmail = "adviser@testing.com"
+            )
+        val inviteResult =
+            mockMvc
+                .perform(
+                    post("$SHARES_ROOT/invite")
+                        .with(jwt().jwt(clientToken))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsBytes(inviteRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val shareId =
+            objectMapper
+                .readValue(
+                    inviteResult.response.contentAsString,
+                    PortfolioSharesResponse::class.java
+                ).data
+                .first()
+                .id
+
+        mockMvc
+            .perform(
+                post("$SHARES_ROOT/$shareId/accept")
+                    .with(jwt().jwt(adviserToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        // Adviser can resolve the portfolio by code (the path bc-view's
+        // /holdings/{code} route hits via svc-position).
+        mockMvc
+            .perform(
+                get("/portfolios/code/${portfolio.code}")
+                    .with(jwt().jwt(adviserToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+    }
+
+    @Test
     fun `adviser cannot view portfolio before acceptance`() {
         val portfolio =
             portfolioCreate(


### PR DESCRIPTION
## Summary
- Opening a managed (shared) portfolio from `/portfolios?tab=managed` in bc-view 404s because the `/holdings/{code}` chain (svc-view → svc-position → svc-data `/portfolios/code/{code}`) resolves the portfolio with `findByCodeAndOwner` only.
- Adviser is not the owner, so the lookup misses and the controller returns 404 even though the share row is ACTIVE.
- Add a fallback in `PortfolioService.findByCode`: if the owned lookup misses, search `portfolio_share` for an ACTIVE row where `shared_with` is the caller and the linked portfolio matches the code; gate the result through `canView()` so revoked/pending shares still 404.

## Test plan
- [x] New test `adviser can view shared portfolio by code after acceptance` covers the new path.
- [x] Existing share/portfolio tests still pass (`./gradlew :svc-data:test` green).
- [ ] Manual: open LIV from `Managed` tab on kauri → page should load instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared portfolios can now be accessed by portfolio code, in addition to owned portfolios.
  * Enhanced portfolio lookup to check both owned and shared portfolios with proper access control.

* **Tests**
  * Added integration test for code-based access to shared portfolios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->