### PR TITLE
feat(svc-agent): default getAssetEventsByTicker market to US

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/EventTools.kt
@@ -41,12 +41,18 @@ class EventTools(
             description = "Ticker symbol as quoted on the market, e.g. 'GOOG', 'AAPL'."
         ) ticker: String,
         @ToolParam(
+            required = false,
             description =
-                "Beancounter market code, e.g. 'NASDAQ', 'US', 'ASX', 'NZX'. " +
-                    "Use listMarkets if unsure."
-        ) market: String
+                "Optional Beancounter market hint. Default 'US' covers every " +
+                    "US-listed equity (NASDAQ/NYSE/AMEX/ARCA all collapse to " +
+                    "the canonical US market server-side). Pass 'ASX', 'NZX', " +
+                    "'SGX' etc. for non-US listings, or call listMarkets for " +
+                    "the full set. Typos like 'NASAQ' and index labels like " +
+                    "'DOW' / 'DOW JONES' are also accepted and resolved to US."
+        ) market: String = "US"
     ): Map<String, Any> {
-        val asset = assetClient.getAsset(market, ticker)
+        val resolved = market.ifBlank { "US" }
+        val asset = assetClient.getAsset(resolved, ticker)
         return eventClient.getAssetEvents(asset.id)
     }
 

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/EventToolsTest.kt
@@ -8,9 +8,7 @@ import com.beancounter.common.model.Market
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 
 /**
  * Confirms the by-ticker corporate-events tool resolves the asset via
@@ -18,16 +16,45 @@ import org.mockito.kotlin.verify
  * LLM never sees the internal asset id — only the ticker / market pair.
  */
 class EventToolsTest {
+    private val asset =
+        Asset(
+            id = ASSET_ID,
+            code = TICKER,
+            market = Market(code = MARKET)
+        )
+    private val payload = mapOf("data" to listOf(mapOf("trnType" to "DIVI")))
+
     @Test
     fun `getAssetEventsByTicker resolves ticker then fetches events by id`() {
-        val asset =
-            Asset(
-                id = ASSET_ID,
-                code = TICKER,
-                market = Market(code = MARKET)
-            )
-        val payload = mapOf("data" to listOf(mapOf("trnType" to "DIVI")))
+        val tools = build()
 
+        val result = tools.getAssetEventsByTicker(TICKER, MARKET)
+
+        assertThat(result).isEqualTo(payload)
+    }
+
+    @Test
+    fun `getAssetEventsByTicker defaults market to US when omitted`() {
+        // Tool param is declared optional; the default arg must thread
+        // through to the AssetClient as 'US' so the LLM doesn't have to
+        // know BC market conventions.
+        val tools = build()
+
+        val result = tools.getAssetEventsByTicker(TICKER)
+
+        assertThat(result).isEqualTo(payload)
+    }
+
+    @Test
+    fun `getAssetEventsByTicker treats blank market as US`() {
+        val tools = build()
+
+        val result = tools.getAssetEventsByTicker(TICKER, "")
+
+        assertThat(result).isEqualTo(payload)
+    }
+
+    private fun build(): EventTools {
         val assetClient =
             mock<AssetClient> {
                 on { getAsset(MARKET, TICKER) } doReturn asset
@@ -36,22 +63,18 @@ class EventToolsTest {
             mock<EventClient> {
                 on { getAssetEvents(ASSET_ID) } doReturn payload
             }
-        val tools =
-            EventTools(
-                eventClient = eventClient,
-                portfolioServiceClient = mock<PortfolioServiceClient>(),
-                assetClient = assetClient
-            )
-
-        val result = tools.getAssetEventsByTicker(TICKER, MARKET)
-
-        assertThat(result).isEqualTo(payload)
-        verify(assetClient).getAsset(eq(MARKET), eq(TICKER))
-        verify(eventClient).getAssetEvents(eq(ASSET_ID))
+        return EventTools(
+            eventClient = eventClient,
+            portfolioServiceClient = mock<PortfolioServiceClient>(),
+            assetClient = assetClient
+        )
     }
 
     companion object {
-        private const val MARKET = "NASDAQ"
+        // US-listed tickers all live under the single canonical 'US'
+        // market in Beancounter — server-side aliases collapse NASDAQ /
+        // NYSE / AMEX / ARCA / NASAQ / DOW / DOW JONES to it.
+        private const val MARKET = "US"
         private const val TICKER = "GOOG"
         private const val ASSET_ID = "asset-goog"
     }


### PR DESCRIPTION
## Summary
- Most chat-fab questions about public tickers are US-listed. Make the \`market\` parameter on \`getAssetEventsByTicker\` optional with a default of \`'US'\`; treat a blank string the same way.
- Rewrite the param description so the LLM knows: \`'US'\` covers NASDAQ / NYSE / AMEX / ARCA, plus typos like \`'NASAQ'\` and index labels like \`'DOW'\` / \`'DOW JONES'\` (server-side aliases in svc-data PR #823 do the actual collapsing).