### PR TITLE
fix(svc-position): anchor performance cache HIT series at requested startDate

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -69,14 +69,14 @@ class PerformanceService(
         if (cached != null) {
             val earliestCached = cached.minOf { it.valuationDate }
             if (!earliestCached.isAfter(startDate)) {
-                val filtered = cached.filter { !it.valuationDate.isBefore(startDate) }
+                val anchored = anchorToStartDate(cached, startDate)
                 log.debug(
                     "Cache HIT: portfolio={}, snapshots={} (filtered from {})",
                     portfolio.code,
-                    filtered.size,
+                    anchored.size,
                     cached.size
                 )
-                return buildResponseFromCache(portfolio, filtered)
+                return buildResponseFromCache(portfolio, anchored)
             }
             log.debug(
                 "Cache PARTIAL: portfolio={}, cached from {} but requested from {}, recomputing",
@@ -489,6 +489,40 @@ class PerformanceService(
         } catch (e: DataAccessException) {
             log.warn("Cache store failed, computation unaffected: {}", e.message)
         }
+    }
+
+    /**
+     * Returns cached snapshots restricted to the requested window with a
+     * baseline anchor at exactly `startDate`. When the cache lacks a snapshot
+     * on that date, synthesize one by carrying forward the latest cached
+     * snapshot strictly before `startDate`.
+     *
+     * `netContributions` and `cumulativeDividends` carry exactly because every
+     * cash flow date is itself a valuation date (see `determineValuationDates`),
+     * so nothing flows between two cached snapshots. `marketValue` is an
+     * approximation — at most ~1 month stale, bounded by the monthly cadence
+     * of valuation dates between cash-flow events.
+     *
+     * Without this anchor, multi-portfolio frontends that union per-portfolio
+     * dates see one portfolio's series start mid-window, leaking that
+     * portfolio's lifetime gain into period-relative metrics.
+     */
+    internal fun anchorToStartDate(
+        cached: List<CachedSnapshot>,
+        startDate: LocalDate
+    ): List<CachedSnapshot> {
+        val onOrAfter = cached.filter { !it.valuationDate.isBefore(startDate) }
+        if (onOrAfter.firstOrNull()?.valuationDate == startDate) return onOrAfter
+        val prior = cached.lastOrNull { it.valuationDate.isBefore(startDate) } ?: return onOrAfter
+        val anchor =
+            CachedSnapshot(
+                valuationDate = startDate,
+                marketValue = prior.marketValue,
+                externalCashFlow = BigDecimal.ZERO,
+                netContributions = prior.netContributions,
+                cumulativeDividends = prior.cumulativeDividends
+            )
+        return listOf(anchor) + onOrAfter
     }
 
     private fun buildResponseFromCache(

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
@@ -234,6 +234,95 @@ class PerformanceServiceCacheTest {
     }
 
     @Test
+    fun `cache hit synthesizes anchor at startDate when no exact match`() {
+        whenever(cacheService.isAvailable()).thenReturn(true)
+
+        // Cache populated for a 12-month window; snapshot dates land at the
+        // original window start (-12M), monthly first-of-month boundaries, and
+        // today. None fall exactly on -3M. The latest snapshot strictly before
+        // the requested -3M startDate is the -4M anchor.
+        val now = LocalDate.now()
+        val startDate = now.minusMonths(3)
+        val cachedSnapshots =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(12),
+                    marketValue = BigDecimal("10000"),
+                    externalCashFlow = BigDecimal("10000"),
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(10),
+                    marketValue = BigDecimal("10500"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(8),
+                    marketValue = BigDecimal("11000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(6),
+                    marketValue = BigDecimal("11500"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(4),
+                    marketValue = BigDecimal("12000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(2),
+                    marketValue = BigDecimal("13500"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now,
+                    marketValue = BigDecimal("15000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("12000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+        whenever(cacheService.findAllSnapshots(eq(portfolio.id)))
+            .thenReturn(cachedSnapshots)
+
+        val result = performanceService.calculate(portfolio, 3)
+
+        // First data point must be the requested startDate (synthesized anchor),
+        // not the first cached snapshot that happens to fall after startDate.
+        assertThat(result.data.series).isNotEmpty()
+        assertThat(
+            result.data.series
+                .first()
+                .date
+        ).isEqualTo(startDate)
+        // Anchor mv and netContributions carry forward from the latest cached
+        // snapshot strictly before startDate (-4M).
+        assertThat(
+            result.data.series
+                .first()
+                .marketValue
+        ).isEqualByComparingTo(BigDecimal("12000"))
+        assertThat(
+            result.data.series
+                .first()
+                .netContributions
+        ).isEqualByComparingTo(BigDecimal("10000"))
+    }
+
+    @Test
     fun `cache with insufficient history triggers recomputation`() {
         whenever(cacheService.isAvailable()).thenReturn(true)
 


### PR DESCRIPTION
## Summary
- Synthesises a baseline anchor at exactly the requested `startDate` when the cache HIT path has no cached snapshot on that day.
- Fixes a cross-window leak where shorter-window requests (e.g. 3M) against a cache populated for a longer window (e.g. 12M) returned a per-portfolio series starting mid-window, causing the bc-view aggregator to bleed the portfolio's pre-window unrealised gain into period `investmentGain`.
- Reported symptom on the bc-view 3M Wealth Performance view: aggregate TWR 1.55% yet `investmentGain` +$216K.

## How
`PerformanceService.anchorToStartDate` carries forward the latest cached snapshot strictly before `startDate`. `netContributions` and `cumulativeDividends` carry exactly (cash-flow dates are themselves valuation dates by design, so nothing flows between two cached snapshots). `marketValue` is an approximation bounded by the monthly cadence of valuation dates between cash-flow events.

## Test plan
- [x] New unit test `PerformanceServiceCacheTest.cache hit synthesizes anchor at startDate when no exact match` — RED before fix, GREEN after.
- [x] Existing `cache hit filters snapshots to requested months window` (which uses a coincidental cache anchor) still passes.
- [x] `./gradlew testSmart` green.
- [x] `./gradlew formatKotlin && ./gradlew lintKotlin` green.
- [ ] Consumer-side regression guard added in bc-view (see companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed performance calculation cache behavior to properly anchor results to requested start dates and synthesize baseline values when needed.

* **Tests**
  * Added test coverage for performance cache anchoring at requested start dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/836)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->