### PR TITLE
fix(svc-agent): null-safe stream chunk mapper

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -261,10 +261,13 @@ class AgentController(
             streamSpec
                 .chatResponse()
                 .doOnNext { resp -> resp.metadata.usage?.let { capturedUsage.set(it) } }
+                // Spring AI emits trailing ChatResponse chunks with no Generation
+                // (metadata-only — token usage, finishReason). Skip those instead
+                // of NPE'ing on resp.result.
                 .map { resp ->
                     resp.result
-                        .output
-                        .text
+                        ?.output
+                        ?.text
                         .orEmpty()
                 }.filter { it.isNotEmpty() }
                 .map { chunk ->

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -218,6 +218,41 @@ class AgentControllerTest {
     }
 
     @Test
+    fun `stream skips ChatResponse chunks that carry no Generation`() {
+        // Spring AI emits trailing metadata-only ChatResponse chunks (token
+        // usage, finishReason) where getResult() is null. Previously the
+        // mapper accessed resp.result.output.text directly and NPE'd. The
+        // chunk should be filtered out, leaving the surrounding text chunks
+        // and the done envelope intact.
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        whenever(streamResponse.chatResponse())
+            .thenReturn(
+                Flux.just(
+                    textResponse("Hello"),
+                    ChatResponse(emptyList()),
+                    textResponse(" world")
+                )
+            )
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(events).hasSize(3)
+        assertThat(events[0].data()).isEqualTo("Hello")
+        assertThat(events[1].data()).isEqualTo(" world")
+        assertThat(events[2].event()).isEqualTo(EVENT_DONE)
+    }
+
+    @Test
     fun `done payload omits model when ollama profile is active`() {
         // On ollama / openai profiles the per-call Anthropic model override is
         // skipped and the configured ChatClient picks the model. Reporting


### PR DESCRIPTION
## Summary
- Spring AI's \`chatResponse()\` Flux emits trailing metadata-only \`ChatResponse\` chunks (token usage, finishReason) where \`getResult()\` returns null. The current mapper accesses \`resp.result.output.text\` unconditionally and NPE's the stream.
- bc-view surfaces this as: \`Agent stream failed: Cannot invoke "...Generation.getOutput()" because the return value of "...ChatResponse.getResult()" is null\`.
- Use safe-call so the empty chunk falls through the existing \`.filter { it.isNotEmpty() }\` gate; the surrounding text chunks and the \`done\` envelope land as before.

## Test plan
- [x] New \`AgentControllerTest\`: \`stream skips ChatResponse chunks that carry no Generation\`.
- [x] \`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin\` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the stream endpoint to safely handle response chunks lacking generation data, preventing potential processing failures and ensuring reliable token streaming.

* **Tests**
  * Added test case for the stream endpoint to verify correct event sequencing and filtering when processing chunks without generation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->