### PR TITLE
feat(svc-agent): deep-think checkbox in chat.html

### DIFF
--- a/svc-agent/src/main/resources/static/chat.html
+++ b/svc-agent/src/main/resources/static/chat.html
@@ -581,6 +581,11 @@
                placeholder="Ask me anything about your portfolios..." autocomplete="off">
         <button id="sendButton" class="send-button">Send</button>
     </div>
+    <div style="text-align: right; margin-top: 6px; font-size: 12px; color: #666;">
+        <label title="Escalates the agent to its DEEP tier (slower, more analytical, higher cost).">
+            <input type="checkbox" id="deepThink"> 🧠 Deep think
+        </label>
+    </div>
 
     <div class="examples">
         <h3>💡 Try these examples:</h3>
@@ -823,12 +828,14 @@
                 headers['Authorization'] = 'Bearer ' + token;
             }
 
+            const deepThink = !!document.getElementById('deepThink')?.checked;
             const response = await fetch('agent/query', {
                 method: 'POST',
                 headers: headers,
                 body: JSON.stringify({
                     query: message,
-                    context: {}
+                    context: {},
+                    deepThink
                 })
             });
 


### PR DESCRIPTION
## Summary

Adds a small \"🧠 Deep think\" checkbox below the chat input in `chat.html` and
forwards its state as `deepThink` on the `/agent/query` POST body. Mirrors
the bc-view ChatPanel toggle so the static UI exercises the same DEEP-tier
path.

## Test plan

- [x] `./gradlew :svc-agent:check` green
- [x] Visual: checkbox renders bottom-right of input row at `localhost:9530/chat.html`
- [x] Wire: curl with `\"deepThink\":true` returns 200, tool roundtrip clean
- [ ] Manual on kauri after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "🧠 Deep think" checkbox to the chat interface, enabling users to opt into enhanced processing mode for more thorough message analysis and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->