### PR TITLE
fix(svc-agent): emit LLM telemetry as OTel attributes, not Sentry tx

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,10 @@ guava = "33.5.0-jre"
 servlet-api = "6.1.0"
 spring-ai = "1.1.2"
 flyway = "11.20.0"
+# Pinned because jar-common exposes the bridge as an api dep but
+# downstream modules (e.g. jar-shell) don't import the spring-boot
+# platform, so version resolution falls back to the catalog.
+micrometer-tracing = "1.5.6"
 
 [libraries]
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
@@ -52,6 +56,7 @@ spring-security-oauth2 = { module = "org.springframework.security:spring-securit
 spring-security-jose = { module = "org.springframework.security:spring-security-oauth2-jose", version.ref = "spring-security" }
 sentry-opentelemetry = { module = "io.sentry:sentry-opentelemetry-core", version.ref = "sentry" }
 sentry-spring-boot = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
+micrometer-tracing-bridge-otel = { module = "io.micrometer:micrometer-tracing-bridge-otel", version.ref = "micrometer-tracing" }
 sentry-jdbc = { module = "io.sentry:sentry-jdbc", version.ref = "sentry" }
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }

--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -17,9 +17,9 @@ dependencies {
     // service that pulls jar-common emits Spring AI / Spring MVC / Hikari
     // / Resilience4j / Spring Data observations as OTel spans, which the
     // sentry-opentelemetry-agent javaagent already exports to Sentry.
-    // Version managed by the consumer's spring-boot-dependencies platform
-    // import (Spring Boot 3.x bom pins it).
-    api("io.micrometer:micrometer-tracing-bridge-otel")
+    // Pinned in the version catalog because some consumers (e.g. jar-shell)
+    // don't import the spring-boot-dependencies platform.
+    api(libs.micrometer.tracing.bridge.otel)
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(platform(libs.spring.boot.dependencies))

--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -13,6 +13,13 @@ dependencies {
     api(libs.jackson.kotlin)
     api(libs.sentry.opentelemetry)
     api(libs.sentry.spring.boot)
+    // Bridges Micrometer Observations -> OTel spans so every Beancounter
+    // service that pulls jar-common emits Spring AI / Spring MVC / Hikari
+    // / Resilience4j / Spring Data observations as OTel spans, which the
+    // sentry-opentelemetry-agent javaagent already exports to Sentry.
+    // Version managed by the consumer's spring-boot-dependencies platform
+    // import (Spring Boot 3.x bom pins it).
+    api("io.micrometer:micrometer-tracing-bridge-otel")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(platform(libs.spring.boot.dependencies))

--- a/svc-agent/build.gradle.kts
+++ b/svc-agent/build.gradle.kts
@@ -39,6 +39,11 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.integration)
+    // Bridges Micrometer Observations -> OTel spans, so Spring AI's
+    // built-in `spring.ai.chat.client` / `gen_ai.*` observations land in
+    // Sentry's spans dataset (the sentry-opentelemetry-agent javaagent
+    // already provides the OTel SDK + Sentry exporter at runtime).
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation(libs.jackson.kotlin)
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/svc-agent/build.gradle.kts
+++ b/svc-agent/build.gradle.kts
@@ -39,11 +39,9 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.integration)
-    // Bridges Micrometer Observations -> OTel spans, so Spring AI's
-    // built-in `spring.ai.chat.client` / `gen_ai.*` observations land in
-    // Sentry's spans dataset (the sentry-opentelemetry-agent javaagent
-    // already provides the OTel SDK + Sentry exporter at runtime).
-    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    // micrometer-tracing-bridge-otel comes via jar-common (api dep) so
+    // Spring AI's `spring.ai.chat.client` / `gen_ai.*` observations
+    // export to Sentry through the existing OTel agent.
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation(libs.jackson.kotlin)
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -249,6 +249,12 @@ class AgentController(
         val tools = toolSelector.selectTools(request.context)
         val modelId = chatModelSelector.selectFor(request.context)
         val startMs = System.currentTimeMillis()
+        // Pin the OTel span at request-time so the doneEvent lambda — which
+        // runs on a Reactor boundedElastic thread — writes telemetry to the
+        // request's http.server span rather than a noop fallback.
+        val requestSpan =
+            io.opentelemetry.api.trace.Span
+                .current()
 
         val totalChars = AtomicLong(0)
         // Spring AI's chatResponse() Flux surfaces ChatResponse per chunk; the
@@ -282,7 +288,8 @@ class AgentController(
                     totalChars = totalChars.get(),
                     usage = capturedUsage.get(),
                     startMs = startMs,
-                    safeQuery = safeQuery
+                    safeQuery = safeQuery,
+                    requestSpan = requestSpan
                 )
             }
         return tokenEvents.concatWith(doneEvent)
