### PR TITLE
feat(svc-agent): pair analyst price targets with current close

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -105,7 +105,22 @@ object DomainSystemPrompts {
           Show ratios as percentages when discussing performance. ROI,
           dividend yield, and trade currency are not exposed — never
           claim them.
+        - `getCurrentPrice(market, code)` — single-asset spot price for
+          assets the user does not yet hold (positions tool only
+          returns held assets). Use this when grounding any
+          forward-looking statement.
         - `listMarkets`, `listCurrencies`, `getFxRate(from, to, date?)`.
+
+        ### Analyst price targets
+
+        Whenever a price target appears (in news output, in user input,
+        or surfaced via Asset Review), pair it with the current close
+        from `priceClose` (positions) or `getCurrentPrice` and compute
+        the implied price growth: `(target − close) / close`. Frame
+        explicitly, e.g. "Analyst target $200 vs current close $180 →
+        implied +11.1%". Never quote a target in isolation; the user
+        must see what magnitude of growth is being predicted. Attribute
+        the target to its source — it is the analyst's claim, not BC's.
 
         ### Workflow
 
@@ -152,6 +167,10 @@ object DomainSystemPrompts {
         - `getPortfolio(code)` — portfolio metadata + XIRR (ratio).
         - `getPositions(code)` — positions in ratio/weight/yield form only.
           See Wealth domain for the exact field shape.
+        - `getCurrentPrice(market, code)` — single-asset spot price.
+          Pair this with any analyst price target the user mentions so
+          the implied growth `(target − close) / close` is always
+          visible. Never quote a target without the current close.
         - `listMarkets`, `listCurrencies`, `getFxRate(from, to, date?)`.
 
         ### Workflow
@@ -366,10 +385,16 @@ object DomainSystemPrompts {
           record date, frequency, "first-ever" / "inaugural" / "initial",
           yield, payout ratio).
         - Do NOT make any factual claim about a split, buyback, earnings
-          number, price target, or upcoming corporate event.
+          number, or upcoming corporate event.
         - If the news articles themselves mention such a fact, you may
           surface it as a news headline (attributed to the article), but
           NEVER restate it as fact in your own analysis.
+        - Analyst price targets are the one numeric exception: when an
+          article cites a target, surface it attributed to the analyst /
+          firm and ALWAYS pair it with the current close (call
+          `getCurrentPrice(market, code)`) so the implied growth
+          `(target − close) / close` is visible. Never quote a target in
+          isolation.
         - For dividend / event history the user must navigate to the Asset
           Review or a portfolio context — say so if asked.
 
@@ -408,6 +433,9 @@ object DomainSystemPrompts {
         - `getNews(ticker, market?, topics?)` — recent news + sentiment.
         - `getAssetEvents(ticker)` — dividends, splits, other corporate
           actions on this ticker.
+        - `getCurrentPrice(market, code)` — current close, prior close,
+          intraday change %. Required for grounding any forward-looking
+          framing such as analyst price targets.
         - `listMarkets`, `listCurrencies`, `getFxRate(from, to, date?)` —
           market metadata for context.
         - `getPortfolio(code)`, `getPositions(code)` — only if the user
@@ -420,7 +448,12 @@ object DomainSystemPrompts {
            general knowledge clearly labelled.
         2. Call `getAssetEvents(ticker)` to surface recent dividend / split
            cadence — useful for income-focused users.
-        3. Synthesise: company + sector summary, what's happening now,
+        3. If a news article cites an analyst price target, call
+           `getCurrentPrice(market, code)` and pair the target with the
+           current close so the implied growth `(target − close) / close`
+           is visible. Attribute the target to the article — it is the
+           analyst's claim, not BC's.
+        4. Synthesise: company + sector summary, what's happening now,
            recent corporate-action pattern, qualitative risk callouts.
 
         ### Output

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/MarketTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/MarketTools.kt
@@ -3,25 +3,31 @@ package com.beancounter.agent.tools
 import com.beancounter.auth.TokenService
 import com.beancounter.client.FxService
 import com.beancounter.client.MarketService
+import com.beancounter.client.services.PriceService
 import com.beancounter.client.services.StaticService
 import com.beancounter.common.contracts.CurrencyResponse
 import com.beancounter.common.contracts.FxRequest
 import com.beancounter.common.contracts.FxResponse
 import com.beancounter.common.contracts.MarketResponse
+import com.beancounter.common.contracts.PriceAsset
+import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.model.IsoCurrencyPair
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
 
 /**
- * Tools for static reference data (markets, currencies) and FX rates.
+ * Tools for static reference data (markets, currencies), FX rates, and
+ * single-asset spot price lookups for AI grounding.
  */
 @Service
 class MarketTools(
     private val marketService: MarketService,
     private val staticService: StaticService,
     private val fxService: FxService,
-    private val tokenService: TokenService
+    private val tokenService: TokenService,
+    private val priceService: PriceService
 ) {
     @Tool(description = MARKETS_DESC)
     fun listMarkets(): MarketResponse = marketService.getMarkets()
@@ -43,6 +49,33 @@ class MarketTools(
         return fxService.getRates(request, tokenService.bearerToken)
     }
 
+    @Tool(description = PRICE_DESC)
+    fun getCurrentPrice(
+        @ToolParam(description = "Market code, e.g. NASDAQ, NZX, ASX") market: String,
+        @ToolParam(description = "Asset code as listed on that market, e.g. AAPL") code: String
+    ): CurrentPrice {
+        val response =
+            priceService.getPrices(
+                PriceRequest(
+                    date = "today",
+                    assets = listOf(PriceAsset(market = market, code = code)),
+                    currentMode = true
+                ),
+                tokenService.bearerToken
+            )
+        val md =
+            response.data.firstOrNull()
+                ?: throw IllegalStateException("No price data for $market:$code")
+        return CurrentPrice(
+            assetCode = md.asset.code,
+            market = md.asset.market.code,
+            priceClose = md.close,
+            previousClose = md.previousClose,
+            changePercent = md.changePercent,
+            priceDate = md.priceDate.toString()
+        )
+    }
+
     companion object {
         const val MARKETS_DESC =
             "List every market Beancounter knows about (NASDAQ, NYSE, ASX, NZX, etc.) " +
@@ -50,5 +83,26 @@ class MarketTools(
         const val FX_DESC =
             "Get the foreign exchange rate between two ISO currency codes on a given date. " +
                 "Returns the rate, the rate date and the provider."
+        const val PRICE_DESC =
+            "Get the current public market price for a single asset (close, prior close, " +
+                "intraday change %, price date). Use this to ground any forward-looking " +
+                "claim — for example, when a news article cites an analyst price target, " +
+                "call this to retrieve the current close so you can frame the implied " +
+                "growth percentage relative to today's price. Never quote a price target " +
+                "without also stating the current close."
     }
 }
+
+/**
+ * Compact projection of a single asset's spot price returned to the LLM.
+ * Mirrors the columnar fields the position tools already expose so the model
+ * sees a consistent vocabulary across tool outputs.
+ */
+data class CurrentPrice(
+    val assetCode: String,
+    val market: String,
+    val priceClose: BigDecimal,
+    val previousClose: BigDecimal,
+    val changePercent: BigDecimal,
+    val priceDate: String
+)

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ToolSelector.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ToolSelector.kt
@@ -36,9 +36,11 @@ class ToolSelector(
             page.contains("asset review") || page.contains("asset-review") -> {
                 (wealthTools + eventTools + newsTools).toTypedArray()
             }
-            // News & Sentiment — focused lookup, nothing else.
+            // News & Sentiment — focused lookup, plus marketTools so the
+            // model can ground analyst price targets surfaced in news
+            // articles against the current close.
             page.contains("news") && page.contains("sentiment") -> {
-                arrayOf(newsTools)
+                arrayOf(newsTools, marketTools)
             }
             // Independence — wealth + retirement planning.
             page.contains("independence") ||

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/MarketToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/MarketToolsTest.kt
@@ -1,0 +1,81 @@
+package com.beancounter.agent.tools
+
+import com.beancounter.auth.TokenService
+import com.beancounter.client.FxService
+import com.beancounter.client.MarketService
+import com.beancounter.client.services.PriceService
+import com.beancounter.client.services.StaticService
+import com.beancounter.common.contracts.PriceResponse
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.MarketData
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class MarketToolsTest {
+    @Mock
+    private lateinit var marketService: MarketService
+
+    @Mock
+    private lateinit var staticService: StaticService
+
+    @Mock
+    private lateinit var fxService: FxService
+
+    @Mock
+    private lateinit var tokenService: TokenService
+
+    @Mock
+    private lateinit var priceService: PriceService
+
+    private lateinit var marketTools: MarketTools
+
+    @BeforeEach
+    fun setup() {
+        lenient().`when`(tokenService.bearerToken).thenReturn("test-token")
+        marketTools = MarketTools(marketService, staticService, fxService, tokenService, priceService)
+    }
+
+    @Test
+    fun `getCurrentPrice returns close and changePercent for asset`() {
+        val asset = Asset(code = "AAPL", id = "aapl-id", market = Market("NASDAQ"))
+        val md =
+            MarketData(
+                asset = asset,
+                priceDate = LocalDate.of(2026, 5, 7),
+                close = BigDecimal("180.50"),
+                previousClose = BigDecimal("178.00"),
+                change = BigDecimal("2.50"),
+                changePercent = BigDecimal("0.014045")
+            )
+        whenever(priceService.getPrices(any(), any())).thenReturn(PriceResponse(listOf(md)))
+
+        val result = marketTools.getCurrentPrice("NASDAQ", "AAPL")
+
+        assertThat(result.assetCode).isEqualTo("AAPL")
+        assertThat(result.market).isEqualTo("NASDAQ")
+        assertThat(result.priceClose).isEqualByComparingTo(BigDecimal("180.50"))
+        assertThat(result.changePercent).isEqualByComparingTo(BigDecimal("0.014045"))
+        assertThat(result.priceDate).isEqualTo("2026-05-07")
+    }
+
+    @Test
+    fun `getCurrentPrice throws when no price data returned`() {
+        whenever(priceService.getPrices(any(), any())).thenReturn(PriceResponse(emptyList()))
+
+        assertThatThrownBy { marketTools.getCurrentPrice("NASDAQ", "GHOST") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("GHOST")
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ToolSelectorTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ToolSelectorTest.kt
@@ -28,9 +28,11 @@ class ToolSelectorTest {
         )
 
     @Test
-    fun `news sentiment page only ships news tools`() {
+    fun `news sentiment page ships news and market tools`() {
+        // marketTools is included so the model can call getCurrentPrice
+        // when grounding analyst price targets surfaced in news articles.
         val tools = selector.selectTools(mapOf("page" to "News & Sentiment"))
-        assertThat(tools).containsExactly(newsTools)
+        assertThat(tools).containsExactlyInAnyOrder(newsTools, marketTools)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRefreshTest.kt
@@ -63,38 +63,56 @@ internal class PriceRefreshTest {
     @Autowired
     private lateinit var currencyService: CurrencyService
 
+    @Autowired
+    private lateinit var cacheManager: org.springframework.cache.CacheManager
+
     @BeforeEach
     fun mockAlpha() {
         Mockito.`when`(alphaPriceService.getId()).thenReturn(AlphaPriceService.ID)
+        // The MdFactory.getMarketDataProvider is @Cacheable("provider") and
+        // shared Spring contexts can carry over a real (non-mocked) provider
+        // proxy from a prior test class — making this test ignore the
+        // @MockitoBean replacement. Clearing the cache forces a fresh
+        // resolve, which goes through isMarketSupported on the mock.
+        cacheManager.getCache("provider")?.clear()
     }
 
     @Test
     fun updatePrices() {
         val keyGenUtils = KeyGenUtils()
         val code = keyGenUtils.id
+        // Mock by argument matcher — full-sweep ordering can resolve the
+        // PriceRequest with `resolvedAsset` populated, so equality matching
+        // on a literal request misses the call. Return a positive close so
+        // PriceRefresh counts the call as a successful fetch (close > 0).
         Mockito
             .`when`(
-                alphaPriceService.getMarketData(
-                    PriceRequest(
-                        TODAY,
-                        listOf(
-                            PriceAsset(
-                                NASDAQ.code,
-                                code = code
-                            )
-                        )
-                    )
-                )
+                alphaPriceService.getMarketData(org.mockito.kotlin.any())
             ).thenReturn(
                 listOf(
                     MarketData(
-                        Asset(
-                            code = "",
-                            market = NASDAQ
-                        )
+                        asset =
+                            Asset(
+                                code = code,
+                                market = NASDAQ
+                            ),
+                        close = BigDecimal("100.00")
                     )
                 )
             )
+        Mockito
+            .`when`(alphaPriceService.isMarketSupported(org.mockito.kotlin.any()))
+            .thenReturn(true)
+        // Mockito returns null for unstubbed LocalDate calls; getDate is
+        // dereferenced as a non-null parameter inside DateCache, so stub
+        // a deterministic date here.
+        Mockito
+            .`when`(
+                alphaPriceService.getDate(
+                    org.mockito.kotlin.any(),
+                    org.mockito.kotlin.any()
+                )
+            ).thenReturn(java.time.LocalDate.now())
         val asset =
             assetRepository.save(
                 Asset(
@@ -107,7 +125,10 @@ internal class PriceRefreshTest {
         assertThat(hydratedAsset).hasFieldOrProperty("market")
 
         // PriceRefresh.updatePrices uses findHeldAssetsForPricing which requires
-        // a positive BUY/ADD net position, so seed a SETTLED BUY transaction.
+        // a positive BUY/ADD net position, so seed a SETTLED BUY transaction
+        // and force a JPA flush. Without the explicit flush the test passes
+        // when run in isolation but the held-query intermittently misses the
+        // newly-saved trn when the class runs as part of the full sweep.
         val owner =
             systemUserRepository.save(
                 SystemUser(
@@ -137,6 +158,13 @@ internal class PriceRefreshTest {
                 tradeCurrency = usd
             )
         )
+
+        // Sanity: the asset must qualify as held before we exercise the
+        // refresh path. This makes the failure mode obvious if a future
+        // change breaks the held-query rather than the refresh logic.
+        assertThat(assetFinder.findHeldAssetsForPricing().map { it.id })
+            .contains(hydratedAsset.id)
+
         val count = priceRefresh.updatePrices()
         assertThat(count).isGreaterThanOrEqualTo(1)
     }


### PR DESCRIPTION
## Summary
- New `getCurrentPrice(market, code)` tool on `MarketTools` so the LLM can fetch a single asset's spot price (close, prior close, intraday change %, price date).
- `DomainSystemPrompts` updated across WEALTH / ASSET / ASSET_REVIEW / NEWS so any analyst price target is paired with the current close and the implied growth `(target − close) / close` is surfaced explicitly. Targets in isolation are still forbidden.
- `ToolSelector` ships `marketTools` to the news-only domain so the prompt is actionable there.
- Folds in a fix for the flaky `PriceRefreshTest.updatePrices` that's been failing on `main` in CircleCI.

## Why
Forward-looking claims (analyst targets) reaching the user without a current-price anchor leave the magnitude of the predicted growth invisible. Holdings analysis already ships `priceClose` for held assets via `getPositions`; for unheld assets the LLM had no way to fetch the current close — the new tool closes that gap, and the prompts now require the pairing.

## Wiring
- `MarketTools.getCurrentPrice` → `PriceService.getPrices(currentMode = true)` → bc-data. Returns `CurrentPrice(assetCode, market, priceClose, previousClose, changePercent, priceDate)`.
- News domain (`@MarketTools`-less previously) now ships `marketTools` so the prompt's "always pair the target with current close" rule is reachable.
- News prompt now permits citing targets when attributed AND paired; other corporate-action fact rules unchanged.

## Folded fix — `PriceRefreshTest.updatePrices`
The held-asset seed shipped in #832 wasn't fully isolated:
- `alphaPriceService.getMarketData` stubbed with a literal `PriceRequest` — full-sweep ordering populated `resolvedAsset`, so the matcher missed and Mockito returned `[]`.
- `getDate` was unstubbed (Mockito → null) → NPE in `MarketDataPriceProcessor.DateCache.addDate`.
- `MdFactory.getMarketDataProvider` is `@Cacheable("provider")` — shared Spring context could carry over a stale (real, not mocked) Alpha proxy.

Fix:
- Argument-matcher stubbing for `getMarketData` and `isMarketSupported`; positive close in the returned `MarketData` so `fetched` actually increments.
- Stub `getDate(any(), any())` returning `LocalDate.now()`.
- Clear the `provider` cache in `@BeforeEach` so each test gets a fresh resolve.
- Sanity assertion that the seeded asset is in `findHeldAssetsForPricing` before `updatePrices` runs — pinpoints held-query vs refresh-logic regressions next time.

## Test plan
- [x] `:svc-agent:test` — new `MarketToolsTest` (2) + updated `ToolSelectorTest` green.
- [x] `:svc-data:test --rerun-tasks` full sweep green (with the PriceRefreshTest fix).
- [x] `formatKotlin lintKotlin` clean.
- Note: occasional unrelated WireMock-port flakiness in `FigiAssetApiTest`/`AlphaPriceApiTest` observed across runs — pre-existing, separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added current price lookup capability to provide real-time asset pricing data.
  * Enhanced analyst price target presentation with mandatory grounding in current prices and explicit implied growth attribution.
  * Enabled price data access in News & Sentiment analysis pages.

* **Tests**
  * Added test coverage for price lookup and tool selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->