### PR TITLE
feat(svc-data): market index support via Alpha Vantage

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/model/AssetCategory.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/AssetCategory.kt
@@ -13,6 +13,7 @@ data class AssetCategory(
         const val ACCOUNT: String = "ACCOUNT"
         const val TRADE: String = "TRADE"
         const val POLICY: String = "POLICY"
+        const val INDEX: String = "INDEX"
 
         @Deprecated("Use POLICY instead", replaceWith = ReplaceWith("POLICY"))
         const val PENSION: String = "PENSION"
@@ -24,6 +25,7 @@ data class AssetCategory(
         const val REPORT_MUTUAL_FUND: String = "Mutual Fund"
         const val REPORT_PROPERTY: String = "Property"
         const val REPORT_RETIREMENT_FUND: String = "Retirement Fund"
+        const val REPORT_INDEX: String = "Index"
 
         /**
          * Maps a detailed category to a higher-level report category.
@@ -37,6 +39,7 @@ data class AssetCategory(
                 "EXCHANGE TRADED FUND", "ETF" -> REPORT_ETF
                 "MUTUAL FUND" -> REPORT_MUTUAL_FUND
                 POLICY, "PENSION" -> REPORT_RETIREMENT_FUND
+                INDEX -> REPORT_INDEX
                 else -> category // Default: use original category
             }
     }

--- a/jar-common/src/test/kotlin/com/beancounter/common/model/AssetCategoryTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/model/AssetCategoryTest.kt
@@ -1,0 +1,28 @@
+package com.beancounter.common.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AssetCategoryTest {
+    @Test
+    fun `INDEX constant exposed`() {
+        assertThat(AssetCategory.INDEX).isEqualTo("INDEX")
+    }
+
+    @Test
+    fun `REPORT_INDEX constant exposed`() {
+        assertThat(AssetCategory.REPORT_INDEX).isEqualTo("Index")
+    }
+
+    @Test
+    fun `INDEX category maps to REPORT_INDEX`() {
+        assertThat(AssetCategory.toReportCategory(AssetCategory.INDEX))
+            .isEqualTo(AssetCategory.REPORT_INDEX)
+    }
+
+    @Test
+    fun `lowercase index maps to REPORT_INDEX`() {
+        assertThat(AssetCategory.toReportCategory("index"))
+            .isEqualTo(AssetCategory.REPORT_INDEX)
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetFinder.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetFinder.kt
@@ -100,6 +100,11 @@ class AssetFinder(
      */
     fun findHeldAssetsForPricing(): List<Asset> = assetRepository.findHeldAssetsForPricing().use { it.toList() }
 
+    /**
+     * Index benchmark assets refreshed on schedule regardless of holdings.
+     */
+    fun findActiveIndexAssets(): List<Asset> = assetRepository.findActiveIndexAssets().map { hydrateAsset(it) }
+
     companion object {
         private val log = LoggerFactory.getLogger(AssetFinder::class.java)
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
@@ -79,6 +79,19 @@ interface AssetRepository : CrudRepository<Asset, String> {
     fun findHeldAssetsForPricing(): Stream<Asset>
 
     /**
+     * Find active assets on the synthetic INDEX market. These are reference
+     * benchmarks (no holdings) that the scheduled refresh fetches alongside
+     * held assets so dashboards always show fresh index quotes.
+     */
+    @Query(
+        "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
+            "WHERE a.status = com.beancounter.common.model.Status.Active " +
+            "AND a.code IS NOT NULL AND a.code <> '' " +
+            "AND a.marketCode = 'INDEX'"
+    )
+    fun findActiveIndexAssets(): List<Asset>
+
+    /**
      * Find all assets owned by a specific user with a specific category.
      */
     @Query(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexConfig.kt
@@ -1,0 +1,24 @@
+package com.beancounter.marketdata.assets
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/**
+ * Pre-seed market index definitions loaded from `beancounter.indices.values`.
+ *
+ * Indices are reference assets (no SystemUser ownership) created at startup so
+ * benchmark prices are queryable without manual asset registration.
+ */
+@ConfigurationProperties(prefix = "beancounter.indices")
+@Component
+class IndexConfig {
+    var values: List<IndexDefinition> = emptyList()
+}
+
+data class IndexDefinition(
+    /** Alpha Vantage symbol, e.g. "^GSPC". */
+    var code: String = "",
+    var name: String = "",
+    /** ISO currency code the index is quoted in. */
+    var currency: String = "USD"
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexSeedRunner.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexSeedRunner.kt
@@ -1,0 +1,63 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.utils.AssetKeyUtils
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+const val INDEX_MARKET_CODE = "INDEX"
+
+/**
+ * Creates pre-seeded index assets at startup. Idempotent: existing assets are
+ * looked up via AssetService.create() which short-circuits to findLocally first.
+ *
+ * The auto-run on `ApplicationRunner` is gated by
+ * `beancounter.indices.seed-on-startup` (default true). Tests that mock
+ * CurrencyService or load a partial context set this to false and call
+ * [seed] explicitly when they need the data.
+ */
+@Component
+class IndexSeedRunner(
+    private val indexConfig: IndexConfig,
+    private val assetService: AssetService
+) : ApplicationRunner {
+    @Value("\${beancounter.indices.seed-on-startup:true}")
+    private var seedOnStartup: Boolean = true
+
+    override fun run(args: ApplicationArguments?) {
+        if (!seedOnStartup) {
+            log.debug("Index pre-seed disabled by configuration")
+            return
+        }
+        seed()
+    }
+
+    fun seed() {
+        if (indexConfig.values.isEmpty()) {
+            return
+        }
+        val inputs =
+            indexConfig.values.associate { def ->
+                val input =
+                    AssetInput(
+                        market = INDEX_MARKET_CODE,
+                        code = def.code,
+                        name = def.name,
+                        currency = def.currency,
+                        category = AssetCategory.INDEX
+                    )
+                AssetKeyUtils.toKey(input) to input
+            }
+        val response = assetService.handle(AssetRequest(inputs))
+        log.info("Seeded {} index assets", response.data.size)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(IndexSeedRunner::class.java)
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceRefresh.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceRefresh.kt
@@ -49,7 +49,13 @@ class PriceRefresh(
         // Assets are collected upfront so no long-running DB transaction
         // wraps the price-fetch loop.  Without this, a single fetch failure
         // could mark the transaction rollback-only and discard ALL saved prices.
-        val assets = assetFinder.findHeldAssetsForPricing()
+        // Index benchmarks (INDEX market) are unioned in — they have no
+        // holdings but dashboards expect them refreshed daily.
+        val held = assetFinder.findHeldAssetsForPricing()
+        val indices = assetFinder.findActiveIndexAssets()
+        val assets =
+            (held + indices)
+                .distinctBy { it.id }
 
         for (asset in assets) {
             totalAssets.getAndIncrement()

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfig.kt
@@ -106,6 +106,10 @@ class AlphaConfig(
         if (asset.priceSymbol != null) {
             return asset.priceSymbol!!
         }
+        // Index symbols (e.g. ^GSPC, ^IXIC) carry no market suffix on Alpha Vantage.
+        if (asset.code.startsWith("^")) {
+            return asset.code
+        }
         val marketCode = translateMarketCode(asset.market)
         return if (!marketCode.isNullOrEmpty()) {
             asset.code + "." + marketCode

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricher.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.alpha
 
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.MarketData
 import com.beancounter.common.model.MarketData.Companion.isDividend
 import com.beancounter.common.model.MarketData.Companion.isSplit
@@ -32,6 +33,11 @@ class AlphaCorporateEventEnricher(
      * @return The same MarketData enriched with split/dividend data and adjusted prices
      */
     fun enrich(marketData: MarketData): MarketData {
+        // Index assets never have splits or dividends. TIME_SERIES_DAILY_ADJUSTED also
+        // returns an error for index symbols (^GSPC, ^IXIC), so skip the upstream call.
+        if (marketData.asset.category.equals(AssetCategory.INDEX, ignoreCase = true)) {
+            return marketData
+        }
         try {
             val events = alphaEventService.getEvents(marketData.asset)
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.exception.SystemException
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
 import com.beancounter.marketdata.providers.MarketDataPriceProvider
@@ -147,7 +148,16 @@ class AlphaPriceService(
     ) = alphaConfig.getMarketDate(market, priceRequest.date, priceRequest.currentMode)
 
     override fun backFill(asset: Asset): PriceResponse {
-        val json = alphaProxy.getAdjusted(asset.code, apiKey)
+        // TIME_SERIES_DAILY_ADJUSTED returns an error for index symbols (^GSPC, ^IXIC).
+        // Fall back to TIME_SERIES_DAILY which works for indices and never carries
+        // dividend/split data.
+        val isIndex = asset.category.equals(AssetCategory.INDEX, ignoreCase = true)
+        val json =
+            if (isIndex) {
+                alphaProxy.getHistoric(asset.code, apiKey)
+            } else {
+                alphaProxy.getAdjusted(asset.code, apiKey)
+            }
         val priceResponse: PriceResponse = alphaConfig.getObjectMapper().readValue(json, PriceResponse::class.java)
         for (marketData in priceResponse.data) {
             marketData.source = ID

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -295,6 +295,25 @@ beancounter:
           name: "Trade Account"
         - id: "POLICY"
           name: "Retirement Fund"
+        - id: "INDEX"
+          name: "Market Index"
+
+  # Pre-seed market index assets created at startup. All routed to the
+  # synthetic INDEX market and priced by Alpha Vantage (TIME_SERIES_DAILY).
+  indices:
+    values:
+      - code: "^GSPC"
+        name: "S&P 500"
+        currency: "USD"
+      - code: "^IXIC"
+        name: "NASDAQ Composite"
+        currency: "USD"
+      - code: "^DJI"
+        name: "Dow Jones Industrial Average"
+        currency: "USD"
+      - code: "^FTSE"
+        name: "FTSE 100"
+        currency: "GBP"
 
   # Default asset enricher - FIGI/ALPHA - can be set on a per market basis
   enricher: FIGI
@@ -426,11 +445,19 @@ beancounter:
         timezoneId: "Europe/London"
         enricher: "DEFAULT"
         type: "Fund"
+
+      - code: "INDEX"
+        name: "Market Index"
+        currencyId: "USD"
+        timezoneId: "US/Eastern"
+        enricher: "DEFAULT"
+        type: "Index"
+        active: false
     providers:
       alpha:
         url: https://www.alphavantage.co
         batchSize: 1
-        markets: "US,NASDAQ,AMEX,NYSE,LON,TSX"
+        markets: "US,NASDAQ,AMEX,NYSE,LON,TSX,INDEX"
         news:
           # Minimum per-ticker relevance_score (0.0-1.0) to keep an article.
           # Raise to narrow to only strongly-on-topic news; lower to be

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/Constants.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/Constants.kt
@@ -70,6 +70,25 @@ class Constants {
         val NZD = Currency("NZD")
         val CAD = Currency("CAD")
 
+        val INDEX_MARKET =
+            Market(
+                "INDEX",
+                USD.code
+            )
+        val SP500 =
+            Asset(
+                code = "^GSPC",
+                id = "^GSPC",
+                name = "S&P 500",
+                market = INDEX_MARKET,
+                priceSymbol = "^GSPC",
+                category = AssetCategory.INDEX,
+                assetCategory =
+                    AssetCategory(
+                        AssetCategory.INDEX,
+                        "Market Index"
+                    )
+            )
         val NZX =
             Market(
                 "NZX",

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.contracts.AssetUpdateResponse
 import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Status
 import com.beancounter.common.utils.AssetKeyUtils.Companion.toKey
 import com.beancounter.common.utils.AssetUtils.Companion.getAssetInput
@@ -248,6 +249,85 @@ internal class AssetControllerTest {
             objectMapper.readValue<AssetUpdateResponse>(mvcResult.response.contentAsString)
         val updatedAsset = assetUpdateResponse.data[toKey(asset)]
         assertThat(updatedAsset).isEqualTo(createdAsset)
+    }
+
+    @Test
+    fun `lookup index asset via URL with caret-prefix code`() {
+        val input =
+            AssetInput(
+                market = "INDEX",
+                code = "^GSPC",
+                name = "S&P 500",
+                category = AssetCategory.INDEX
+            )
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(ASSET_ROOT)
+                    .with(
+                        SecurityMockMvcRequestPostProcessors
+                            .jwt()
+                            .jwt(mockAuthConfig.getUserToken())
+                    ).with(csrf())
+                    .content(objectMapper.writeValueAsBytes(AssetRequest(mapOf(toKey(input) to input))))
+                    .contentType(APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        val mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("$ASSET_ROOT/{marketCode}/{assetCode}", "INDEX", "^GSPC")
+                        .with(
+                            SecurityMockMvcRequestPostProcessors
+                                .jwt()
+                                .jwt(mockAuthConfig.getUserToken())
+                        )
+                ).andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andReturn()
+
+        val response = objectMapper.readValue<AssetResponse>(mvcResult.response.contentAsString)
+        assertThat(response.data.code).isEqualTo("^GSPC")
+        assertThat(response.data.marketCode).isEqualTo("INDEX")
+        assertThat(response.data.assetCategory.id).isEqualTo(AssetCategory.INDEX)
+    }
+
+    @Test
+    fun `create market index asset with INDEX category`() {
+        val input =
+            AssetInput(
+                market = "INDEX",
+                code = "^GSPC",
+                name = "S&P 500",
+                category = AssetCategory.INDEX
+            )
+        val assetRequest = AssetRequest(mapOf(toKey(input) to input))
+
+        val mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post(ASSET_ROOT)
+                        .with(
+                            SecurityMockMvcRequestPostProcessors
+                                .jwt()
+                                .jwt(mockAuthConfig.getUserToken())
+                        ).with(csrf())
+                        .content(objectMapper.writeValueAsBytes(assetRequest))
+                        .contentType(APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andReturn()
+
+        val response = objectMapper.readValue<AssetUpdateResponse>(mvcResult.response.contentAsString)
+        val created = response.data[toKey(input)]
+        assertThat(created)
+            .isNotNull
+            .hasFieldOrPropertyWithValue("code", "^GSPC")
+            .hasFieldOrPropertyWithValue("marketCode", "INDEX")
+        assertThat(created!!.assetCategory.id).isEqualTo(AssetCategory.INDEX)
+        assertThat(created.effectiveReportCategory).isEqualTo(AssetCategory.REPORT_INDEX)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/IndexConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/IndexConfigTest.kt
@@ -1,0 +1,39 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.auth.AutoConfigureMockAuth
+import com.beancounter.marketdata.MarketDataBoot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@SpringBootTest(classes = [MarketDataBoot::class])
+@ActiveProfiles("h2db")
+@AutoConfigureMockAuth
+class IndexConfigTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var indexConfig: IndexConfig
+
+    @Test
+    fun `binds index definitions from yml`() {
+        assertThat(indexConfig.values)
+            .extracting<String> { it.code }
+            .contains("^GSPC", "^IXIC", "^DJI", "^FTSE")
+    }
+
+    @Test
+    fun `each index defines name and currency`() {
+        val gspc = indexConfig.values.first { it.code == "^GSPC" }
+        assertThat(gspc.name).isEqualTo("S&P 500")
+        assertThat(gspc.currency).isEqualTo("USD")
+
+        val ftse = indexConfig.values.first { it.code == "^FTSE" }
+        assertThat(ftse.currency).isEqualTo("GBP")
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/IndexSeedRunnerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/IndexSeedRunnerTest.kt
@@ -1,0 +1,69 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.auth.AutoConfigureMockAuth
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.marketdata.MarketDataBoot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@SpringBootTest(classes = [MarketDataBoot::class])
+@ActiveProfiles("h2db")
+@AutoConfigureMockAuth
+class IndexSeedRunnerTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var indexSeedRunner: IndexSeedRunner
+
+    @Autowired
+    private lateinit var assetFinder: AssetFinder
+
+    @Autowired
+    private lateinit var indexConfig: IndexConfig
+
+    @Test
+    fun `seed creates one asset per configured index`() {
+        indexSeedRunner.seed()
+        for (def in indexConfig.values) {
+            val asset =
+                assetFinder.findLocally(
+                    AssetInput(market = INDEX_MARKET_CODE, code = def.code)
+                )
+            assertThat(asset)
+                .describedAs("expected seeded index ${def.code}")
+                .isNotNull
+            assertThat(asset!!.assetCategory.id).isEqualTo(AssetCategory.INDEX)
+            assertThat(asset.marketCode).isEqualTo(INDEX_MARKET_CODE)
+        }
+    }
+
+    @Test
+    fun `seed is idempotent across multiple invocations`() {
+        indexSeedRunner.seed()
+        val firstIds =
+            indexConfig.values
+                .mapNotNull { def ->
+                    assetFinder
+                        .findLocally(AssetInput(market = INDEX_MARKET_CODE, code = def.code))
+                        ?.id
+                }
+
+        indexSeedRunner.seed()
+        val secondIds =
+            indexConfig.values
+                .mapNotNull { def ->
+                    assetFinder
+                        .findLocally(AssetInput(market = INDEX_MARKET_CODE, code = def.code))
+                        ?.id
+                }
+
+        assertThat(secondIds).isEqualTo(firstIds)
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
@@ -3,6 +3,8 @@ package com.beancounter.marketdata.providers
 import com.beancounter.common.contracts.PriceAsset
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
 import com.beancounter.common.utils.DateUtils.Companion.TODAY
 import com.beancounter.common.utils.KeyGenUtils
@@ -83,5 +85,50 @@ internal class PriceRefreshTest {
         assertThat(hydratedAsset).hasFieldOrProperty("market")
         val count = priceRefresh.updatePrices()
         assertThat(count).isGreaterThanOrEqualTo(1)
+    }
+
+    @Test
+    fun `findActiveIndexAssets returns INDEX market assets without holdings`() {
+        val indexCode = "^GSPC_TEST"
+        val indexMarket = Market("INDEX")
+        assetRepository.save(
+            Asset(
+                code = indexCode,
+                id = indexCode,
+                market = indexMarket,
+                marketCode = indexMarket.code,
+                category = AssetCategory.INDEX
+            )
+        )
+
+        val indices = assetFinder.findActiveIndexAssets()
+        assertThat(indices.map { it.code }).contains(indexCode)
+    }
+
+    @Test
+    fun `updatePrices includes index assets even without holdings`() {
+        val indexCode = "^GSPC_REFRESH"
+        val indexMarket = Market("INDEX")
+        Mockito
+            .`when`(alphaPriceService.isMarketSupported(org.mockito.kotlin.any()))
+            .thenReturn(true)
+        assetRepository.save(
+            Asset(
+                code = indexCode,
+                id = indexCode,
+                market = indexMarket,
+                marketCode = indexMarket.code,
+                category = AssetCategory.INDEX
+            )
+        )
+
+        priceRefresh.updatePrices()
+
+        // Confirms PriceRefresh enrolled the index asset in its refresh loop:
+        // routing through MdFactory.resolveProvider → isMarketSupported is the
+        // first observable signal that the asset entered the price pipeline.
+        val captor = org.mockito.kotlin.argumentCaptor<Market>()
+        Mockito.verify(alphaPriceService, Mockito.atLeastOnce()).isMarketSupported(captor.capture())
+        assertThat(captor.allValues.map { it.code }).contains("INDEX")
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfigTest.kt
@@ -1,0 +1,52 @@
+package com.beancounter.marketdata.providers.alpha
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.marketdata.Constants.Companion.INDEX_MARKET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AlphaConfigTest {
+    private val alphaConfig = AlphaConfig()
+
+    @Test
+    fun `getPriceCode returns priceSymbol verbatim when set`() {
+        val asset =
+            Asset(
+                code = "^GSPC",
+                market = INDEX_MARKET,
+                priceSymbol = "^GSPC"
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("^GSPC")
+    }
+
+    @Test
+    fun `getPriceCode passes through caret-prefixed code without market suffix`() {
+        val asset =
+            Asset(
+                code = "^GSPC",
+                market = INDEX_MARKET
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("^GSPC")
+    }
+
+    @Test
+    fun `getPriceCode appends market suffix for non-null market`() {
+        val asset =
+            Asset(
+                code = "BHP",
+                market = Market("ASX")
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("BHP.AX")
+    }
+
+    @Test
+    fun `getPriceCode returns code only for US-aggregator markets`() {
+        val asset =
+            Asset(
+                code = "AAPL",
+                market = Market("NASDAQ")
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("AAPL")
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaCorporateEventEnricherTest.kt
@@ -2,8 +2,10 @@ package com.beancounter.marketdata.providers.alpha
 
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
+import com.beancounter.marketdata.Constants.Companion.INDEX_MARKET
 import com.beancounter.marketdata.providers.ProviderArguments
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -439,6 +441,31 @@ class AlphaCorporateEventEnricherTest {
 
         // And: change should be correct (no adjustment needed since GLOBAL_QUOTE handles it)
         assertThat(enrichedData.change).isEqualByComparingTo(BigDecimal("0.50"))
+    }
+
+    @Test
+    fun `should skip enrichment for INDEX category assets`() {
+        val indexAsset =
+            Asset(
+                id = "^GSPC",
+                code = "^GSPC",
+                market = INDEX_MARKET,
+                category = AssetCategory.INDEX
+            )
+        val marketData =
+            MarketData(
+                asset = indexAsset,
+                priceDate = priceDate,
+                close = BigDecimal("5808.12"),
+                source = AlphaPriceService.ID
+            )
+
+        val enriched = enricher.enrich(marketData)
+
+        verify(alphaEventService, never()).getEvents(any<Asset>())
+        assertThat(enriched).isSameAs(marketData)
+        assertThat(enriched.split).isEqualByComparingTo(BigDecimal.ONE)
+        assertThat(enriched.dividend).isEqualByComparingTo(BigDecimal.ZERO)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaIndexApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaIndexApiTest.kt
@@ -1,0 +1,118 @@
+package com.beancounter.marketdata.providers.alpha
+
+import com.beancounter.auth.AutoConfigureMockAuth
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.MarketDataBoot
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.assets.INDEX_MARKET_CODE
+import com.beancounter.marketdata.assets.IndexConfig
+import com.beancounter.marketdata.assets.IndexSeedRunner
+import com.beancounter.marketdata.providers.MarketDataService
+import com.beancounter.marketdata.providers.PriceService
+import com.beancounter.marketdata.providers.alpha.AlphaMockUtils.ALPHA_MOCK
+import com.beancounter.marketdata.providers.alpha.AlphaMockUtils.mockHistoricResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.core.io.ClassPathResource
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.LocalDate
+
+@SpringBootTest(classes = [MarketDataBoot::class])
+@ActiveProfiles("h2db", "alpha")
+@Tag("wiremock")
+@AutoConfigureWireMock(port = 0)
+@AutoConfigureMockAuth
+@TestPropertySource(
+    properties = ["beancounter.market.providers.alpha.markets=NASDAQ,AMEX,NYSE,ASX,LON,INDEX"]
+)
+class AlphaIndexApiTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var marketDataService: MarketDataService
+
+    @Autowired
+    private lateinit var priceService: PriceService
+
+    @Autowired
+    private lateinit var indexConfig: IndexConfig
+
+    @Autowired
+    private lateinit var indexSeedRunner: IndexSeedRunner
+
+    @Test
+    fun `pre-seeded indices are persisted as INDEX category assets`() {
+        indexSeedRunner.seed()
+
+        val codes = indexConfig.values.map { it.code }
+        assertThat(codes).contains("^GSPC")
+
+        val response =
+            assetService.handle(
+                AssetRequest(
+                    mapOf(
+                        "gspc" to
+                            AssetInput(
+                                market = INDEX_MARKET_CODE,
+                                code = "^GSPC"
+                            )
+                    )
+                )
+            )
+        val gspc = response.data["gspc"]
+        assertThat(gspc).isNotNull
+        assertThat(gspc!!.assetCategory.id).isEqualTo(AssetCategory.INDEX)
+        assertThat(gspc.marketCode).isEqualTo(INDEX_MARKET_CODE)
+    }
+
+    @Test
+    fun `backFill of index asset persists prices via TIME_SERIES_DAILY`() {
+        mockHistoricResponse(
+            "^GSPC",
+            ClassPathResource("$ALPHA_MOCK/gspc-historic.json").file
+        )
+
+        indexSeedRunner.seed()
+        val gspc =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "gspc" to
+                                AssetInput(
+                                    market = INDEX_MARKET_CODE,
+                                    code = "^GSPC"
+                                )
+                        )
+                    )
+                ).data["gspc"]!!
+
+        marketDataService.backFill(gspc.id)
+
+        val history =
+            priceService.getPriceHistory(
+                gspc.id,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31)
+            )
+        assertThat(history.prices)
+            .describedAs("Index backFill should persist TIME_SERIES_DAILY prices")
+            .hasSize(2)
+        assertThat(history.prices.map { it.priceDate })
+            .contains(LocalDate.of(2026, 5, 7), LocalDate.of(2026, 5, 6))
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaIndexBackFillTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaIndexBackFillTest.kt
@@ -1,0 +1,68 @@
+package com.beancounter.marketdata.providers.alpha
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.marketdata.Constants.Companion.INDEX_MARKET
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+class AlphaIndexBackFillTest {
+    private val proxy = mock(AlphaProxy::class.java)
+    private val adapter = mock(AlphaPriceAdapter::class.java)
+    private val service =
+        AlphaPriceService(AlphaConfig()).also {
+            it.setAlphaHelpers(proxy, adapter)
+            // apiKey is lateinit but unused by mocked proxy; set via reflection
+            val field = AlphaPriceService::class.java.getDeclaredField("apiKey")
+            field.isAccessible = true
+            field.set(it, "demo")
+        }
+
+    private val emptyHistoric =
+        """{"Meta Data":{"2. Symbol":"X"},"Time Series (Daily)":{}}"""
+    private val emptyAdjusted =
+        """{"Meta Data":{"2. Symbol":"X"},"Time Series (Daily)":{}}"""
+
+    @Test
+    fun `backFill uses getHistoric for INDEX category asset`() {
+        val sp500 =
+            Asset(
+                code = "^GSPC",
+                id = "^GSPC",
+                market = INDEX_MARKET,
+                priceSymbol = "^GSPC",
+                category = AssetCategory.INDEX
+            )
+        whenever(proxy.getHistoric(eq("^GSPC"), any())).thenReturn(emptyHistoric)
+
+        val response = service.backFill(sp500)
+
+        verify(proxy).getHistoric(eq("^GSPC"), any())
+        verify(proxy, never()).getAdjusted(any(), any())
+        assertThat(response.data).isEmpty()
+    }
+
+    @Test
+    fun `backFill uses getAdjusted for non-INDEX category asset`() {
+        val msft =
+            Asset(
+                code = "MSFT",
+                id = "MSFT",
+                market = NASDAQ,
+                category = "EQUITY"
+            )
+        whenever(proxy.getAdjusted(eq("MSFT"), any())).thenReturn(emptyAdjusted)
+
+        service.backFill(msft)
+
+        verify(proxy).getAdjusted(eq("MSFT"), any())
+        verify(proxy, never()).getHistoric(any(), any())
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaMockUtils.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaMockUtils.kt
@@ -83,6 +83,22 @@ object AlphaMockUtils {
     }
 
     /**
+     * Stub TIME_SERIES_DAILY (non-adjusted, no dividend/split data).
+     * Used for index symbols (^GSPC etc.) where the _ADJUSTED endpoint errors.
+     * `^` is URL-encoded as `%5E` by RestClient, which the WireMock stub must mirror.
+     */
+    fun mockHistoricResponse(
+        symbol: String,
+        jsonFile: File
+    ) {
+        val encoded = symbol.replace("^", "%5E")
+        mockGetResponse(
+            "/query?function=TIME_SERIES_DAILY&symbol=$encoded&apikey=demo",
+            jsonFile
+        )
+    }
+
+    /**
      * Convenience function to stub a GET/200 response.
      *
      * @param url          url to stub

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
@@ -249,6 +249,39 @@ class AlphaPriceDeserializerTest {
     }
 
     @Test
+    fun `should deserialize index symbol with caret prefix from Global Quote`() {
+        val apiResponse =
+            """
+            {
+                "Global Quote": {
+                    "01. symbol": "^GSPC",
+                    "02. open": "5780.4400",
+                    "03. high": "5810.6300",
+                    "04. low": "5777.4500",
+                    "05. price": "5808.1200",
+                    "06. volume": "0",
+                    "07. latest trading day": "2026-05-07",
+                    "08. previous close": "5793.7500",
+                    "09. change": "14.3700",
+                    "10. change percent": "0.2480%"
+                }
+            }
+            """.trimIndent()
+
+        val parser = objectMapper.createParser(apiResponse)
+        val context = mock(DeserializationContext::class.java)
+        val priceResponse = deserializer.deserialize(parser, context)
+
+        assertEquals(1, priceResponse.data.size)
+        val marketData = priceResponse.data.first()
+
+        assertEquals("^GSPC", marketData.asset.code)
+        assertEquals(BigDecimal("5808.1200"), marketData.close)
+        assertEquals(0, marketData.volume)
+        assertEquals(AlphaPriceService.ID, marketData.source)
+    }
+
+    @Test
     fun `isSplit should return true for non-1 split coefficient`() {
         // Given: MarketData with split coefficient != 1
         val marketDataWithSplit =

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializerTest.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
 import com.beancounter.common.utils.BcJson
 import com.beancounter.marketdata.Constants.Companion.US
 import com.fasterxml.jackson.databind.DeserializationContext
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -272,13 +273,13 @@ class AlphaPriceDeserializerTest {
         val context = mock(DeserializationContext::class.java)
         val priceResponse = deserializer.deserialize(parser, context)
 
-        assertEquals(1, priceResponse.data.size)
+        assertThat(priceResponse.data).hasSize(1)
         val marketData = priceResponse.data.first()
 
-        assertEquals("^GSPC", marketData.asset.code)
-        assertEquals(BigDecimal("5808.1200"), marketData.close)
-        assertEquals(0, marketData.volume)
-        assertEquals(AlphaPriceService.ID, marketData.source)
+        assertThat(marketData.asset.code).isEqualTo("^GSPC")
+        assertThat(marketData.close).isEqualByComparingTo(BigDecimal("5808.1200"))
+        assertThat(marketData.volume).isEqualTo(0)
+        assertThat(marketData.source).isEqualTo(AlphaPriceService.ID)
     }
 
     @Test

--- a/svc-data/src/test/resources/application-h2db.yaml
+++ b/svc-data/src/test/resources/application-h2db.yaml
@@ -38,6 +38,8 @@ spring:
       bindings: {}
 beancounter:
   enricher: DEFAULT
+  indices:
+    seed-on-startup: false
 
   market.providers:
     alpha:

--- a/svc-data/src/test/resources/application-test.yaml
+++ b/svc-data/src/test/resources/application-test.yaml
@@ -29,6 +29,8 @@ spring:
 
 beancounter:
   enricher: DEFAULT
+  indices:
+    seed-on-startup: false
   market.providers:
     alpha:
       markets: NASDAQ,AMEX,NYSE,ASX,LON,US

--- a/svc-data/src/test/resources/mock/alpha/gspc-global.json
+++ b/svc-data/src/test/resources/mock/alpha/gspc-global.json
@@ -1,0 +1,14 @@
+{
+  "Global Quote": {
+    "01. symbol": "^GSPC",
+    "02. open": "5780.4400",
+    "03. high": "5810.6300",
+    "04. low": "5777.4500",
+    "05. price": "5808.1200",
+    "06. volume": "0",
+    "07. latest trading day": "2026-05-07",
+    "08. previous close": "5793.7500",
+    "09. change": "14.3700",
+    "10. change percent": "0.2480%"
+  }
+}

--- a/svc-data/src/test/resources/mock/alpha/gspc-historic.json
+++ b/svc-data/src/test/resources/mock/alpha/gspc-historic.json
@@ -1,0 +1,25 @@
+{
+  "Meta Data": {
+    "1. Information": "Daily Prices (open, high, low, close) and Volumes",
+    "2. Symbol": "^GSPC",
+    "3. Last Refreshed": "2026-05-07",
+    "4. Output Size": "Compact",
+    "5. Time Zone": "US/Eastern"
+  },
+  "Time Series (Daily)": {
+    "2026-05-07": {
+      "1. open": "5780.4400",
+      "2. high": "5810.6300",
+      "3. low": "5777.4500",
+      "4. close": "5808.1200",
+      "5. volume": "0"
+    },
+    "2026-05-06": {
+      "1. open": "5775.1000",
+      "2. high": "5795.2500",
+      "3. low": "5770.0000",
+      "4. close": "5793.7500",
+      "5. volume": "0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds market index assets (^GSPC, ^IXIC, ^DJI, ^FTSE) as a new `INDEX` `AssetCategory` on a synthetic `INDEX` market, priced via Alpha Vantage `TIME_SERIES_DAILY` (the `_ADJUSTED` endpoint errors for indices).
- Pre-seeds indices at startup via `IndexSeedRunner` (idempotent; gated by `beancounter.indices.seed-on-startup`).
- Wires indices into `PriceRefresh.updatePrices()` so benchmarks refresh on schedule even without holdings.

## Why
Provide benchmark prices alongside held assets for comparison/reporting, reusing existing `Asset` model and Alpha Vantage integration — no parallel entity, no DB migration.

## Wiring
- `AssetCategory.INDEX` + `REPORT_INDEX` in jar-common.
- `INDEX` market (USD, US/Eastern, `DEFAULT` enricher, `active: false`) added to `alpha.markets`.
- `AlphaConfig.getPriceCode` short-circuits `^`-prefix codes (kills `^GSPC.INDEX` bug).
- `AlphaPriceService.backFill` routes `INDEX` category to `getHistoric` (TIME_SERIES_DAILY) instead of `getAdjusted`.
- `AlphaCorporateEventEnricher` skips enrichment for `INDEX` category (no `getEvents` call — indices have no divs/splits).

## Pre-seed
- `beancounter.indices.values` yml block lists indices with `code`, `name`, `currency`.
- `IndexConfig` `@ConfigurationProperties` binds the list.
- `IndexSeedRunner` `ApplicationRunner` creates assets via `AssetService.handle` (idempotent via `findLocally` short-circuit).
- Test profiles set `beancounter.indices.seed-on-startup: false` to keep `CurrencyService`-mocking tests stable.

## Scheduled refresh
- `AssetRepository.findActiveIndexAssets()` JPQL — returns active `INDEX` market assets regardless of holdings.
- `PriceRefresh.updatePrices()` unions held + index assets, deduped by id.

## Test plan
- [x] `:jar-common:test` — `AssetCategoryTest` for new constant + mapping.
- [x] `:svc-data:test` — all new tests green:
  - `AlphaConfigTest` — `^`-prefix pass-through + market-suffix regression.
  - `AlphaPriceDeserializerTest` — `^GSPC` Global Quote round-trip.
  - `AlphaCorporateEventEnricherTest` — `INDEX` category skips enricher.
  - `AlphaIndexBackFillTest` — `backFill` routes to `getHistoric` for `INDEX`.
  - `AssetControllerTest` — POST and GET (with `^`-prefix path param) for `INDEX` assets.
  - `IndexConfigTest`, `IndexSeedRunnerTest` — yml binding + idempotent seed.
  - `AlphaIndexApiTest` (WireMock) — full E2E backFill via `TIME_SERIES_DAILY`.
  - `PriceRefreshTest` — `findActiveIndexAssets` + index assets enrolled in refresh.
- [x] `formatKotlin lintKotlin` clean.
- [ ] One pre-existing flaky `PriceRefreshTest.updatePrices` failure — broken on `main` before this branch (verified via stash); not introduced here.

## Follow-ups (out of scope)
- Per-index timezone (e.g. `^FTSE` on Europe/London) — currently all indices share `INDEX` market's `US/Eastern`. Address when adding more non-US indices.
- bc-view rendering for `effectiveReportCategory == "Index"`.
- AlphaVantage `SYMBOL_SEARCH` doesn't return index symbols — pre-seed is the only way to register them (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive index asset support (S&P 500, NASDAQ Composite, Dow Jones, FTSE 100) and an INDEX market category
  * Pre-configured index assets can be seeded at startup and are configurable
  * Index benchmark prices are included in daily price refreshes

* **Tests**
  * Added end-to-end and unit tests covering index seeding, pricing, lookup, and provider behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->