### PR TITLE
feat(svc-agent): by-id portfolio/position/event tools for managed views

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/client/PositionClient.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/client/PositionClient.kt
@@ -31,4 +31,22 @@ class PositionClient(
             .retrieve()
             .body<PositionResponse>()
             ?: PositionResponse()
+
+    /**
+     * Lookup positions by portfolio id. Required for managed (shared)
+     * portfolios because portfolio code is unique only within an owner —
+     * the by-code path 404s for an adviser viewing a client's portfolio.
+     */
+    fun getPositionsById(
+        portfolioId: String,
+        asAt: String = "today",
+        includeValues: Boolean = true
+    ): PositionResponse =
+        restClient
+            .get()
+            .uri("/id/{id}?asAt={asAt}&value={value}", portfolioId, asAt, includeValues)
+            .header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+            .retrieve()
+            .body<PositionResponse>()
+            ?: PositionResponse()
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -9,8 +9,15 @@ import org.springframework.stereotype.Service
 /**
  * Tools for corporate event lookup, loading and backfill.
  *
- * Portfolio-scoped tools accept a user-visible code and resolve it to the
- * internal id inside the tool — the LLM never sees or has to manage ids.
+ * Portfolio-scoped tools come in pairs: a by-**code** variant for the
+ * standard case (the user owns the portfolio and refers to it by its
+ * short code), and a by-**id** variant
+ * ([loadPortfolioEventsByPortfolioId], [backfillPortfolioEventsByPortfolioId])
+ * for managed/shared portfolios where code is ambiguous. The by-code
+ * variants resolve the code to an internal id inside the tool; the by-id
+ * variants pass the caller-supplied id straight through. The frontend
+ * exposes `portfolioId` in the page context when the by-id variants
+ * should be picked.
  */
 @Service
 class EventTools(

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -31,6 +31,17 @@ class EventTools(
         return eventClient.loadPortfolioEvents(portfolio.id, asAt)
     }
 
+    @Tool(description = LOAD_BY_ID_DESC)
+    fun loadPortfolioEventsByPortfolioId(
+        @ToolParam(
+            description =
+                "Internal portfolio id (UUID-like, ~22 chars). Use this when the page " +
+                    "context provides `portfolioId` instead of `portfolioCode` " +
+                    "(managed/shared portfolios)."
+        ) portfolioId: String,
+        @ToolParam(description = "Date YYYY-MM-DD or 'today'") asAt: String = "today"
+    ): Map<String, Any> = eventClient.loadPortfolioEvents(portfolioId, asAt)
+
     @Tool(description = BACKFILL_DESC)
     fun backfillPortfolioEvents(
         @ToolParam(description = "Portfolio code as the user types it, e.g. 'TYLER'") portfolioCode: String,
@@ -41,6 +52,18 @@ class EventTools(
         return eventClient.backfillPortfolio(portfolio.id, fromDate, toDate.ifBlank { fromDate })
     }
 
+    @Tool(description = BACKFILL_BY_ID_DESC)
+    fun backfillPortfolioEventsByPortfolioId(
+        @ToolParam(
+            description =
+                "Internal portfolio id (UUID-like, ~22 chars). Use this when the page " +
+                    "context provides `portfolioId` instead of `portfolioCode` " +
+                    "(managed/shared portfolios)."
+        ) portfolioId: String,
+        @ToolParam(description = "Start date YYYY-MM-DD") fromDate: String,
+        @ToolParam(description = "End date YYYY-MM-DD; defaults to fromDate") toDate: String = ""
+    ): Map<String, Any> = eventClient.backfillPortfolio(portfolioId, fromDate, toDate.ifBlank { fromDate })
+
     companion object {
         const val ASSET_EVENTS_DESC =
             "List all stored corporate events (dividends, splits) for an asset, " +
@@ -48,8 +71,14 @@ class EventTools(
         const val LOAD_DESC =
             "Trigger a load of new corporate events from external providers for every asset " +
                 "in a portfolio. Returns immediately; the load runs asynchronously."
+        const val LOAD_BY_ID_DESC =
+            "Same as loadPortfolioEvents but resolves the portfolio by its internal id. " +
+                "Prefer this when the context exposes `portfolioId` (managed/shared portfolios)."
         const val BACKFILL_DESC =
             "Reprocess corporate events for a portfolio between two dates, generating any " +
                 "missing dividend/split transactions. Use to reconcile or repair history."
+        const val BACKFILL_BY_ID_DESC =
+            "Same as backfillPortfolioEvents but resolves the portfolio by its internal id. " +
+                "Prefer this when the context exposes `portfolioId` (managed/shared portfolios)."
     }
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PortfolioTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PortfolioTools.kt
@@ -30,6 +30,16 @@ class PortfolioTools(
         @ToolParam(description = "Portfolio code as the user types it, e.g. 'TYLER'") code: String
     ): ScrubbedPortfolio = scrubber.scrub(portfolioServiceClient.getPortfolioByCode(code))
 
+    @Tool(description = BY_ID_DESC)
+    fun getPortfolioByPortfolioId(
+        @ToolParam(
+            description =
+                "Internal portfolio id (UUID-like, ~22 chars, e.g. 'WKN0stp6QIWhg8LdQti5-Q'). " +
+                    "Required for managed/shared portfolios where the user is not the owner. " +
+                    "Use this when the page context provides `portfolioId` instead of `portfolioCode`."
+        ) portfolioId: String
+    ): ScrubbedPortfolio = scrubber.scrub(portfolioServiceClient.getPortfolioById(portfolioId))
+
     companion object {
         const val LIST_DESC =
             "List every portfolio the current user owns. " +
@@ -40,5 +50,11 @@ class PortfolioTools(
             "Look up a single portfolio by its short user-facing code (e.g. 'TYLER', 'NZD'). " +
                 "Returns the portfolio's metadata and XIRR as a decimal ratio. " +
                 "Absolute monetary amounts are intentionally not included."
+        const val BY_ID_DESC =
+            "Same response shape as getPortfolio, but resolves the portfolio by " +
+                "its internal id rather than its code. Prefer this tool whenever " +
+                "the page context exposes `portfolioId` (managed/shared portfolios). " +
+                "The by-code tool 404s for shared portfolios because portfolio " +
+                "code is unique only within an owner."
     }
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PortfolioTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PortfolioTools.kt
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Service
 /**
  * Tools the LLM can call to enumerate and resolve Beancounter portfolios.
  *
- * Every portfolio-shaped tool in the agent accepts a user-visible **code**,
- * never an internal UUID — users only ever talk about codes, and surfacing
- * the id to the LLM just invites it to feed codes into id-shaped parameters.
- * Code→id resolution, when needed, happens inside the tool implementation.
+ * The default surface is by **code** — the user-visible short identifier (e.g.
+ * `TYLER`). A parallel by-id tool ([getPortfolioByPortfolioId]) is exposed
+ * for managed/shared portfolios where the caller is not the owner: portfolio
+ * code is unique only within an owner, so the by-code lookup 404s for
+ * advisers viewing a client's portfolio. The frontend exposes `portfolioId`
+ * in the page context whenever the by-id tool should be picked.
  *
  * Responses are scrubbed of absolute monetary amounts (market value, gain
  * on day) — the LLM receives IRR as a ratio and portfolio metadata only.

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
@@ -29,6 +29,18 @@ class PositionTools(
     ): ScrubbedPositionResponse =
         scrubber.scrub(positionClient.getPositionsByCode(portfolioCode, asAt, includeValues = true))
 
+    @Tool(description = POSITIONS_BY_ID_DESC)
+    fun getPositionsByPortfolioId(
+        @ToolParam(
+            description =
+                "Internal portfolio id (UUID-like, ~22 chars, e.g. 'WKN0stp6QIWhg8LdQti5-Q'). " +
+                    "Required for managed/shared portfolios where the user is not the owner. " +
+                    "Use this when the page context provides `portfolioId` instead of `portfolioCode`."
+        ) portfolioId: String,
+        @ToolParam(description = "Valuation date YYYY-MM-DD or 'today'") asAt: String = "today"
+    ): ScrubbedPositionResponse =
+        scrubber.scrub(positionClient.getPositionsById(portfolioId, asAt, includeValues = true))
+
     companion object {
         const val POSITIONS_DESC =
             "Get the positions for a portfolio identified by its code. " +
@@ -52,5 +64,11 @@ class PositionTools(
                 "Show ratios as percentages when discussing performance. " +
                 "Never invent or request dollar amounts, ROI, dividend yield, or " +
                 "trade currency — they are not available in this tool."
+        const val POSITIONS_BY_ID_DESC =
+            "Same response shape as getPositions, but resolves the portfolio by " +
+                "its internal id rather than its code. Prefer this tool whenever " +
+                "the page context exposes `portfolioId` (managed/shared portfolios). " +
+                "The by-code tool 404s for shared portfolios because portfolio " +
+                "code is unique only within an owner."
     }
 }


### PR DESCRIPTION
## Summary
- bc-view's ChatFab now exposes managed (shared) portfolios in the agent context as `portfolioId` instead of `portfolioCode` (companion bc-view PR).
- Add sibling agent tools so the LLM has a by-id surface to pick when the context carries `portfolioId`. The existing by-code tools 404 for shared portfolios because portfolio code is unique only within an owner.

New tools / methods:
- `PortfolioTools.getPortfolioByPortfolioId`
- `PositionTools.getPositionsByPortfolioId`
- `PositionClient.getPositionsById` (hits svc-position `/id/{id}`)
- `EventTools.loadPortfolioEventsByPortfolioId`
- `EventTools.backfillPortfolioEventsByPortfolioId`

Tool descriptions instruct the LLM to prefer the by-id variant whenever the page context exposes `portfolioId`, otherwise stick with the existing by-code tools.

## Test plan
- [x] `./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin` — green.
- [ ] Manual after deploy: open AI Chat on a managed portfolio (LIV) — agent should resolve via id and not 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve portfolio details using internal portfolio IDs.
  * Fetch positions by portfolio ID, with optional "as-at" date and values included by default.
  * Load and backfill corporate events by portfolio ID with sensible date defaults.
  * Improved handling for managed/shared portfolios where code-based lookups can fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->