### PR TITLE
feat(svc-agent): by-ticker corporate events tool

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/client/AssetClient.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/client/AssetClient.kt
@@ -1,0 +1,39 @@
+package com.beancounter.agent.client
+
+import com.beancounter.auth.TokenService
+import com.beancounter.common.contracts.AssetResponse
+import com.beancounter.common.model.Asset
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+
+/**
+ * Thin client for the svc-data assets API. Resolves a (market, ticker)
+ * pair to a Beancounter [Asset] (creating one on demand). Used by the
+ * agent's by-ticker tools (e.g. dividend / split history) so the LLM can
+ * answer questions like "how many dividends has GOOG paid?" without ever
+ * seeing internal asset ids.
+ */
+@Service
+class AssetClient(
+    @Qualifier("bcDataRestClient")
+    private val restClient: RestClient,
+    private val tokenService: TokenService
+) {
+    fun getAsset(
+        market: String,
+        code: String
+    ): Asset {
+        val response =
+            restClient
+                .get()
+                .uri("/assets/{market}/{code}", market, code)
+                .header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+                .retrieve()
+                .body<AssetResponse>()
+        return response?.data
+            ?: error("Unable to resolve asset $market:$code")
+    }
+}

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -28,7 +28,11 @@ class EventTools(
 ) {
     @Tool(description = ASSET_EVENTS_DESC)
     fun getAssetEvents(
-        @ToolParam(description = "Asset identifier (UUID or ticker)") assetId: String
+        @ToolParam(
+            description =
+                "Internal Beancounter asset id (UUID-like). " +
+                    "If the user gives a public ticker, use getAssetEventsByTicker instead."
+        ) assetId: String
     ): Map<String, Any> = eventClient.getAssetEvents(assetId)
 
     @Tool(description = ASSET_EVENTS_BY_TICKER_DESC)
@@ -90,8 +94,9 @@ class EventTools(
 
     companion object {
         const val ASSET_EVENTS_DESC =
-            "List all stored corporate events (dividends, splits) for an asset, " +
-                "ordered by pay date, most recent first."
+            "List all stored corporate events (dividends, splits) for an internal " +
+                "Beancounter asset id, ordered by pay date, most recent first. " +
+                "For public tickers, prefer getAssetEventsByTicker."
         const val ASSET_EVENTS_BY_TICKER_DESC =
             "List all stored corporate events (dividends, splits) for a publicly " +
                 "listed ticker — e.g. 'how many dividends has GOOG paid?'. " +

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -1,5 +1,6 @@
 package com.beancounter.agent.tools
 
+import com.beancounter.agent.client.AssetClient
 import com.beancounter.agent.client.EventClient
 import com.beancounter.client.services.PortfolioServiceClient
 import org.springframework.ai.tool.annotation.Tool
@@ -22,12 +23,28 @@ import org.springframework.stereotype.Service
 @Service
 class EventTools(
     private val eventClient: EventClient,
-    private val portfolioServiceClient: PortfolioServiceClient
+    private val portfolioServiceClient: PortfolioServiceClient,
+    private val assetClient: AssetClient
 ) {
     @Tool(description = ASSET_EVENTS_DESC)
     fun getAssetEvents(
         @ToolParam(description = "Asset identifier (UUID or ticker)") assetId: String
     ): Map<String, Any> = eventClient.getAssetEvents(assetId)
+
+    @Tool(description = ASSET_EVENTS_BY_TICKER_DESC)
+    fun getAssetEventsByTicker(
+        @ToolParam(
+            description = "Ticker symbol as quoted on the market, e.g. 'GOOG', 'AAPL'."
+        ) ticker: String,
+        @ToolParam(
+            description =
+                "Beancounter market code, e.g. 'NASDAQ', 'US', 'ASX', 'NZX'. " +
+                    "Use listMarkets if unsure."
+        ) market: String
+    ): Map<String, Any> {
+        val asset = assetClient.getAsset(market, ticker)
+        return eventClient.getAssetEvents(asset.id)
+    }
 
     @Tool(description = LOAD_DESC)
     fun loadPortfolioEvents(
@@ -75,6 +92,13 @@ class EventTools(
         const val ASSET_EVENTS_DESC =
             "List all stored corporate events (dividends, splits) for an asset, " +
                 "ordered by pay date, most recent first."
+        const val ASSET_EVENTS_BY_TICKER_DESC =
+            "List all stored corporate events (dividends, splits) for a publicly " +
+                "listed ticker — e.g. 'how many dividends has GOOG paid?'. " +
+                "Resolves the ticker on the named market into a Beancounter asset " +
+                "(creating one on demand) and then returns the same payload as " +
+                "getAssetEvents. Prefer this tool when the user names a ticker " +
+                "rather than referring to a portfolio holding."
         const val LOAD_DESC =
             "Trigger a load of new corporate events from external providers for every asset " +
                 "in a portfolio. Returns immediately; the load runs asynchronously."

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
@@ -22,19 +22,19 @@ class EventToolsTest {
     fun `getAssetEventsByTicker resolves ticker then fetches events by id`() {
         val asset =
             Asset(
-                id = "asset-goog",
-                code = "GOOG",
-                market = Market(code = "NASDAQ")
+                id = ASSET_ID,
+                code = TICKER,
+                market = Market(code = MARKET)
             )
         val payload = mapOf("data" to listOf(mapOf("trnType" to "DIVI")))
 
         val assetClient =
             mock<AssetClient> {
-                on { getAsset("NASDAQ", "GOOG") } doReturn asset
+                on { getAsset(MARKET, TICKER) } doReturn asset
             }
         val eventClient =
             mock<EventClient> {
-                on { getAssetEvents("asset-goog") } doReturn payload
+                on { getAssetEvents(ASSET_ID) } doReturn payload
             }
         val tools =
             EventTools(
@@ -43,10 +43,16 @@ class EventToolsTest {
                 assetClient = assetClient
             )
 
-        val result = tools.getAssetEventsByTicker("GOOG", "NASDAQ")
+        val result = tools.getAssetEventsByTicker(TICKER, MARKET)
 
         assertThat(result).isEqualTo(payload)
-        verify(assetClient).getAsset(eq("NASDAQ"), eq("GOOG"))
-        verify(eventClient).getAssetEvents(eq("asset-goog"))
+        verify(assetClient).getAsset(eq(MARKET), eq(TICKER))
+        verify(eventClient).getAssetEvents(eq(ASSET_ID))
+    }
+
+    companion object {
+        private const val MARKET = "NASDAQ"
+        private const val TICKER = "GOOG"
+        private const val ASSET_ID = "asset-goog"
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
@@ -1,0 +1,52 @@
+package com.beancounter.agent.tools
+
+import com.beancounter.agent.client.AssetClient
+import com.beancounter.agent.client.EventClient
+import com.beancounter.client.services.PortfolioServiceClient
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+/**
+ * Confirms the by-ticker corporate-events tool resolves the asset via
+ * [AssetClient] before delegating to [EventClient.getAssetEvents]. The
+ * LLM never sees the internal asset id — only the ticker / market pair.
+ */
+class EventToolsTest {
+    @Test
+    fun `getAssetEventsByTicker resolves ticker then fetches events by id`() {
+        val asset =
+            Asset(
+                id = "asset-goog",
+                code = "GOOG",
+                market = Market(code = "NASDAQ")
+            )
+        val payload = mapOf("data" to listOf(mapOf("trnType" to "DIVI")))
+
+        val assetClient =
+            mock<AssetClient> {
+                on { getAsset("NASDAQ", "GOOG") } doReturn asset
+            }
+        val eventClient =
+            mock<EventClient> {
+                on { getAssetEvents("asset-goog") } doReturn payload
+            }
+        val tools =
+            EventTools(
+                eventClient = eventClient,
+                portfolioServiceClient = mock<PortfolioServiceClient>(),
+                assetClient = assetClient
+            )
+
+        val result = tools.getAssetEventsByTicker("GOOG", "NASDAQ")
+
+        assertThat(result).isEqualTo(payload)
+        verify(assetClient).getAsset(eq("NASDAQ"), eq("GOOG"))
+        verify(eventClient).getAssetEvents(eq("asset-goog"))
+    }
+}


### PR DESCRIPTION
## Summary
- The chat fab couldn't answer "how many dividends has GOOG paid?" — \`getAssetEvents\` takes an internal asset id, which the LLM never sees.
- Add \`AssetClient.getAsset(market, code)\` calling svc-data's \`/assets/{market}/{code}\` (auto-creates on demand), and a sibling tool \`getAssetEventsByTicker(ticker, market)\` that resolves the ticker first then returns the same dividend/split payload.
- Tool description tells the LLM to prefer this variant whenever the user names a public ticker rather than a portfolio holding.