### PR TITLE
feat(svc-data): add autoSettle user preference, default true

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
@@ -18,5 +18,6 @@ data class UserPreferencesRequest(
     val reportingCurrencyCode: String? = null,
     val showWeightedIrr: Boolean? = null,
     val enableTwr: Boolean? = null,
-    val milestoneMode: MilestoneMode? = null
+    val milestoneMode: MilestoneMode? = null,
+    val autoSettle: Boolean? = null
 )

--- a/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
@@ -39,5 +39,7 @@ data class UserPreferences(
     var enableTwr: Boolean = false,
     @Enumerated(EnumType.STRING)
     @Column(name = "milestone_mode")
-    var milestoneMode: MilestoneMode = MilestoneMode.ACTIVE
+    var milestoneMode: MilestoneMode = MilestoneMode.ACTIVE,
+    @Column(name = "auto_settle")
+    var autoSettle: Boolean = true
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
@@ -50,6 +50,7 @@ class UserPreferencesService(
         request.showWeightedIrr?.let { preferences.showWeightedIrr = it }
         request.enableTwr?.let { preferences.enableTwr = it }
         request.milestoneMode?.let { preferences.milestoneMode = it }
+        request.autoSettle?.let { preferences.autoSettle = it }
         return userPreferencesRepository.save(preferences)
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.registration.UserPreferencesService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -13,12 +14,17 @@ import org.springframework.stereotype.Service
  * This service is called by a scheduler to automatically transition dividend and
  * split transactions from PROPOSED to SETTLED status once the pay date is reached.
  * TRADE transactions (BUY, SELL, etc.) are NOT auto-settled.
+ *
+ * Honours the per-owner `autoSettle` preference: rows whose portfolio owner has
+ * disabled auto-settlement are left in PROPOSED so the user can confirm them
+ * manually.
  */
 @Service
 @Transactional
 class AutoSettleService(
     private val trnRepository: TrnRepository,
-    private val dateUtils: DateUtils
+    private val dateUtils: DateUtils,
+    private val userPreferencesService: UserPreferencesService
 ) {
     private val log = LoggerFactory.getLogger(AutoSettleService::class.java)
 
@@ -50,8 +56,24 @@ class AutoSettleService(
             return 0
         }
 
+        // Cache per-owner preference lookups across the batch so we don't hit
+        // the user_preferences table once per transaction.
+        val autoSettleByOwner = mutableMapOf<String, Boolean>()
         var settledCount = 0
         for (trn in dueTransactions) {
+            val owner = trn.portfolio.owner
+            val ownerOptIn =
+                autoSettleByOwner.getOrPut(owner.id) {
+                    userPreferencesService.getOrCreate(owner).autoSettle
+                }
+            if (!ownerOptIn) {
+                log.debug(
+                    "Skipping auto-settle for {} — owner {} has autoSettle disabled",
+                    trn.id,
+                    owner.id
+                )
+                continue
+            }
             trn.status = TrnStatus.SETTLED
             trnRepository.save(trn)
             settledCount++

--- a/svc-data/src/main/resources/db/migration/V17__add_user_pref_auto_settle.sql
+++ b/svc-data/src/main/resources/db/migration/V17__add_user_pref_auto_settle.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences
+    ADD COLUMN auto_settle BOOLEAN NOT NULL DEFAULT TRUE;

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
@@ -55,6 +55,7 @@ class UserPreferencesServiceTest {
             .hasFieldOrPropertyWithValue("baseCurrencyCode", "USD")
             .hasFieldOrPropertyWithValue("showWeightedIrr", true)
             .hasFieldOrPropertyWithValue("enableTwr", false)
+            .hasFieldOrPropertyWithValue("autoSettle", true)
         assertThat(preferences.owner.id).isEqualTo(user.id)
 
         // Verify preferences are now persisted
@@ -118,6 +119,26 @@ class UserPreferencesServiceTest {
         assertThat(updated.preferredName).isEqualTo("Mike")
         assertThat(updated.defaultHoldingsView).isEqualTo(defaultView) // unchanged
         assertThat(updated.baseCurrencyCode).isEqualTo("USD") // unchanged
+    }
+
+    @Test
+    fun `should update autoSettle preference`() {
+        val user = createAndAuthenticateUser("prefs-test-autosettle@email.com")
+
+        val updated =
+            userPreferencesService.update(
+                user,
+                UserPreferencesRequest(autoSettle = false)
+            )
+
+        assertThat(updated.autoSettle).isFalse()
+
+        val reEnabled =
+            userPreferencesService.update(
+                user,
+                UserPreferencesRequest(autoSettle = true)
+            )
+        assertThat(reEnabled.autoSettle).isTrue()
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
@@ -5,9 +5,11 @@ import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.model.UserPreferences
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.registration.UserPreferencesService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +20,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.math.BigDecimal
 import java.time.LocalDate
+import org.mockito.kotlin.any as kAny
 
 /**
  * Tests for AutoSettleService - the service that auto-settles PROPOSED
@@ -28,8 +31,10 @@ class AutoSettleServiceTest {
     private lateinit var trnRepository: TrnRepository
     private lateinit var autoSettleService: AutoSettleService
     private lateinit var dateUtils: DateUtils
+    private lateinit var userPreferencesService: UserPreferencesService
     private val today = LocalDate.now()
 
+    private val testOwner = SystemUser("test-user", "test@example.com")
     private val testPortfolio =
         Portfolio(
             id = "test-portfolio-id",
@@ -37,7 +42,7 @@ class AutoSettleServiceTest {
             name = "Test Portfolio",
             currency = USD,
             base = USD,
-            owner = SystemUser("test-user", "test@example.com")
+            owner = testOwner
         )
 
     companion object {
@@ -48,8 +53,15 @@ class AutoSettleServiceTest {
     fun setUp() {
         trnRepository = mock(TrnRepository::class.java)
         dateUtils = mock(DateUtils::class.java)
+        userPreferencesService = mock(UserPreferencesService::class.java)
         `when`(dateUtils.date).thenReturn(today)
-        autoSettleService = AutoSettleService(trnRepository, dateUtils)
+        // Default: every owner opted in.
+        `when`(userPreferencesService.getOrCreate(kAny<SystemUser>()))
+            .thenAnswer { invocation ->
+                UserPreferences(owner = invocation.getArgument(0))
+            }
+        autoSettleService =
+            AutoSettleService(trnRepository, dateUtils, userPreferencesService)
     }
 
     @Test
@@ -131,6 +143,21 @@ class AutoSettleServiceTest {
 
         // Then: No transactions should be settled
         assertThat(result).isEqualTo(0)
+        verify(trnRepository, never()).save(any(Trn::class.java))
+    }
+
+    @Test
+    fun `should leave transactions PROPOSED when owner has autoSettle disabled`() {
+        val proposedTrn = createProposedTransaction("trn-1", today, TrnType.DIVI)
+        `when`(trnRepository.findDueEventTransactions(TrnStatus.PROPOSED, EVENT_TYPES, today))
+            .thenReturn(listOf(proposedTrn))
+        `when`(userPreferencesService.getOrCreate(testOwner))
+            .thenReturn(UserPreferences(owner = testOwner, autoSettle = false))
+
+        val result = autoSettleService.autoSettleDueTransactions()
+
+        assertThat(result).isEqualTo(0)
+        assertThat(proposedTrn.status).isEqualTo(TrnStatus.PROPOSED)
         verify(trnRepository, never()).save(any(Trn::class.java))
     }
 


### PR DESCRIPTION
## Summary
- `UserPreferences` gains a new `autoSettle` flag (default `true`).
- `AutoSettleService` now reads the owner's preference and skips PROPOSED rows whose owner has opted out, caching per-owner lookups across the batch.
- Flyway V17 adds the `auto_settle BOOLEAN NOT NULL DEFAULT TRUE` column so existing users are migrated as opted-in (preserves current behaviour).

## Test plan
- [x] AutoSettleServiceTest: new test confirms PROPOSED rows are left alone when owner has `autoSettle = false`; existing tests still pass.
- [x] `./gradlew testSmart formatKotlin lintKotlin` — green.
- [ ] Manual after deploy on kauri: confirm Flyway V17 ran and existing `user_preferences` rows have `auto_settle = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user preference to enable/disable automatic transaction settlement (enabled by default).

* **Behavior**
  * Automatic settlement now respects each owner's preference; owners who disable it keep proposed transactions unsettled.

* **Database**
  * Schema updated to persist the new preference with a true default.

* **Tests**
  * Added tests covering default value and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->