### PR TITLE
feat(svc-data): scope param on /trns/proposed for managed portfolios

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/ProposedScope.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/ProposedScope.kt
@@ -1,0 +1,7 @@
+package com.beancounter.marketdata.trn
+
+enum class ProposedScope {
+    OWNED,
+    MANAGED,
+    ALL
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -535,7 +535,9 @@ class TrnController(
             )
         ]
     )
-    fun findProposed(): TrnResponse = TrnResponse(trnService.findProposedForUser())
+    fun findProposed(
+        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope
+    ): TrnResponse = TrnResponse(trnService.findProposedForUser(scope))
 
     @GetMapping(
         value = ["/proposed/count"],
@@ -560,7 +562,9 @@ class TrnController(
             )
         ]
     )
-    fun countProposed(): Map<String, Long> = mapOf("count" to trnService.countProposedForUser())
+    fun countProposed(
+        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope
+    ): Map<String, Long> = mapOf("count" to trnService.countProposedForUser(scope))
 
     @GetMapping(
         value = ["/settled"],

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -210,6 +210,32 @@ interface TrnRepository :
         owner: SystemUser
     ): Long
 
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset " +
+            "join fetch t.tradeCurrency " +
+            "join fetch t.portfolio " +
+            "left join fetch t.cashAsset " +
+            "left join fetch t.cashCurrency " +
+            "where t.status = ?1 " +
+            "and t.portfolio.id in ?2 " +
+            "order by t.tradeDate desc"
+    )
+    fun findByStatusAndPortfolioIdIn(
+        status: TrnStatus,
+        portfolioIds: Collection<String>
+    ): Collection<Trn>
+
+    @Query(
+        "select count(t) from Trn t " +
+            "where t.status = ?1 " +
+            "and t.portfolio.id in ?2"
+    )
+    fun countByStatusAndPortfolioIdIn(
+        status: TrnStatus,
+        portfolioIds: Collection<String>
+    ): Long
+
     /**
      * Find all transactions with a specific status and trade date for portfolios owned by the given user.
      * Used for showing settled transactions on a specific date across all portfolios.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -6,11 +6,13 @@ import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.input.TrnInput
 import com.beancounter.common.input.TrustedTrnEvent
 import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.ShareStatus
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -33,7 +35,8 @@ class TrnService(
     private val trnMigrator: TrnMigrator,
     private val assetFinder: AssetFinder,
     private val systemUserService: SystemUserService,
-    private val cacheInvalidationProducer: CacheInvalidationProducer
+    private val cacheInvalidationProducer: CacheInvalidationProducer,
+    private val portfolioShareRepository: PortfolioShareRepository
 ) {
     private val log = LoggerFactory.getLogger(TrnService::class.java)
 
@@ -120,24 +123,62 @@ class TrnService(
     }
 
     /**
-     * Find all PROPOSED transactions for the current user across all their portfolios.
+     * Find PROPOSED transactions for the current user.
+     *
+     * - OWNED: portfolios where current user is the owner (default historical behaviour).
+     * - MANAGED: portfolios shared with the current user via an ACTIVE PortfolioShare.
+     * - ALL: union of both.
      */
-    fun findProposedForUser(): Collection<Trn> {
+    fun findProposedForUser(scope: ProposedScope = ProposedScope.ALL): Collection<Trn> {
         val user = systemUserService.getOrThrow()
-        val results = trnRepository.findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
-        log.trace("proposed trns: ${results.size}")
-        return postProcess(results.toList())
+        val results = mutableMapOf<String, Trn>()
+
+        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
+            trnRepository
+                .findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
+                .forEach { results[it.id] = it }
+        }
+
+        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
+            val managedPortfolioIds = managedPortfolioIdsFor(user)
+            if (managedPortfolioIds.isNotEmpty()) {
+                trnRepository
+                    .findByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds)
+                    .forEach { results[it.id] = it }
+            }
+        }
+
+        log.trace("proposed trns: ${results.size} (scope=$scope)")
+        return postProcess(results.values.toList())
     }
 
     /**
-     * Count all PROPOSED transactions for the current user across all their portfolios.
+     * Count PROPOSED transactions for the current user under the given scope.
      */
-    fun countProposedForUser(): Long {
+    fun countProposedForUser(scope: ProposedScope = ProposedScope.ALL): Long {
         val user = systemUserService.getOrThrow()
-        val count = trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
-        log.trace("proposed count: $count")
+        var count = 0L
+
+        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
+            count += trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
+        }
+
+        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
+            val managedPortfolioIds = managedPortfolioIdsFor(user)
+            if (managedPortfolioIds.isNotEmpty()) {
+                count += trnRepository.countByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds)
+            }
+        }
+
+        log.trace("proposed count: $count (scope=$scope)")
         return count
     }
