### PR TITLE
fix(svc-data): IndexSeedRunner null-guard + disable in contracts profile

### DIFF
--- a/svc-data/src/contractTest/resources/application-contracts.yaml
+++ b/svc-data/src/contractTest/resources/application-contracts.yaml
@@ -2,6 +2,11 @@ auth:
   enabled: false
   web: false
 beancounter:
+  indices:
+    # Contract-test profile mocks AssetService; the seed runner would
+    # NPE on the null AssetUpdateResponse. Indices aren't part of any
+    # contract, so disable.
+    seed-on-startup: false
   market:
     providers:
       mock:

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexSeedRunner.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/IndexSeedRunner.kt
@@ -54,7 +54,10 @@ class IndexSeedRunner(
                 AssetKeyUtils.toKey(input) to input
             }
         val response = assetService.handle(AssetRequest(inputs))
-        log.info("Seeded {} index assets", response.data.size)
+        // Defensive: contract / partial-context tests mock AssetService and
+        // the mock returns null. Don't fail startup over a missing seed.
+        val count = response?.data?.size ?: 0
+        log.info("Seeded {} index assets", count)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Main red on CircleCI (pipeline #3127). Root cause in svc-data contractTest: `IndexSeedRunner.seed` NPE'd because the contracts-profile mocked `AssetService.handle` returns null. 55 cascading `ApplicationContext failure threshold (1) exceeded` errors after the first context-load failed.
- The earlier flaky-test fix in #833 unblocked the build past `PriceRefreshTest`, exposing this latent issue (contractTest never previously ran on main).

## Fix
- `application-contracts.yaml`: set `beancounter.indices.seed-on-startup: false`. Indices aren't part of any contract.
- `IndexSeedRunner.seed`: null-coalesce on `response?.data?.size` so a mocked / partial-context `AssetService` can never crash startup.

## Test plan
- [x] `:svc-data:contractTest` green locally (was 55/58 failing).
- [x] `:svc-data:test` full sweep green.
- [x] `formatKotlin lintKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null pointer exception during index seeding on application startup, improving stability when seed data is unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->