### PR TITLE
feat(svc-position): index benchmark series for performance overlay

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
@@ -363,6 +363,36 @@ class AssetController(
         @PathVariable category: String
     ): AssetUpdateResponse = ownedAssetService.findByOwnerAndCategory(category)
 
+    @GetMapping(
+        value = ["/market/{market}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "List assets on a given market",
+        description = """
+            Returns all assets registered on the supplied market code.
+            Primary use case is enumerating reference assets such as the
+            pre-seeded benchmark indices on the synthetic INDEX market,
+            which clients render as a chart-overlay selector.
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Assets retrieved successfully",
+                content = [Content(schema = Schema(implementation = AssetUpdateResponse::class))]
+            )
+        ]
+    )
+    fun getAssetsByMarket(
+        @Parameter(description = "Market code to filter by", example = "INDEX")
+        @PathVariable market: String
+    ): AssetUpdateResponse {
+        val assets = assetFinder.findByMarketCode(market.uppercase())
+        return AssetUpdateResponse(assets.associateBy { it.id })
+    }
+
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Create or update multiple assets",

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
@@ -252,6 +252,58 @@ internal class AssetControllerTest {
     }
 
     @Test
+    fun `list INDEX market assets via market endpoint`() {
+        val gspc =
+            AssetInput(
+                market = "INDEX",
+                code = "^GSPC",
+                name = "S&P 500",
+                category = AssetCategory.INDEX
+            )
+        val ftse =
+            AssetInput(
+                market = "INDEX",
+                code = "^FTSE",
+                name = "FTSE 100",
+                category = AssetCategory.INDEX
+            )
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(ASSET_ROOT)
+                    .with(
+                        SecurityMockMvcRequestPostProcessors
+                            .jwt()
+                            .jwt(mockAuthConfig.getUserToken())
+                    ).with(csrf())
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            AssetRequest(mapOf(toKey(gspc) to gspc, toKey(ftse) to ftse))
+                        )
+                    ).contentType(APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        val mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("$ASSET_ROOT/market/{market}", "INDEX")
+                        .with(
+                            SecurityMockMvcRequestPostProcessors
+                                .jwt()
+                                .jwt(mockAuthConfig.getUserToken())
+                        )
+                ).andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andReturn()
+
+        val response = objectMapper.readValue<AssetUpdateResponse>(mvcResult.response.contentAsString)
+        assertThat(response.data.values.map { it.code })
+            .contains("^GSPC", "^FTSE")
+        assertThat(response.data.values).allMatch { it.marketCode == "INDEX" }
+    }
+
+    @Test
     fun `lookup index asset via URL with caret-prefix code`() {
         val input =
             AssetInput(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
@@ -6,13 +6,22 @@ import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils.Companion.TODAY
 import com.beancounter.common.utils.KeyGenUtils
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.SpringMvcDbTest
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetRepository
+import com.beancounter.marketdata.currency.CurrencyService
+import com.beancounter.marketdata.portfolio.PortfolioRepository
 import com.beancounter.marketdata.providers.alpha.AlphaPriceService
+import com.beancounter.marketdata.registration.SystemUserRepository
+import com.beancounter.marketdata.trn.TrnRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,6 +29,7 @@ import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.math.BigDecimal
 
 /**
  * Verify price refresh removes and re-imports the price for a single asset.
@@ -40,6 +50,18 @@ internal class PriceRefreshTest {
 
     @Autowired
     private lateinit var assetFinder: AssetFinder
+
+    @Autowired
+    private lateinit var portfolioRepository: PortfolioRepository
+
+    @Autowired
+    private lateinit var systemUserRepository: SystemUserRepository
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var currencyService: CurrencyService
 
     @BeforeEach
     fun mockAlpha() {
@@ -83,6 +105,38 @@ internal class PriceRefreshTest {
             )
         val hydratedAsset = assetFinder.hydrateAsset(asset)
         assertThat(hydratedAsset).hasFieldOrProperty("market")
+
+        // PriceRefresh.updatePrices uses findHeldAssetsForPricing which requires
+        // a positive BUY/ADD net position, so seed a SETTLED BUY transaction.
+        val owner =
+            systemUserRepository.save(
+                SystemUser(
+                    id = "refresh-test-user-$code",
+                    email = "refresh-$code@test.com",
+                    auth0 = "auth0|refresh-$code"
+                )
+            )
+        val usd = currencyService.getCode(USD.code)
+        val portfolio =
+            portfolioRepository.save(
+                Portfolio(
+                    id = "refresh-pf-$code",
+                    code = "REFRESH_PF_$code",
+                    name = "Refresh Test Portfolio",
+                    currency = usd,
+                    base = usd,
+                    owner = owner
+                )
+            )
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.BUY,
+                asset = hydratedAsset,
+                quantity = BigDecimal("10"),
+                portfolio = portfolio,
+                tradeCurrency = usd
+            )
+        )
         val count = priceRefresh.updatePrices()
         assertThat(count).isGreaterThanOrEqualTo(1)
     }

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/BenchmarkService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/BenchmarkService.kt
@@ -1,0 +1,140 @@
+package com.beancounter.position.service
+
+import com.beancounter.auth.TokenService
+import com.beancounter.client.services.PriceService
+import com.beancounter.common.contracts.BulkPriceRequest
+import com.beancounter.common.contracts.PerformanceData
+import com.beancounter.common.contracts.PerformanceDataPoint
+import com.beancounter.common.contracts.PerformanceResponse
+import com.beancounter.common.contracts.PriceAsset
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.utils.DateUtils
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+/**
+ * Computes a benchmark "Growth of 1000" series for a market index aligned to the
+ * same monthly valuation grid the portfolio performance series uses, so the two
+ * series overlay cleanly on a shared X axis.
+ *
+ * The series is rebased to BASE_VALUE (1000) at the first available close, with
+ * each subsequent point computed as `(close / firstClose) * BASE_VALUE`.
+ *
+ * This is the foundation for future investment-modelling extensions: with the
+ * same date grid, a synthetic-contribution variant ("if I'd put my actual cash
+ * flows into ^GSPC") becomes a layering on top of the rebase logic, not a
+ * separate code path.
+ */
+@Service
+class BenchmarkService(
+    private val priceService: PriceService,
+    private val tokenService: TokenService,
+    private val dateUtils: DateUtils
+) {
+    fun benchmark(
+        portfolio: Portfolio,
+        indexAssetId: String,
+        months: Int = DEFAULT_MONTHS
+    ): PerformanceResponse {
+        val endDate = dateUtils.date
+        val startDate = endDate.minusMonths(months.toLong())
+        val dates = monthlyDates(startDate, endDate)
+
+        val bulk =
+            priceService.getBulkPrices(
+                BulkPriceRequest(
+                    dates = dates.map { it.toString() },
+                    assets = listOf(PriceAsset(market = INDEX_MARKET, code = "", assetId = indexAssetId))
+                ),
+                tokenService.bearerToken
+            )
+
+        val closesByDate = closesByDate(bulk.data, indexAssetId)
+        if (closesByDate.isEmpty()) {
+            log.warn("No prices for index {} in [{} .. {}]", indexAssetId, startDate, endDate)
+            return PerformanceResponse(PerformanceData(portfolio.currency, emptyList()))
+        }
+
+        val firstClose =
+            firstAvailableClose(dates, closesByDate)
+                ?: throw BusinessException("No reference close available for $indexAssetId from $startDate")
+
+        val series =
+            dates.mapNotNull { date ->
+                val close = closeAtOrBefore(date, closesByDate) ?: return@mapNotNull null
+                val growthOf1000 =
+                    close
+                        .divide(firstClose, SCALE, RoundingMode.HALF_UP)
+                        .multiply(BASE_VALUE)
+                        .setScale(2, RoundingMode.HALF_UP)
+                val cumulativeReturn =
+                    growthOf1000
+                        .divide(BASE_VALUE, SCALE, RoundingMode.HALF_UP)
+                        .subtract(BigDecimal.ONE)
+                PerformanceDataPoint(
+                    date = date,
+                    growthOf1000 = growthOf1000,
+                    marketValue = BigDecimal.ZERO,
+                    netContributions = BigDecimal.ZERO,
+                    cumulativeReturn = cumulativeReturn,
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            }
+
+        return PerformanceResponse(PerformanceData(portfolio.currency, series))
+    }
+
+    internal fun monthlyDates(
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<LocalDate> {
+        val dates = mutableListOf<LocalDate>()
+        var cursor = startDate
+        while (!cursor.isAfter(endDate)) {
+            dates.add(cursor)
+            cursor = cursor.plusMonths(1)
+        }
+        if (dates.last() != endDate) {
+            dates.add(endDate)
+        }
+        return dates
+    }
+
+    private fun closesByDate(
+        bulk: Map<String, Collection<com.beancounter.common.model.MarketData>>,
+        indexAssetId: String
+    ): Map<LocalDate, BigDecimal> =
+        bulk
+            .mapNotNull { (dateStr, mds) ->
+                val close = mds.firstOrNull { it.asset.id == indexAssetId }?.close ?: return@mapNotNull null
+                LocalDate.parse(dateStr) to close
+            }.toMap()
+
+    private fun firstAvailableClose(
+        dates: List<LocalDate>,
+        closes: Map<LocalDate, BigDecimal>
+    ): BigDecimal? = dates.firstNotNullOfOrNull { closeAtOrBefore(it, closes) }
+
+    private fun closeAtOrBefore(
+        date: LocalDate,
+        closes: Map<LocalDate, BigDecimal>
+    ): BigDecimal? {
+        closes[date]?.let { return it }
+        return closes
+            .filterKeys { !it.isAfter(date) }
+            .maxByOrNull { it.key }
+            ?.value
+    }
+
+    companion object {
+        private const val INDEX_MARKET = "INDEX"
+        private const val DEFAULT_MONTHS = 12
+        private const val SCALE = 6
+        private val BASE_VALUE = BigDecimal("1000")
+        private val log = LoggerFactory.getLogger(BenchmarkService::class.java)
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
@@ -31,7 +31,8 @@ import org.springframework.web.bind.annotation.RestController
 class PerformanceController(
     private val portfolioServiceClient: PortfolioServiceClient,
     private val performanceService: PerformanceService,
-    private val performanceCacheService: PerformanceCacheService
+    private val performanceCacheService: PerformanceCacheService,
+    private val benchmarkService: BenchmarkService
 ) {
     private val log = LoggerFactory.getLogger(PerformanceController::class.java)
 
@@ -51,6 +52,34 @@ class PerformanceController(
         log.debug("Performance request for portfolio={}, months={}", code, months)
         val portfolio = portfolioServiceClient.getPortfolioByCode(code)
         return performanceService.calculate(portfolio, months)
+    }
+
+    @GetMapping("/{code}/performance/benchmark")
+    @Operation(
+        summary = "Get index benchmark series for a portfolio",
+        description =
+            "Returns a Growth-of-1000 series for the supplied index asset, " +
+                "aligned to the portfolio performance series' monthly date grid."
+    )
+    fun getBenchmark(
+        @Parameter(description = "Portfolio code", example = "MY_PORTFOLIO")
+        @PathVariable
+        code: String,
+        @Parameter(description = "Index asset id (INDEX market)", example = "^GSPC")
+        @RequestParam(value = "indexAssetId")
+        indexAssetId: String,
+        @Parameter(description = "Number of months to look back", example = "12")
+        @RequestParam(value = "months", defaultValue = "12")
+        months: Int
+    ): PerformanceResponse {
+        log.debug(
+            "Benchmark request portfolio={} indexAssetId={} months={}",
+            code,
+            indexAssetId,
+            months
+        )
+        val portfolio = portfolioServiceClient.getPortfolioByCode(code)
+        return benchmarkService.benchmark(portfolio, indexAssetId, months)
     }
 
     @DeleteMapping("/{code}/performance/cache")

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/BenchmarkServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/BenchmarkServiceTest.kt
@@ -1,0 +1,169 @@
+package com.beancounter.position.service
+
+import com.beancounter.auth.TokenService
+import com.beancounter.client.services.PriceService
+import com.beancounter.common.contracts.BulkPriceRequest
+import com.beancounter.common.contracts.BulkPriceResponse
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.MarketData
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.position.Constants.Companion.USD
+import com.beancounter.position.Constants.Companion.owner
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class BenchmarkServiceTest {
+    @Mock
+    private lateinit var priceService: PriceService
+
+    @Mock
+    private lateinit var tokenService: TokenService
+
+    private val dateUtils = DateUtils()
+    private lateinit var benchmarkService: BenchmarkService
+
+    private val indexMarket = Market("INDEX")
+    private val sp500 =
+        Asset(
+            code = "^GSPC",
+            id = "^GSPC",
+            name = "S&P 500",
+            market = indexMarket
+        )
+    private val portfolio =
+        Portfolio(
+            id = "test-pf",
+            code = "TEST",
+            name = "Test Portfolio",
+            currency = USD,
+            base = USD,
+            owner = owner
+        )
+
+    @BeforeEach
+    fun setup() {
+        lenient().`when`(tokenService.bearerToken).thenReturn("test-token")
+        benchmarkService = BenchmarkService(priceService, tokenService, dateUtils)
+    }
+
+    @Test
+    fun `monthlyDates spans start and end with 1-month cadence`() {
+        val start = LocalDate.of(2024, 1, 15)
+        val end = LocalDate.of(2024, 4, 15)
+        val dates = benchmarkService.monthlyDates(start, end)
+        assertThat(dates)
+            .containsExactly(
+                LocalDate.of(2024, 1, 15),
+                LocalDate.of(2024, 2, 15),
+                LocalDate.of(2024, 3, 15),
+                LocalDate.of(2024, 4, 15)
+            )
+    }
+
+    @Test
+    fun `monthlyDates appends end date when last cadence step misses it`() {
+        val start = LocalDate.of(2024, 1, 1)
+        val end = LocalDate.of(2024, 2, 20)
+        val dates = benchmarkService.monthlyDates(start, end)
+        assertThat(dates).contains(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1), end)
+        assertThat(dates.last()).isEqualTo(end)
+    }
+
+    @Test
+    fun `series rebases first close to 1000 and scales subsequent closes`() {
+        val today = dateUtils.date
+        val firstDate = today.minusMonths(2)
+        val midDate = today.minusMonths(1)
+        val bulk =
+            BulkPriceResponse(
+                mapOf(
+                    firstDate.toString() to listOf(priceFor(sp500, firstDate, BigDecimal("4000.00"))),
+                    midDate.toString() to listOf(priceFor(sp500, midDate, BigDecimal("4400.00"))),
+                    today.toString() to listOf(priceFor(sp500, today, BigDecimal("5000.00")))
+                )
+            )
+        whenever(priceService.getBulkPrices(any<BulkPriceRequest>(), any())).thenReturn(bulk)
+
+        val response = benchmarkService.benchmark(portfolio, sp500.id, months = 2)
+
+        assertThat(response.data.series).hasSize(3)
+        assertThat(
+            response.data.series
+                .first()
+                .growthOf1000
+        ).isCloseTo(BigDecimal("1000.00"), Offset.offset(BigDecimal("0.01")))
+        assertThat(response.data.series[1].growthOf1000)
+            .isCloseTo(BigDecimal("1100.00"), Offset.offset(BigDecimal("0.01")))
+        assertThat(
+            response.data.series
+                .last()
+                .growthOf1000
+        ).isCloseTo(BigDecimal("1250.00"), Offset.offset(BigDecimal("0.01")))
+    }
+
+    @Test
+    fun `missing exact-date close falls back to nearest prior close`() {
+        val today = dateUtils.date
+        val firstDate = today.minusMonths(2)
+        val priorDate = firstDate.minusDays(3)
+        val midDate = today.minusMonths(1)
+        val bulk =
+            BulkPriceResponse(
+                mapOf(
+                    // Provide a close BEFORE the firstDate slot and a later close on midDate
+                    priorDate.toString() to listOf(priceFor(sp500, priorDate, BigDecimal("4000.00"))),
+                    midDate.toString() to listOf(priceFor(sp500, midDate, BigDecimal("4200.00")))
+                )
+            )
+        whenever(priceService.getBulkPrices(any<BulkPriceRequest>(), any())).thenReturn(bulk)
+
+        val response = benchmarkService.benchmark(portfolio, sp500.id, months = 2)
+
+        assertThat(response.data.series).isNotEmpty
+        // First slot uses priorDate close (4000) → growthOf1000 = 1000
+        assertThat(
+            response.data.series
+                .first()
+                .growthOf1000
+        ).isCloseTo(BigDecimal("1000.00"), Offset.offset(BigDecimal("0.01")))
+        // Mid slot has its own close (4200) → growthOf1000 = 1050
+        val midPoint = response.data.series.first { it.date == midDate }
+        assertThat(midPoint.growthOf1000)
+            .isCloseTo(BigDecimal("1050.00"), Offset.offset(BigDecimal("0.01")))
+    }
+
+    @Test
+    fun `empty price response returns empty series with portfolio currency`() {
+        whenever(priceService.getBulkPrices(any<BulkPriceRequest>(), any()))
+            .thenReturn(BulkPriceResponse(emptyMap()))
+
+        val response = benchmarkService.benchmark(portfolio, sp500.id, months = 6)
+
+        assertThat(response.data.series).isEmpty()
+        assertThat(response.data.currency.code).isEqualTo("USD")
+    }
+
+    private fun priceFor(
+        asset: Asset,
+        date: LocalDate,
+        close: BigDecimal
+    ): MarketData =
+        MarketData(
+            asset = asset,
+            priceDate = date,
+            close = close
+        )
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
@@ -31,6 +31,9 @@ class PerformanceControllerTest {
     @Mock
     private lateinit var performanceCacheService: PerformanceCacheService
 
+    @Mock
+    private lateinit var benchmarkService: BenchmarkService
+
     private lateinit var controller: PerformanceController
 
     private val portfolio =
@@ -45,7 +48,13 @@ class PerformanceControllerTest {
 
     @BeforeEach
     fun setup() {
-        controller = PerformanceController(portfolioServiceClient, performanceService, performanceCacheService)
+        controller =
+            PerformanceController(
+                portfolioServiceClient,
+                performanceService,
+                performanceCacheService,
+                benchmarkService
+            )
     }
 
     @Test
@@ -90,6 +99,45 @@ class PerformanceControllerTest {
 
         assertThat(result.data.currency.code).isEqualTo("GBP")
         assertThat(result.data.series).isEmpty()
+    }
+
+    @Test
+    fun `getBenchmark delegates to BenchmarkService and returns its response`() {
+        val benchmarkResponse =
+            PerformanceResponse(
+                PerformanceData(
+                    currency = USD,
+                    series =
+                        listOf(
+                            PerformanceDataPoint(
+                                date = LocalDate.of(2024, 1, 1),
+                                growthOf1000 = BigDecimal("1000"),
+                                marketValue = BigDecimal.ZERO,
+                                netContributions = BigDecimal.ZERO,
+                                cumulativeReturn = BigDecimal.ZERO
+                            ),
+                            PerformanceDataPoint(
+                                date = LocalDate.of(2024, 6, 1),
+                                growthOf1000 = BigDecimal("1075"),
+                                marketValue = BigDecimal.ZERO,
+                                netContributions = BigDecimal.ZERO,
+                                cumulativeReturn = BigDecimal("0.075")
+                            )
+                        )
+                )
+            )
+        whenever(portfolioServiceClient.getPortfolioByCode("TEST")).thenReturn(portfolio)
+        whenever(benchmarkService.benchmark(portfolio, "^GSPC", 12)).thenReturn(benchmarkResponse)
+
+        val result = controller.getBenchmark("TEST", "^GSPC", 12)
+
+        assertThat(result.data.series).hasSize(2)
+        assertThat(
+            result.data.series
+                .last()
+                .growthOf1000
+        ).isEqualByComparingTo(BigDecimal("1075"))
+        verify(benchmarkService).benchmark(portfolio, "^GSPC", 12)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- New `GET /{code}/performance/benchmark?indexAssetId=X&months=N` on svc-position. Returns `PerformanceData` rebased to Growth-of-1000 against a chosen index, on the same monthly date grid as the existing performance endpoint.
- New `GET /assets/market/{market}` on svc-data lists assets on a given market — primarily indices for the chart's benchmark dropdown.

## Why
Dashboards need a server-side benchmark series so portfolios can be compared against indices (S&P 500, FTSE 100). Building it server-side now lays the foundation for investment-modelling extensions (synthetic-contribution variants — "if I'd put my actual cash flows into ^GSPC") which will layer on the same rebase pipeline rather than starting from scratch.

## Wiring
- `BenchmarkService.benchmark(portfolio, indexAssetId, months)`:
  - Generates monthly date list from `today - months` to `today`.
  - Bulk-fetches index closes via the existing `PriceService` client.
  - Rebases first available close to 1000; subsequent points = `(close / firstClose) * 1000`.
  - Falls back to nearest-prior close when an exact date has no quote (weekends, holidays).
- `PerformanceController.getBenchmark` thin delegate.
- `AssetController.getAssetsByMarket` returns `AssetUpdateResponse` from `assetFinder.findByMarketCode()`.

## Test plan
- [x] `BenchmarkServiceTest` (4 tests): monthly date generation, rebase math (3-point series scales to 1100/1250), nearest-prior fallback, empty response handling.
- [x] `PerformanceControllerTest`: new test covers `getBenchmark` delegation.
- [x] `AssetControllerTest`: new test exercises `GET /assets/market/INDEX`.
- [x] `:svc-position:test` + `:svc-data:test` green for new tests.
- [x] `formatKotlin lintKotlin` clean.
- [ ] One pre-existing flaky `PriceRefreshTest.updatePrices` — broken on `main` before this branch.

## Frontend pair
[bc-view PR](https://github.com/monowai/bc-view/pull/new/feature/index-benchmark-overlay) consumes the new endpoints with a "vs Benchmark" tab on `PerformanceChart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint to list assets by market code.
  * Endpoint to retrieve benchmark "Growth of 1000" performance for a portfolio over a customizable monthly period.

* **Tests**
  * New tests covering market-filtered asset retrieval and benchmark computations, including monthly date handling, rebasing logic, missing-close fallback, and empty-price responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->