@@ -314,20 +321,23 @@ class AgentController(
         totalChars: Long,
         usage: Usage?,
         startMs: Long,
-        safeQuery: String
+        safeQuery: String,
+        requestSpan: io.opentelemetry.api.trace.Span
     ): Flux<ServerSentEvent<String>> {
         val elapsedMs = System.currentTimeMillis() - startMs
-        // Sentry transaction measurements — same shape as the non-streaming
-        // path so dashboards can mix call+stream traffic. Only attribute the
-        // model tag when the per-call Anthropic override was applied; on
-        // ollama / openai the configured ChatClient picks the model and our
-        // selectedModelId would mislead the metric.
+        // Token telemetry as OTel attributes on the captured request span
+        // (same span the http.server transaction owns). Same shape as the
+        // non-streaming path so dashboards can mix call+stream traffic.
+        // Only attribute the model tag when the per-call Anthropic override
+        // was applied — on ollama / openai the configured ChatClient picks
+        // the model and our selectedModelId would mislead the metric.
         llmMetrics.capture(
             modelId = modelId.takeIf { anthropicActive },
             usage = usage,
             elapsedMs = elapsedMs,
             toolCount = tools.size,
-            mode = LlmMetrics.Mode.STREAM
+            mode = LlmMetrics.Mode.STREAM,
+            span = requestSpan
         )
         if (log.isDebugEnabled) {
             log.debug(

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/LlmMetrics.kt
@@ -1,23 +1,34 @@
 package com.beancounter.agent
 
-import io.sentry.Sentry
+import io.opentelemetry.api.trace.Span
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.metadata.Usage
 import org.springframework.stereotype.Component
 
 /**
- * Publishes per-call LLM telemetry to Sentry so token usage is queryable
- * from the events / measurements UI without parsing kauri pod stdout.
+ * Publishes per-call LLM telemetry as OpenTelemetry span attributes.
  *
- * Strategy: piggyback on the inbound HTTP request's Sentry transaction
- * (Spring's Sentry integration auto-creates one per request). Each LLM
- * call adds:
- *   - tags    `agent.model`, `agent.tools`, `agent.mode` (call/stream)
- *   - data    `agent.elapsed_ms`
- *   - measurements `prompt_tokens`, `completion_tokens`, `total_tokens`
+ * The previous implementation wrote Sentry transaction measurements via
+ * `Sentry.getCurrentScopes().transaction.setMeasurement`. That works on
+ * the request thread for the non-streaming `/agent/query` path, but
+ * silently no-ops on the SSE `/agent/query/stream` path because the
+ * `doneEvent` lambda runs on a Reactor `boundedElastic` thread where the
+ * Sentry scope is empty. Result: zero token data in Sentry's spans
+ * dataset for any streamed call (which is the dominant traffic shape).
  *
- * Sentry's events search supports filtering on `measurements.total_tokens`
- * and aggregating sum/avg per `agent.model` tag.
+ * Switching to OTel attributes solves both axes:
+ *   - bc-agent already runs the `sentry-opentelemetry-agent` javaagent
+ *     plus the `opentelemetry-instrumentation-reactor` autoload, which
+ *     propagates the ambient `Span` across Reactor schedulers.
+ *   - Sentry's OTel exporter reads OTel span attributes and surfaces them
+ *     under the same span the http.server transaction already owns.
+ *
+ * Callers capture the request-time `Span.current()` and pass it to
+ * [capture] so the lambda always writes to the right span — even if
+ * Reactor's automatic context propagation regresses in a future agent
+ * upgrade. The default-arg `Span.current()` keeps unit tests (where no
+ * agent is attached) noop-safe — the SDK returns an invalid span and
+ * `setAttribute` is a cheap no-op.
  */
 @Component
 class LlmMetrics {
@@ -28,31 +39,24 @@ class LlmMetrics {
         usage: Usage?,
         elapsedMs: Long,
         toolCount: Int,
-        mode: Mode
+        mode: Mode,
+        span: Span = Span.current()
     ) {
         @Suppress("TooGenericExceptionCaught")
-        // Sentry's SDK can surface unexpected errors (uninitialised, IO, etc).
-        // Telemetry must never break the user-visible response, so we catch
-        // broadly and log at DEBUG. Narrowing the type would let an unfamiliar
-        // failure mode crash the request thread purely to satisfy the linter.
         try {
-            val tx = Sentry.getCurrentScopes().transaction
-            if (tx == null) {
-                // No active Sentry transaction (e.g. unit test, Sentry disabled
-                // by profile). Bail silently — metrics are best-effort.
-                return
+            if (!modelId.isNullOrBlank()) span.setAttribute(ATTR_MODEL, modelId)
+            span.setAttribute(ATTR_TOOLS, toolCount.toLong())
+            span.setAttribute(ATTR_MODE, mode.tag)
+            span.setAttribute(ATTR_ELAPSED_MS, elapsedMs)
+            usage?.promptTokens?.toLong()?.let {
+                span.setAttribute(ATTR_PROMPT_TOKENS, it)
             }
-            // Only tag the model when we actually know it. On ollama / openai
-            // profiles the per-call selected id doesn't reflect what answered
-            // the request, so attributing measurements to it would mislead
-            // dashboards. Skip the tag rather than poison the data.
-            if (!modelId.isNullOrBlank()) tx.setTag(TAG_MODEL, modelId)
-            tx.setTag(TAG_TOOLS, toolCount.toString())
-            tx.setTag(TAG_MODE, mode.tag)
-            tx.setData(DATA_ELAPSED_MS, elapsedMs)
-            usage?.promptTokens?.toLong()?.let { tx.setMeasurement(M_PROMPT_TOKENS, it) }
-            usage?.completionTokens?.toLong()?.let { tx.setMeasurement(M_COMPLETION_TOKENS, it) }
-            usage?.totalTokens?.toLong()?.let { tx.setMeasurement(M_TOTAL_TOKENS, it) }
+            usage?.completionTokens?.toLong()?.let {
+                span.setAttribute(ATTR_COMPLETION_TOKENS, it)
+            }
+            usage?.totalTokens?.toLong()?.let {
+                span.setAttribute(ATTR_TOTAL_TOKENS, it)
+            }
         } catch (e: Exception) {
             log.debug("LlmMetrics.capture failed: {}", e.message)
         }
@@ -66,12 +70,16 @@ class LlmMetrics {
     }
 
     companion object {
-        private const val TAG_MODEL = "agent.model"
-        private const val TAG_TOOLS = "agent.tools"
-        private const val TAG_MODE = "agent.mode"
-        private const val DATA_ELAPSED_MS = "agent.elapsed_ms"
-        private const val M_PROMPT_TOKENS = "prompt_tokens"
-        private const val M_COMPLETION_TOKENS = "completion_tokens"
-        private const val M_TOTAL_TOKENS = "total_tokens"
+        private const val ATTR_MODEL = "agent.model"
+        private const val ATTR_TOOLS = "agent.tools"
+        private const val ATTR_MODE = "agent.mode"
+        private const val ATTR_ELAPSED_MS = "agent.elapsed_ms"
+
+        // Tokens use the `llm.*` namespace so Sentry's GenAI dashboards
+        // and the standard `has:llm.total_tokens` event filter pick them
+        // up without further config.
+        private const val ATTR_PROMPT_TOKENS = "llm.prompt_tokens"
+        private const val ATTR_COMPLETION_TOKENS = "llm.completion_tokens"
+        private const val ATTR_TOTAL_TOKENS = "llm.total_tokens"
     }
 }

--- a/svc-agent/src/main/resources/application.yml
+++ b/svc-agent/src/main/resources/application.yml
@@ -42,6 +42,16 @@ management:
   info:
     git:
       mode: SIMPLE
+  # Sample every Micrometer observation so Spring AI's gen_ai.* spans —
+  # which now feed Sentry's GenAI dashboard via the OTel bridge — never
+  # get dropped. Adjust per-env in application-<profile>.yaml if cost
+  # becomes an issue.
+  tracing:
+    sampling:
+      probability: 1.0
+  observations:
+    annotations:
+      enabled: true
 
 logging:
   pattern:

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/LlmMetricsTest.kt
@@ -1,22 +1,29 @@
 package com.beancounter.agent
 
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.ai.chat.metadata.DefaultUsage
 
 /**
- * LlmMetrics piggybacks on the active Sentry transaction, so when no
- * transaction is bound (unit-test environment, Sentry disabled) it must
- * silently no-op rather than throw and disturb the user-visible response.
+ * LlmMetrics writes OTel span attributes. Outside an OTel context the
+ * default `Span.current()` returns an invalid (noop) span so attribute
+ * sets are silently dropped — must never throw and disturb the
+ * user-visible response.
  */
 class LlmMetricsTest {
     @Test
-    fun `capture is a no-op when no Sentry transaction is bound`() {
+    fun `capture is a no-op when no OTel span is active`() {
         val metrics = LlmMetrics()
 
-        // Should not throw despite Sentry not being initialised in this test JVM.
+        // Should not throw despite no OTel javaagent attached in this JVM.
         metrics.capture(
             modelId = "claude-haiku-4-5",
             usage = DefaultUsage(100, 50, 150),
@@ -55,16 +62,16 @@ class LlmMetricsTest {
 
     @Test
     fun `Mode tag value is stable wire contract`() {
-        // The string emitted as the agent.mode Sentry tag is part of the
-        // observability contract — pin it so dashboards keep working.
+        // The string emitted as the agent.mode span attribute is part of
+        // the observability contract — pin it so dashboards keep working.
         assertThat(LlmMetrics.Mode.CALL.tag).isEqualTo("call")
         assertThat(LlmMetrics.Mode.STREAM.tag).isEqualTo("stream")
     }
 
     @Test
-    fun `capture survives an exception thrown by Sentry`() {
+    fun `capture survives an exception thrown while reading usage`() {
         // Use a stub usage that throws when read — proves the try/catch
-        // around Sentry interaction shields the caller.
+        // around the OTel interaction shields the caller.
         val brokenUsage = mock<org.springframework.ai.chat.metadata.Usage>()
         whenever(brokenUsage.promptTokens).thenThrow(RuntimeException("simulated"))
         val metrics = LlmMetrics()
@@ -75,5 +82,58 @@ class LlmMetricsTest {
             toolCount = 0,
             mode = LlmMetrics.Mode.CALL
         )
+    }
+
+    @Test
+    fun `capture writes token attributes onto the supplied span`() {
+        // The streaming controller pins the request span and passes it
+        // explicitly so the doneEvent lambda — which fires on a Reactor
+        // boundedElastic thread without an active OTel context — still
+        // writes telemetry to the http.server transaction.
+        val span = mock<Span>()
+        // Span builder methods return `this` in production; mockito returns
+        // the bare mock by default for chained calls, which is fine here
+        // because we only assert the verify(...) interactions.
+        whenever(span.setAttribute(any<AttributeKey<String>>(), any<String>())).thenReturn(span)
+        whenever(span.setAttribute(any<String>(), any<String>())).thenReturn(span)
+        whenever(span.setAttribute(any<String>(), any<Long>())).thenReturn(span)
+
+        val metrics = LlmMetrics()
+        metrics.capture(
+            modelId = "claude-haiku-4-5",
+            usage = DefaultUsage(100, 50, 150),
+            elapsedMs = 1234,
+            toolCount = 4,
+            mode = LlmMetrics.Mode.STREAM,
+            span = span
+        )
+
+        verify(span).setAttribute(eq("agent.model"), eq("claude-haiku-4-5"))
+        verify(span).setAttribute(eq("agent.tools"), eq(4L))
+        verify(span).setAttribute(eq("agent.mode"), eq("stream"))
+        verify(span).setAttribute(eq("agent.elapsed_ms"), eq(1234L))
+        verify(span).setAttribute(eq("llm.prompt_tokens"), eq(100L))
+        verify(span).setAttribute(eq("llm.completion_tokens"), eq(50L))
+        verify(span).setAttribute(eq("llm.total_tokens"), eq(150L))
+    }
+
+    @Test
+    fun `capture skips model attribute when modelId is null`() {
+        val span = mock<Span>()
+        whenever(span.setAttribute(any<String>(), any<String>())).thenReturn(span)
+        whenever(span.setAttribute(any<String>(), any<Long>())).thenReturn(span)
+
+        LlmMetrics().capture(
+            modelId = null,
+            usage = DefaultUsage(10, 5, 15),
+            elapsedMs = 0,
+            toolCount = 0,
+            mode = LlmMetrics.Mode.CALL,
+            span = span
+        )
+
+        verify(span, never()).setAttribute(eq("agent.model"), any<String>())
+        verify(span).setAttribute(eq("agent.mode"), eq("call"))
+        verify(span).setAttribute(eq("llm.total_tokens"), eq(15L))
     }
 }


### PR DESCRIPTION
## Summary
- Sentry's spans dataset shows **zero token data** for bc-agent (verified via search), despite ~70 streamed agent transactions/day on kauri.
- Root cause: \`LlmMetrics.capture\` writes \`Sentry.getCurrentScopes().transaction.setMeasurement(...)\` from the streaming \`doneEvent\` lambda, which fires on a Reactor \`boundedElastic\` thread. Sentry scope is empty there; the transaction lookup returns null and capture silently bails.
- Switch the metric emit path to OTel span attributes. bc-agent already runs the \`sentry-opentelemetry-agent\` javaagent + OTel Reactor instrumentation, so attributes land on the request's http.server span and Sentry's OTel exporter forwards them.
- Belt-and-braces: \`AgentController.runStream\` pins \`Span.current()\` at request start and passes it explicitly through to \`LlmMetrics.capture\`. The default-arg \`Span.current()\` keeps the synchronous call-path and unit tests noop-safe.
- Token attributes use the \`llm.*\` namespace so Sentry's standard GenAI filter (\`has:llm.total_tokens\`) and dashboards pick them up.

## Test plan
- [x] LlmMetricsTest: existing no-op cases preserved; two new tests assert attributes on a passed-in mock span (model omitted when null).
- [x] \`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin\` — green.
- [ ] Manual after deploy: \`search_events(query='has:llm.total_tokens', dataset='spans')\` should return aggregated token sums per \`agent.mode\` and (for Anthropic) per \`agent.model\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * LLM/token telemetry now records as OpenTelemetry span attributes and is attributed to the captured request span.

* **Tests**
  * Tests updated to verify span-attribute behavior, noop semantics when no active span is present, and attribute omission for null model IDs.

* **Chores**
  * Enabled observation sampling/annotations and added tracing bridge to surface observation events into OpenTelemetry tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->