### PR TITLE
feat(review): replace CodeRabbit with on-repo code-review skill + GH Action

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: code-review
+description: Review uncommitted/branch diff for security, correctness, clean-code (incl. DRY), and project guardrails. Optimised for low-noise high-signal feedback. Trigger on /code-review or when the user asks for a review, security audit, or PR feedback. Skip stylistic issues already enforced by lint/prettier/ktlint.
+---
+
+You are reviewing a code diff for the Beancounter ecosystem. Output ONLY actionable issues. No praise, no summaries of what changed, no speculative refactors.
+
+## How to gather the diff
+
+In priority order:
+
+1. If the user gave a PR number or URL → `gh pr diff <num>`
+2. If `--base <branch>` was specified → `git diff <base>...HEAD`
+3. Default → `git diff main...HEAD` plus `git diff` (for uncommitted)
+
+Stop if the diff is empty.
+
+## Optional static-analysis layer
+
+Before reasoning over the diff, run Codacy if the MCP tool is available **and** the diff contains files Codacy can analyse:
+
+- Use `mcp__codacy__codacy_cli_analyze` with the changed file paths (relative to repo root). Skip if it fails — do not block the review.
+- Pull findings into the review only when severity ≥ **Warning** AND the finding sits on a line the diff actually touches. Drop everything else; Codacy is otherwise too noisy.
+- If Codacy is unavailable or times out, note it in one line at the end (`Codacy: skipped (reason)`) and continue.
+
+Do NOT run `.codacy/cli.sh analyze` directly — first-run installs are slow (semgrep/trivy DB) and break the review loop. Use the MCP tool which reuses the cached install.
+
+## Severity rubric
+
+- 🔴 **Critical**: security vulnerability, data loss, auth bypass, secret leak, broken access control, OWASP top-10, hard-coded credential, dangerous SQL/cmd construction
+- 🟠 **Bug**: logic error, race, leak, swallowed error, off-by-one, wrong equality, async misuse
+- 🟡 **Cleanup**: clean-code violation likely to bite later — DRY violation (3+ near-identical blocks), large function (>~30 lines, multi-purpose), premature abstraction, dead code, name lying about behaviour on a public API
+- ⚪ **Nit**: stylistic, only if not already auto-fixable by lint/prettier/ktlint
+
+Cap at **10 comments**. If more issues exist, report the worst 10 and add a one-line tally (`8 additional nits omitted`).
+
+## Required for each comment
+
+```
+{severity} `path/to/file.kt:42`
+**Issue**: <one sentence>
+**Why**: <impact — security risk, specific bug scenario, future maintenance cost — be concrete>
+**Fix**:
+\`\`\`<lang>
+<minimal patch>
+\`\`\`
+```
+
+## What to check
+
+### Security (highest priority — never skip)
+
+- Injection: SQL, command, path traversal, SSRF, LDAP, header injection
+- Authn/authz: missing JWT validation, missing scope check on state-changing endpoints, role bypass, IDOR
+- Secrets: hard-coded keys/tokens/passwords, secrets in logs or error messages, secrets in URL query strings
+- CSRF on state-changing endpoints that aren't bearer-token-only
+- Input validation at trust boundaries only (don't add it inside trusted internal code)
+- Deserialization of untrusted data, especially Java/Jackson polymorphic types
+- Broken multi-tenant isolation: BC repos must store `SystemUser.id` as the owner, NEVER `jwt.subject` directly (see `SERVICE_DESIGN.md` data-ownership rule)
+- Unbounded/expensive operations without rate limit (LLM calls, exports, recursive joins)
+- Open redirect, file upload without type/size/path-traversal guard
+- Dependency vulnerability if a version is pinned in this diff (note + suggest upgrade)
+
+### Correctness
+
+- Off-by-one, missing `await`/fire-and-forget on a critical path
+- Empty `catch {}` swallowing errors, lost stack traces
+- Resource leak (stream / connection / file descriptor not closed; missing `use {}` / `try-with-resources`)
+- Wrong equality semantics: `==` vs `equals` in Kotlin, `==` vs `===` in TS, list-by-reference, float equality
+- Timezone assumed local, `Instant` vs `LocalDateTime` mix-ups
+- Mutated shared mutable state, race on shared resource
+- Premature `return` skipping cleanup
+- Optional/nullable unwrapped without guard
+
+### Clean code (incl. DRY)
+
+- **DRY violations**: 3+ near-identical blocks (rule of three — extract on the third occurrence, not the first; flag when 3+ exist and aren't extracted)
+- Function does more than one thing or > ~30 lines without a strong reason
+- Names lie about behaviour (`getX` that mutates, `isEmpty` that throws, etc.)
+- Premature abstraction added to handle one-off variation
+- Defensive null/undefined checks inside trusted internal boundaries (BC convention: validate at system boundaries only)
+- Comments explaining WHAT instead of WHY; comments referencing the current task/PR/issue (rot)
+- Magic numbers without named constant
+- Deeply nested conditionals (>3 levels)
+- Public API surface that should be internal/private
+
+### Tests
+
+- Test mocks the unit under test (mocking the thing you're testing)
+- No assertions
+- `Thread.sleep` / `setTimeout` -based wait
+- Integration scope where unit suffices, or vice versa
+- Tests deleted without replacement
+
+### Idioms — Kotlin / Spring (beancounter, svc-retire, svc-rebalance)
+
+Apply these only when the diff touches `*.kt` files. Skip if the file is a generated build artefact.
+
+- **Immutability**: prefer `val` over `var`; flag mutable backing fields on data classes without justification.
+- **Null safety**: `!!` non-null assertion in production code is 🟠 unless paired with a comment explaining why null is impossible. Prefer `?.let { }`, `requireNotNull()`, or `checkNotNull()` with a message.
+- **`when` exhaustiveness**: when used as an expression on a sealed type or enum, every branch must be covered without `else` — flag bare `else` swallowing future cases.
+- **Spring DI**: constructor injection only — no `@Autowired` on fields or setters, no `lateinit var` for beans.
+- **`@Bean` + `@Profile`**: profile-qualified beans must inject the concrete subtype (e.g., `AnthropicChatModel`), not the super-type (`ChatModel`) with `@ConditionalOnBean`. User-config conditions evaluate before auto-config and silently skip otherwise (BC trap, see `ChatClientConfiguration.kt` comment).
+- **`@Transactional`**: required on service-layer methods that modify the DB through a repository; flag direct repo writes from `@Controller` classes.
+- **RabbitMQ message handlers**: must be idempotent — flag handlers that don't tolerate redelivery.
+- **DTOs**: prefer `data class` over plain class for value objects with `equals`/`hashCode`/`copy` semantics.
+- **Mocks**: prefer `mockito-kotlin` (`whenever(x).thenReturn(...)`) over `Mockito.when` (clashes with Kotlin `when` keyword); prefer `mock<T> { on { ... } doReturn ... }` lambda style.
+- **Assertions**: prefer AssertJ `assertThat(x).isEqualTo(y)` over JUnit `assertEquals(y, x)` (argument order trap).
+- **Coroutines vs Reactor**: don't mix unless explicitly bridged — flag `runBlocking` inside reactive chains, flag `.block()` outside tests.
+- **Kotlin Spring AI options builder**: per-call options REPLACE (don't merge with) the ChatClient's defaults — re-apply `cacheOptions` etc. on every per-call override (BC incident: silent loss of prompt caching).
+- **Logging**: parameterised `log.debug("x={}, y={}", x, y)` — never `log.debug("x=$x")` (string concatenation runs even when DEBUG is off).
+
+### Idioms — TypeScript / Next.js (bc-view)
+
+Apply only when the diff touches `*.ts` / `*.tsx`.
+
+- **Pages Router**: bc-view uses Pages Router (`src/pages/`), NOT App Router. Flag any `app/` directory imports, `'use client'` directives, or `next/navigation` imports — should be `next/router`.
+- **Auth0 v4**: `auth0.getSession(req)` + `auth0.getAccessToken(req, res)` — flag legacy `withApiAuthRequired` (removed in v4). `getAccessToken` returns `{ token }` (was `{ accessToken }` in v3). Auth routes live at `/auth/*` (NOT `/api/auth/*`). `User` type imports from `@auth0/nextjs-auth0/types` — flag imports from `/client`.
+- **API routes**: use `createApiHandler` (`src/pages/api/...`) for the centralised path — flag bare `export default function handler(...)` that re-implements auth/error handling already in the wrapper.
+- **`any` usage**: `any` in non-test code is 🟡 — push for `unknown` + narrowing. Casts via `as unknown as T` are 🟠.
+- **Hooks**: `useEffect` cleanup function required for subscriptions / timers / event listeners. `useCallback` / `useMemo` only with a concrete reason (referenced in dep array of a child memo, expensive compute) — flag premature memoization.
+- **State updates in tests**: every state update inside `act(async () => { ... })`; flag bare `fireEvent` followed by an assertion that depends on the post-update state without an `await`.
+- **SSR safety**: flag `window`, `document`, `localStorage` access in component render path without a `typeof window !== 'undefined'` guard or `useEffect` wrapper.
+- **Tailwind**: prefer utilities over inline `style={{}}` when a utility exists; mobile-first breakpoint defaults (`md:`, `lg:` add at wider sizes); `mobile-portrait:` is a custom variant defined in `tailwind.config.js` (only fires at max-width 639px + portrait).
+- **Routing imports**: `useRouter` from `next/router` (Pages Router), not `next/navigation`.
+- **Path aliases**: `@lib/*` resolves to `src/lib/utils/*`, `@components/*` to `src/components/*`, `@hooks/*` to `src/hooks/*` (per `tsconfig.json` paths) — flag relative `../../../` imports that an alias would shorten.
+- **React imports**: with React 17+ JSX transform, `import React from "react"` is unused noise unless the file references `React.X` directly — but the codebase still includes it; ESLint will flag dead imports, so don't double-flag.
+- **Jest mocks**: Auth0 mocks live in `__mocks__/@auth0/nextjs-auth0/` (per CLAUDE.md memory) — flag inline `jest.mock("@auth0/nextjs-auth0", ...)` that duplicates the global mock.
+
+### Project guardrails (apply when the diff matches)
+
+- `**/db/migration/V*.sql` added → ensure entity changes in same diff are consistent; the migration must be staged with the entity change (BC incident: V16 dropped during commit-amend, bc-retire CrashLoopBackOff). Flag if entity diff exists without paired migration or vice versa.
+- Kotlin entity files in `svc-retire`/`svc-rebalance` ownership columns → must store `SystemUser.id`, not `jwt.subject`. Existing tech debt — new code must be compliant.
+- RabbitMQ topic strings → `application.yml` defaults to `-dev`; `-demo` overrides only in `bc-deploy/env/kauri.yaml`. Flag any cross-talk.
+- Auth0 JWT scope check → required on every state-changing controller method.
+- `--no-verify`, `--no-gpg-sign`, force-push to main, `git reset --hard` in scripts → 🔴 always.
+- New `@Bean` with `@Profile` conditions → check Spring's user-config evaluates BEFORE auto-config (memory: ChatClientConfiguration silent skip trap); profile-qualified beans + concrete subtype injection avoids it.
+- Spring AI / Anthropic / DeepSeek tool-loop changes → flag if `reasoning_content` handling missing on follow-up turns (memory: DeepSeek 400 on multi-turn).
+
+## What to SKIP
+
+- Anything caught by lint / prettier / ktlint / typecheck (CI runs these — do not duplicate)
+- "Consider extracting", "perhaps", "you could" — speculative refactors with no concrete bug or readability cost
+- Per-file summaries
+- Praise
+- Re-stating what the diff does
+- Cosmetic comments on tests that exercise the contract correctly
+
+## Output shape
+
+Comments in severity order (🔴 first). End with a single-line verdict:
+
+- `READY` — no 🔴 / 🟠 issues
+- `BLOCKED` — at least one 🔴 / 🟠 issue
+- `Codacy: <skipped|N findings>` — one line if Codacy ran or was skipped
+
+Nothing else.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,13 +31,27 @@ jobs:
       BASE_REF: ${{ github.base_ref }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      - name: Check API key presence
+        id: gate
+        env:
+          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          if [ "$HAS_KEY" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::ANTHROPIC_API_KEY not configured — skipping Claude review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout PR head
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history so `git diff <base>...HEAD` works
 
       - name: Resolve diff base
         id: diff
+        if: steps.gate.outputs.skip != 'true'
         run: |
           git fetch --no-tags --depth=1 origin "$BASE_REF"
           BASE_SHA=$(git rev-parse "origin/$BASE_REF")
@@ -49,7 +63,7 @@ jobs:
 
       - name: Run Codacy (best-effort, non-blocking)
         id: codacy
-        if: steps.diff.outputs.skip != 'true'
+        if: steps.gate.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
         continue-on-error: true
         env:
           BASE_SHA: ${{ steps.diff.outputs.base_sha }}
@@ -65,7 +79,7 @@ jobs:
           test -f codacy.sarif || echo '{}' > codacy.sarif
 
       - name: Claude review
-        if: steps.diff.outputs.skip != 'true'
+        if: steps.gate.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,6 +100,6 @@ jobs:
             Do NOT post inline review threads — one consolidated comment only.
             Prefix the comment body with `## Claude review`.
 
-      - name: Skip notice
-        if: steps.diff.outputs.skip == 'true'
+      - name: Skip notice (empty diff)
+        if: steps.gate.outputs.skip != 'true' && steps.diff.outputs.skip == 'true'
         run: echo "::notice::Empty diff vs base — skipping Claude review."

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,91 @@
+name: Code review (Claude)
+
+# Runs the .claude/skills/code-review prompt against the PR diff and posts a
+# single review comment with severity-tiered findings. Augments — does not
+# replace — CircleCI's existing test/lint/typecheck pipeline.
+#
+# Security: every github.* expression is hoisted into env: with proper quoting
+# so an attacker cannot inject shell via PR metadata. See
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel an in-flight review if a new commit lands on the same PR.
+concurrency:
+  group: code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so `git diff <base>...HEAD` works
+
+      - name: Resolve diff base
+        id: diff
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          BASE_SHA=$(git rev-parse "origin/$BASE_REF")
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          # Skip on empty diffs (renamed-only, whitespace-only, etc.)
+          if [ -z "$(git diff --name-only "$BASE_SHA"...HEAD)" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Codacy (best-effort, non-blocking)
+        id: codacy
+        if: steps.diff.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ steps.diff.outputs.base_sha }}
+        run: |
+          if [ -x .codacy/cli.sh ]; then
+            # Limit Codacy to the changed files — full-repo scans take minutes.
+            mapfile -t CHANGED < <(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD)
+            if [ "${#CHANGED[@]}" -gt 0 ]; then
+              .codacy/cli.sh analyze --format sarif "${CHANGED[@]}" > codacy.sarif 2>codacy.log || true
+            fi
+          fi
+          # Always emit the file (even empty) so the next step can read unconditionally.
+          test -f codacy.sarif || echo '{}' > codacy.sarif
+
+      - name: Claude review
+        if: steps.diff.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ steps.diff.outputs.base_sha }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The action mounts the workspace so .claude/skills/code-review/SKILL.md
+          # is auto-discovered. The prompt body is static — all dynamic values
+          # come from env: above to prevent injection via PR metadata.
+          prompt: |
+            Run the `code-review` skill against the diff between $BASE_SHA and HEAD.
+
+            Codacy SARIF (may be empty {}): see `codacy.sarif` in the workspace —
+            fold its findings into the review per the skill's rules.
+
+            Post the review as a single PR comment via
+            `gh pr comment "$PR_NUMBER"`.
+            Do NOT post inline review threads — one consolidated comment only.
+            Prefix the comment body with `## Claude review`.
+
+      - name: Skip notice
+        if: steps.diff.outputs.skip == 'true'
+        run: echo "::notice::Empty diff vs base — skipping Claude review."

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,14 @@ svc-agent/src/main/resources/application-kauri.yaml
 **/application-local.y*ml
 **/application-sentry.y*ml
 .run/
-.claude/
+# Ignore .claude/* (settings.local.json etc.) but not the directory itself —
+# we still need to traverse it to surface the negated paths below. Project-
+# shared skills + commands ARE checked in; runtime/local files stay ignored.
+.claude/*
+!.claude/skills/
+!.claude/skills/**
+!.claude/commands/
+!.claude/commands/**
 .ci/gradle*
 
 # You can put a script which call `yarn prettier-eslint --write` that prettify the file in-place.


### PR DESCRIPTION
## Summary

- New `.claude/skills/code-review/SKILL.md` — single low-noise review prompt covering security (OWASP, BC `SystemUser.id` ownership, secrets, scope checks), correctness, clean code (DRY rule-of-three, no premature abstraction, comment WHY not WHAT), per-language idioms (Kotlin/Spring + TS/Next.js Pages Router), and project guardrails (Flyway+entity pairing, RabbitMQ topic suffix, Spring AI tool-loop reasoning_content trap, `--no-verify`, force-push).
- Output discipline: severity tiers (🔴/🟠/🟡/⚪), capped at 10 comments, READY/BLOCKED verdict, no praise, no diff restating, no overlap with lint/prettier/ktlint.
- Codacy folded in opportunistically via MCP — Warning+ findings on lines the diff actually touches only.
- `.github/workflows/code-review.yml` — runs the same skill on PR open/sync, posts a single consolidated comment, all `github.*` expressions hoisted into `env:` per GitHub's actions-injection guide.
- `.gitignore` flipped to `.claude/*` + negation so the skill is committed but local runtime files (settings.local.json) stay ignored.
- bc-claude `CLAUDE.md` updated: CodeRabbit removed, code-review skill referenced.

## Migration

CodeRabbit binary may still exist locally but is no longer part of any workflow. `/coderabbit:code-review` slash command will continue to work for one-off use; the new flow is `/code-review` (project skill) or the auto-run on PR.

## Test plan

- [x] `git status` shows the skill file is staged (gitignore negation works)
- [x] Skill prompt covers DRY explicitly (rule of three) per request
- [x] Workflow YAML hoists all `github.*` into `env:` (security_reminder hook flagged + fixed)
- [ ] After merge, open a follow-up PR to mirror the skill into bc-view + svc-retire + svc-rebalance
- [ ] After merge, configure repo `ANTHROPIC_API_KEY` secret + verify the workflow fires on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated code review runs on PRs targeting main (opened/updated/ready) and posts a single consolidated review comment that replaces prior reviews.
* **Behavior Changes**
  * Reviews are skipped for draft PRs, when the diff is empty, or necessary review config is absent.
  * Static-analysis results are folded into the review; comment output is concise and capped to a limited number of items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->