### PR TITLE
fix(svc-data): stamp ex-date split from Alpha when provider omits the flag

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -169,6 +169,16 @@ class PriceService(
             return marketData
         }
 
+        // Some providers (e.g. MarketStack) deliver the ex-date row without a
+        // split flag, leaving previousClose on the pre-split basis and the
+        // change/changePercent at -1/N. Cross-check Alpha's split feed (cached)
+        // and stamp the row before the rebase logic below kicks in.
+        if (marketData.split.compareTo(BigDecimal.ONE) == 0) {
+            knownSplitFor(marketData.asset, marketData.priceDate)?.let { factor ->
+                marketData.split = factor
+            }
+        }
+
         val split = marketData.split
         val hasSplit =
             split.compareTo(BigDecimal.ZERO) > 0 && split.compareTo(BigDecimal.ONE) != 0
@@ -413,6 +423,39 @@ class PriceService(
      * coefficients on each ex-date. Without this, [SplitAdjuster] would
      * have nothing to detect when the price rows themselves are bare.
      */
+
+    // Returns Alpha's known split factor for the asset on `date` when one
+    // exists, or null otherwise. Lets enrichWithPreviousClose recover from
+    // providers that omit the split flag on the ex-date row (e.g. MarketStack
+    // on VUG 2026-04-21).
+    private fun knownSplitFor(
+        asset: Asset,
+        date: LocalDate
+    ): BigDecimal? {
+        val service = alphaEventService ?: return null
+        return try {
+            service
+                .getEvents(asset)
+                .data
+                .asSequence()
+                .filter(::isSplit)
+                .firstOrNull { it.priceDate == date }
+                ?.split
+                ?.takeIf { it.compareTo(BigDecimal.ONE) != 0 && it.signum() > 0 }
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.debug(
+                "Split lookup failed for {} on {}: {}",
+                asset.code,
+                date,
+                e.message
+            )
+            null
+        }
+    }
+
     private fun collectSplitEvents(
         asset: Asset,
         from: LocalDate,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -173,7 +173,11 @@ class PriceService(
         // split flag, leaving previousClose on the pre-split basis and the
         // change/changePercent at -1/N. Cross-check Alpha's split feed (cached)
         // and stamp the row before the rebase logic below kicks in.
-        if (marketData.split.compareTo(BigDecimal.ONE) == 0) {
+        // Gate the lookup behind a "likely missing split" anomaly check so we
+        // don't hit Alpha for every normal split=1 row (the common case).
+        if (marketData.split.compareTo(BigDecimal.ONE) == 0 &&
+            looksLikeMissingSplit(marketData, previousDayData.get())
+        ) {
             knownSplitFor(marketData.asset, marketData.priceDate)?.let { factor ->
                 marketData.split = factor
             }
@@ -413,6 +417,21 @@ class PriceService(
         )
     }
 
+    // True when today's close has dropped sharply enough versus yesterday to
+    // suggest the provider may have omitted a split flag on the ex-date row.
+    // Uses a 30% gap threshold — small enough to catch a 2-for-1 split (50%
+    // drop) and well above any plausible single-day organic move, so we keep
+    // Alpha lookups limited to genuinely suspicious rows.
+    private fun looksLikeMissingSplit(
+        marketData: MarketData,
+        previousDay: MarketData
+    ): Boolean {
+        if (previousDay.close.compareTo(BigDecimal.ZERO) <= 0) return false
+        if (marketData.close.compareTo(BigDecimal.ZERO) <= 0) return false
+        val anomalyThreshold = previousDay.close.multiply(MISSING_SPLIT_DROP_THRESHOLD)
+        return marketData.close.compareTo(anomalyThreshold) < 0
+    }
+
     // Returns Alpha's known split factor for the asset on `date` when one
     // exists, or null otherwise. Lets enrichWithPreviousClose recover from
     // providers that omit the split flag on the ex-date row (e.g. MarketStack
@@ -504,4 +523,12 @@ class PriceService(
         assetId: String,
         date: LocalDate
     ): Long = marketDataRepo.countByAssetIdAndPriceDate(assetId, date)
+
+    companion object {
+        // Today's close must be below this fraction of yesterday's close before
+        // we treat the row as a candidate for a missing split flag and consult
+        // Alpha. 0.70 catches 2:1 splits (50% drop) with comfortable headroom
+        // over any realistic organic single-day move.
+        private val MISSING_SPLIT_DROP_THRESHOLD = BigDecimal("0.70")
+    }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -413,17 +413,6 @@ class PriceService(
         )
     }
 
-    /**
-     * Pulls known split events for the asset within the requested range.
-     *
-     * The historical backfill via Alpha's TIME_SERIES_DAILY does not carry
-     * split coefficients, so the database can hold raw pre-split closes
-     * with split=1 across the board. AlphaEventService (cached) returns
-     * splits sourced from TIME_SERIES_DAILY_ADJUSTED which contains the
-     * coefficients on each ex-date. Without this, [SplitAdjuster] would
-     * have nothing to detect when the price rows themselves are bare.
-     */
-
     // Returns Alpha's known split factor for the asset on `date` when one
     // exists, or null otherwise. Lets enrichWithPreviousClose recover from
     // providers that omit the split flag on the ex-date row (e.g. MarketStack
@@ -456,6 +445,16 @@ class PriceService(
         }
     }
 
+    /**
+     * Pulls known split events for the asset within the requested range.
+     *
+     * The historical backfill via Alpha's TIME_SERIES_DAILY does not carry
+     * split coefficients, so the database can hold raw pre-split closes
+     * with split=1 across the board. AlphaEventService (cached) returns
+     * splits sourced from TIME_SERIES_DAILY_ADJUSTED which contains the
+     * coefficients on each ex-date. Without this, [SplitAdjuster] would
+     * have nothing to detect when the price rows themselves are bare.
+     */
     private fun collectSplitEvents(
         asset: Asset,
         from: LocalDate,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.utils.CashUtils
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.event.EventProducer
+import com.beancounter.marketdata.providers.alpha.AlphaEventService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -221,6 +222,72 @@ class PriceServiceTest {
         assertTrue(
             saved[0].changePercent.compareTo(BigDecimal("-0.01")) > 0 &&
                 saved[0].changePercent.compareTo(BigDecimal("0.01")) < 0,
+            "changePercent should be small but was ${saved[0].changePercent}"
+        )
+    }
+
+    @Test
+    fun `should stamp ex-date split from Alpha when provider omits the flag`() {
+        // Given: MarketStack-style ex-date row — close already on the post-split
+        // basis, no split flag on the row, no previousClose supplied. The
+        // Alpha-backed events feed knows the 6:1 split happened today.
+        val today = LocalDate.of(2026, 4, 21)
+        val yesterday = LocalDate.of(2026, 4, 20)
+
+        val todayMarketData =
+            MarketData(
+                asset = asset,
+                priceDate = today,
+                close = BigDecimal("81.50"),
+                split = BigDecimal.ONE
+            )
+        val yesterdayMarketData =
+            MarketData(
+                asset = asset,
+                priceDate = yesterday,
+                close = BigDecimal("492.58")
+            )
+
+        val alphaEventService = mock(AlphaEventService::class.java)
+        `when`(alphaEventService.getEvents(asset)).thenReturn(
+            PriceResponse(
+                listOf(
+                    MarketData(
+                        asset = asset,
+                        priceDate = today,
+                        close = BigDecimal.ZERO,
+                        split = BigDecimal("6"),
+                        dividend = BigDecimal.ZERO
+                    )
+                )
+            )
+        )
+        priceService.setAlphaEventService(alphaEventService)
+
+        `when`(cashUtils.isCash(asset)).thenReturn(false)
+        `when`(marketDataRepo.countByAssetIdAndPriceDate(asset.id, today)).thenReturn(0L)
+        `when`(
+            marketDataRepo.findTop1ByAssetAndPriceDateLessThanOrderByPriceDateDesc(asset, today)
+        ).thenReturn(Optional.of(yesterdayMarketData))
+        `when`(marketDataRepo.saveAll(anyList())).thenAnswer { it.arguments[0] }
+
+        val saved = priceService.handle(PriceResponse(listOf(todayMarketData))).toList()
+
+        // Split flag stamped from Alpha so SplitAdjuster recognises the ex-date.
+        assertTrue(
+            saved[0].split.compareTo(BigDecimal("6")) == 0,
+            "split should be 6 but was ${saved[0].split}"
+        )
+        // previousClose rebased onto post-split basis (492.58 / 6 ≈ 82.0967)
+        assertTrue(
+            saved[0].previousClose.compareTo(BigDecimal("82.00")) > 0 &&
+                saved[0].previousClose.compareTo(BigDecimal("82.20")) < 0,
+            "previousClose should be ~82.10 but was ${saved[0].previousClose}"
+        )
+        // changePercent reflects the real intraday move, not -83%
+        assertTrue(
+            saved[0].changePercent.compareTo(BigDecimal("-0.05")) > 0 &&
+                saved[0].changePercent.compareTo(BigDecimal("0.05")) < 0,
             "changePercent should be small but was ${saved[0].changePercent}"
         )
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
@@ -8,6 +8,7 @@ import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.event.EventProducer
 import com.beancounter.marketdata.providers.alpha.AlphaEventService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -274,22 +275,15 @@ class PriceServiceTest {
         val saved = priceService.handle(PriceResponse(listOf(todayMarketData))).toList()
 
         // Split flag stamped from Alpha so SplitAdjuster recognises the ex-date.
-        assertTrue(
-            saved[0].split.compareTo(BigDecimal("6")) == 0,
-            "split should be 6 but was ${saved[0].split}"
-        )
+        assertThat(saved[0].split).isEqualByComparingTo("6")
         // previousClose rebased onto post-split basis (492.58 / 6 ≈ 82.0967)
-        assertTrue(
-            saved[0].previousClose.compareTo(BigDecimal("82.00")) > 0 &&
-                saved[0].previousClose.compareTo(BigDecimal("82.20")) < 0,
-            "previousClose should be ~82.10 but was ${saved[0].previousClose}"
-        )
+        assertThat(saved[0].previousClose)
+            .isGreaterThan(BigDecimal("82.00"))
+            .isLessThan(BigDecimal("82.20"))
         // changePercent reflects the real intraday move, not -83%
-        assertTrue(
-            saved[0].changePercent.compareTo(BigDecimal("-0.05")) > 0 &&
-                saved[0].changePercent.compareTo(BigDecimal("0.05")) < 0,
-            "changePercent should be small but was ${saved[0].changePercent}"
-        )
+        assertThat(saved[0].changePercent)
+            .isGreaterThan(BigDecimal("-0.05"))
+            .isLessThan(BigDecimal("0.05"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The b646fdb4 fix only covered the Alpha-supplied stamp. MarketStack-priced assets (e.g. VUG) hit the same problem from the other side: the ex-date row arrives with `split=1` because MarketStack doesn't flag the day, so `enrichWithPreviousClose` never rebases `previousClose`. The holdings page then renders -83% for a 6:1 split.
- Cross-check Alpha's cached split feed inside `enrichWithPreviousClose` when the row arrives with `split=1` — if Alpha knows a split happened on that priceDate, stamp the factor before the rebase logic runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stock splits when market data providers don't supply split flags
  * Enhanced price rebasement calculations to prevent incorrect change percentages resulting from undetected splits
  * Added anomaly detection to identify likely missing split data based on historical patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->