### PR TITLE
fix(svc-agent): correct market hint for US-listed tickers

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -42,8 +42,10 @@ class EventTools(
         ) ticker: String,
         @ToolParam(
             description =
-                "Beancounter market code, e.g. 'NASDAQ', 'US', 'ASX', 'NZX'. " +
-                    "Use listMarkets if unsure."
+                "Beancounter market code. US-listed tickers (NASDAQ, NYSE, " +
+                    "AMEX, ARCA) all live under the single market code 'US'. " +
+                    "Other examples: 'ASX' (Australia), 'NZX' (New Zealand), " +
+                    "'SGX' (Singapore). Call listMarkets if unsure."
         ) market: String
     ): Map<String, Any> {
         val asset = assetClient.getAsset(market, ticker)

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
@@ -51,7 +51,9 @@ class EventToolsTest {
     }
 
     companion object {
-        private const val MARKET = "NASDAQ"
+        // US-listed tickers all live under the single 'US' market code
+        // in Beancounter — there's no separate NASDAQ/NYSE distinction.
+        private const val MARKET = "US"
         private const val TICKER = "GOOG"
         private const val ASSET_ID = "asset-goog"
     }


### PR DESCRIPTION
## Summary
- The \`getAssetEventsByTicker\` market parameter description told the LLM 'NASDAQ' was a valid Beancounter market code. It isn't — US-listed tickers (NASDAQ, NYSE, AMEX, ARCA) all live under the single market code 'US'.
- Rewrite the description to make the 'US' convention explicit and update the unit test fixture (\`MARKET = "US"\`) so it matches reality.

## Test plan
- [x] \`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin\` — green.
- [ ] Manual after deploy: ask "how many dividends has GOOG paid?" — expect the agent to call \`getAssetEventsByTicker("GOOG", "US")\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified market code conventions for asset event queries, specifying that US-listed tickers use code 'US' while international listings use their respective regional codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->