### PR TITLE
fix(svc-agent): exclude closed positions from scrubbed tool response

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
@@ -54,11 +54,10 @@ class PositionTools(
                 "`xirr` (annualised money-weighted return, decimal — 0.12 = 12% p.a.; " +
                 "the most accurate performance measure across holdings); " +
                 "`weight` (portfolio weight, decimal — 0.125 = 12.5%); " +
-                "`category` (asset class, useful for grouping); " +
-                "`closed` (boolean — true means zero quantity). " +
-                "Never mention, count, or discuss closed positions in your " +
-                "answer unless the user has explicitly asked about closed, " +
-                "sold, or historical holdings — filter them out silently. " +
+                "`category` (asset class, useful for grouping). " +
+                "Closed (zero-quantity) positions are filtered out before " +
+                "the response is built, so every row represents an open " +
+                "holding — there is no `closed` column to inspect. " +
                 "The response also carries `portfolioCode`, `portfolioName`, " +
                 "`baseCurrency`, `asAt`, `mixedCurrencies`, and `overallIrr`. " +
                 "Show ratios as percentages when discussing performance. " +

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
@@ -32,6 +32,10 @@ data class ScrubbedPortfolio(
  * named-field objects, and tool results are never cached, so the saving
  * applies on every chat turn.
  *
+ * Closed (zero-quantity) positions are filtered out before this DTO is
+ * built, so every row represents an open position. The legacy `closed`
+ * column has been dropped accordingly.
+ *
  * Column meanings (decimals throughout for ratios):
  *   assetCode, assetName, market   — public identifiers
  *   priceClose                     — public market price
@@ -39,7 +43,6 @@ data class ScrubbedPortfolio(
  *   xirr                           — annualised money-weighted return
  *   weight                         — portfolio weight (0.125 = 12.5%)
  *   category                       — asset class
- *   closed                         — true if quantity is zero
  */
 data class ScrubbedPositionResponse(
     val portfolioCode: String,
@@ -61,8 +64,7 @@ data class ScrubbedPositionResponse(
                 "changePercent",
                 "xirr",
                 "weight",
-                "category",
-                "closed"
+                "category"
             )
     }
 }
@@ -85,6 +87,14 @@ class ResponseScrubber {
 
     fun scrub(response: PositionResponse): ScrubbedPositionResponse {
         val positions = response.data
+        // Drop closed (zero-quantity) rows server-side so the LLM never sees
+        // them. Earlier the system prompt asked the LLM to filter silently;
+        // it kept surfacing them in commentary anyway. Excluding here is
+        // both cheaper (smaller payload) and behaviourally reliable.
+        val openRows =
+            positions.positions.values
+                .filter { it.quantityValues.getTotal().signum() != 0 }
+                .map(::scrubPositionRow)
         return ScrubbedPositionResponse(
             portfolioCode = positions.portfolio.code,
             portfolioName = positions.portfolio.name,
@@ -95,7 +105,7 @@ class ResponseScrubber {
                 positions.totals[Position.In.PORTFOLIO]
                     ?.irr
                     ?.toNullableDouble(),
-            rows = positions.positions.values.map(::scrubPositionRow)
+            rows = openRows
         )
     }
 
@@ -103,7 +113,6 @@ class ResponseScrubber {
         val portfolioBucket = position.moneyValues[Position.In.PORTFOLIO]
         val price = portfolioBucket?.priceData
         val asset = position.asset
-        val isClosed = position.quantityValues.getTotal().signum() == 0
         return listOf(
             asset.code,
             asset.name,
@@ -112,8 +121,7 @@ class ResponseScrubber {
             price?.changePercent?.toNullableDouble(),
             portfolioBucket?.irr?.toNullableDouble(),
             portfolioBucket?.weight?.toDouble() ?: 0.0,
-            asset.category,
-            isClosed
+            asset.category
         )
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
@@ -101,8 +101,7 @@ class ResponseScrubberTest {
                 "changePercent",
                 "xirr",
                 "weight",
-                "category",
-                "closed"
+                "category"
             )
         assertThat(scrubbed.rows).hasSize(1)
         assertThat(scrubbed.rows.first())
@@ -114,8 +113,7 @@ class ResponseScrubberTest {
                 0.012,
                 0.14,
                 0.125,
-                "Equity",
-                false
+                "Equity"
             )
     }
 
@@ -134,24 +132,28 @@ class ResponseScrubberTest {
     }
 
     @Test
-    fun `zero-quantity position is marked closed`() {
-        val asset =
-            Asset(
-                code = "OLD",
-                market = nasdaq,
-                category = "Equity"
-            )
-        val position = Position(asset, portfolio)
-        val money = position.getMoneyValues(Position.In.PORTFOLIO)
-        money.marketValue = BigDecimal.ZERO
-        money.weight = BigDecimal.ZERO
-        // quantityValues.total = purchased + sold + adjustment, all zero by default
+    fun `zero-quantity positions are filtered out before reaching the LLM`() {
+        // Closed (zero-quantity) positions clutter analysis prompts and the
+        // LLM has been observed surfacing them in commentary even when the
+        // system prompt forbids it. Drop them server-side so the row list
+        // contains only open holdings.
+        val openAsset = Asset(code = "OPEN", market = nasdaq, category = "Equity")
+        val openPosition = Position(openAsset, portfolio)
+        openPosition.quantityValues.purchased = BigDecimal("10")
 
-        val positions = Positions(portfolio)
-        positions.add(position)
+        val closedAsset = Asset(code = "OLD", market = nasdaq, category = "Equity")
+        val closedPosition = Position(closedAsset, portfolio)
+        // quantityValues defaults sum to zero, marking the position closed.
+
+        val positions =
+            Positions(portfolio).apply {
+                add(openPosition)
+                add(closedPosition)
+            }
         val scrubbed = scrubber.scrub(PositionResponse(positions))
 
-        val closedIdx = scrubbed.cols.indexOf("closed")
-        assertThat(scrubbed.rows.single()[closedIdx]).isEqualTo(true)
+        val codeIdx = scrubbed.cols.indexOf("assetCode")
+        assertThat(scrubbed.rows).hasSize(1)
+        assertThat(scrubbed.rows.single()[codeIdx]).isEqualTo("OPEN")
     }
 }


### PR DESCRIPTION
## Summary
- The system prompt told the LLM to filter zero-quantity rows out silently, but Haiku kept surfacing them in commentary (real example: "Reduce closed positions: BIL, BITO, DRIV, SGOV, SPY are cluttering"). Closed-position chatter pollutes the bottom-line summary in AI Overview / Chat Fab.
- Drop closed (\`quantityValues.total == 0\`) rows in \`ResponseScrubber.scrub(PositionResponse)\` before they reach the LLM. The legacy \`closed\` column comes off the columnar projection and the corresponding hint in \`PositionTools\` is replaced.

## Test plan
- [x] \`ResponseScrubberTest\` updated; new test confirms only open holdings reach the row list.
- [x] \`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin\` — green.
- [ ] Manual after deploy: AI Overview / Chat shouldn't mention closed/exited positions unless explicitly asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved position response filtering to automatically exclude closed positions (zero-quantity holdings) from results
  * Simplified position data structure by removing the closed status indicator column
  * API responses now return exclusively active holdings for cleaner, more actionable data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->