+
+    private fun managedPortfolioIdsFor(user: com.beancounter.common.model.SystemUser): Set<String> =
+        portfolioShareRepository
+            .findBySharedWithAndStatus(user, ShareStatus.ACTIVE)
+            .mapNotNull { it.portfolio?.id }
+            .toSet()
 
     /**
      * Find all SETTLED transactions for the current user on a specific trade date.

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
@@ -3,11 +3,14 @@ package com.beancounter.marketdata.trn
 import com.beancounter.auth.MockAuthConfig
 import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.contracts.PortfolioSharesResponse
+import com.beancounter.common.contracts.ShareInviteRequest
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.contracts.TrnResponse
 import com.beancounter.common.input.PortfolioInput
 import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.BcJson.Companion.objectMapper
@@ -27,13 +30,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.math.BigDecimal
 
@@ -211,6 +217,125 @@ class ProposedTransactionsTest {
         // Then: Count should be 0
         val count = objectMapper.readTree(result.response.contentAsString).get("count").asInt()
         assertThat(count).isEqualTo(0)
+    }
+
+    @Test
+    fun `scope MANAGED returns proposed transactions on portfolios shared with the user`() {
+        // Client owns a portfolio with a PROPOSED transaction. An adviser is granted
+        // ACTIVE share access. The adviser must see the trn under scope=MANAGED, while
+        // scope=OWNED returns nothing for the adviser, and ALL returns the trn.
+
+        val adviser =
+            SystemUser(
+                id = "managed-adviser",
+                email = "managed-adviser@test.com",
+                auth0 = "auth0|managed-adviser"
+            )
+        val adviserToken = mockAuthConfig.getUserToken(adviser)
+        RegistrationUtils.registerUser(mockMvc, adviserToken)
+
+        val msft = bcMvcHelper.asset(AssetRequest(msftInput))
+        val portfolio =
+            bcMvcHelper.portfolio(
+                PortfolioInput("PROPOSED-MANAGED", "Managed", currency = USD.code)
+            )
+
+        val trnInput =
+            TrnInput(
+                CallerRef(batch = "MANAGED-PROPOSED", callerId = "1"),
+                msft.id,
+                trnType = TrnType.SELL,
+                quantity = BigDecimal("5"),
+                tradeCurrency = USD.code,
+                tradeDate = dateUtils.getFormattedDate("2024-04-10"),
+                price = BigDecimal("180.00"),
+                status = TrnStatus.PROPOSED
+            )
+        trnService.save(portfolio, TrnRequest(portfolio.id, listOf(trnInput)))
+
+        val invite =
+            ShareInviteRequest(
+                portfolioIds = listOf(portfolio.id),
+                adviserEmail = adviser.email
+            )
+        val inviteResult =
+            mockMvc
+                .perform(
+                    post("/shares/invite")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsBytes(invite))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+        val shareId =
+            objectMapper
+                .readValue(inviteResult.response.contentAsString, PortfolioSharesResponse::class.java)
+                .data
+                .first()
+                .id
+        mockMvc
+            .perform(
+                post("/shares/$shareId/accept")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adviserToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+
+        val managed =
+            objectMapper.readValue(
+                mockMvc
+                    .perform(
+                        get("$TRNS_ROOT/proposed?scope=MANAGED")
+                            .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adviserToken))
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString,
+                TrnResponse::class.java
+            )
+        assertThat(managed.data)
+            .anySatisfy { trn ->
+                assertThat(trn.portfolio.id).isEqualTo(portfolio.id)
+                assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+            }
+
+        val owned =
+            objectMapper.readValue(
+                mockMvc
+                    .perform(
+                        get("$TRNS_ROOT/proposed?scope=OWNED")
+                            .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adviserToken))
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString,
+                TrnResponse::class.java
+            )
+        assertThat(owned.data).noneMatch { it.portfolio.id == portfolio.id }
+
+        val all =
+            objectMapper.readValue(
+                mockMvc
+                    .perform(
+                        get("$TRNS_ROOT/proposed?scope=ALL")
+                            .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adviserToken))
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString,
+                TrnResponse::class.java
+            )
+        assertThat(all.data).anyMatch { it.portfolio.id == portfolio.id }
+
+        val countNode =
+            objectMapper.readTree(
+                mockMvc
+                    .perform(
+                        get("$TRNS_ROOT/proposed/count?scope=MANAGED")
+                            .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adviserToken))
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString
+            )
+        assertThat(countNode.get("count").asInt()).isGreaterThanOrEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
Adviser-side PROPOSED transactions on shared portfolios were never returned by /trns/proposed because the query filtered on portfolio.owner only.

Adds an optional `scope` query parameter — OWNED | MANAGED | ALL (default ALL) — and unions ACTIVE PortfolioShare records into the result for MANAGED/ALL. The count endpoint mirrors the same scope semantics so the header badge reflects managed work.

Adds an integration test covering the adviser-on-shared-portfolio path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now filter proposed transactions by scope: view only owned transactions, transactions from shared portfolios (managed), or all proposed transactions combined.

* **Tests**
  * Added test coverage for proposed transaction visibility across shared portfolios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/835)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->