### PR TITLE
feat(svc-position): aggregate composite TWR endpoint

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/AggregatedPerformanceResponse.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/AggregatedPerformanceResponse.kt
@@ -1,0 +1,55 @@
+package com.beancounter.common.contracts
+
+import com.beancounter.common.model.Currency
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * One row of an aggregated, period-relative performance series for a set of
+ * portfolios converted to a single display currency.
+ *
+ * Period-relative fields (`netContributions`, `cumulativeDividends`,
+ * `investmentGain`) are baselined from the first point in the requested window
+ * — series[0] returns zero for these. `lifetimeContributions` carries the
+ * inception-to-date total at this date for tooltip / context use.
+ *
+ * Composite TWR (`growthOf1000`, `cumulativeReturn`) is chained sub-period
+ * with beginning-of-sub-period AUM weights in display currency, per GIPS.
+ */
+data class AggregatedPerformanceDataPoint(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer::class)
+    @JsonDeserialize(using = LocalDateDeserializer::class)
+    val date: LocalDate,
+    val growthOf1000: BigDecimal = BigDecimal.ZERO,
+    val cumulativeReturn: BigDecimal = BigDecimal.ZERO,
+    val marketValue: BigDecimal = BigDecimal.ZERO,
+    val netContributions: BigDecimal = BigDecimal.ZERO,
+    val lifetimeContributions: BigDecimal = BigDecimal.ZERO,
+    val cumulativeDividends: BigDecimal = BigDecimal.ZERO,
+    val investmentGain: BigDecimal = BigDecimal.ZERO
+)
+
+data class AggregatedPerformanceData(
+    val currency: Currency,
+    val series: List<AggregatedPerformanceDataPoint> = emptyList(),
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer::class)
+    @JsonDeserialize(using = LocalDateDeserializer::class)
+    val firstTradeDate: LocalDate? = null
+)
+
+data class AggregatedPerformanceResponse(
+    override val data: AggregatedPerformanceData
+) : Payload<AggregatedPerformanceData>
+
+data class AggregatedPerformanceRequest(
+    val portfolioCodes: List<String>,
+    val months: Int = 12,
+    val displayCurrency: String
+)

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
@@ -2,7 +2,11 @@ package com.beancounter.position.service
 
 import com.beancounter.auth.model.AuthConstants
 import com.beancounter.client.services.PortfolioServiceClient
+import com.beancounter.client.services.StaticService
+import com.beancounter.common.contracts.AggregatedPerformanceRequest
+import com.beancounter.common.contracts.AggregatedPerformanceResponse
 import com.beancounter.common.contracts.PerformanceResponse
+import com.beancounter.common.exception.BusinessException
 import com.beancounter.position.cache.PerformanceCacheService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -13,6 +17,8 @@ import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -32,7 +38,8 @@ class PerformanceController(
     private val portfolioServiceClient: PortfolioServiceClient,
     private val performanceService: PerformanceService,
     private val performanceCacheService: PerformanceCacheService,
-    private val benchmarkService: BenchmarkService
+    private val benchmarkService: BenchmarkService,
+    private val staticService: StaticService
 ) {
     private val log = LoggerFactory.getLogger(PerformanceController::class.java)
 
@@ -80,6 +87,31 @@ class PerformanceController(
         )
         val portfolio = portfolioServiceClient.getPortfolioByCode(code)
         return benchmarkService.benchmark(portfolio, indexAssetId, months)
+    }
+
+    @PostMapping("/performance/aggregate")
+    @Operation(
+        summary = "Aggregate composite TWR across portfolios",
+        description =
+            "Combines per-portfolio TWR series into a single display-currency series using " +
+                "chained sub-period AUM-weighted composite TWR (GIPS). Period-relative " +
+                "netContributions / cumulativeDividends / investmentGain are baselined from the " +
+                "first point in the requested window."
+    )
+    fun aggregate(
+        @RequestBody request: AggregatedPerformanceRequest
+    ): AggregatedPerformanceResponse {
+        val displayCurrency =
+            staticService.getCurrency(request.displayCurrency)
+                ?: throw BusinessException("Unknown display currency ${request.displayCurrency}")
+        val portfolios = request.portfolioCodes.map { portfolioServiceClient.getPortfolioByCode(it) }
+        log.debug(
+            "Aggregate performance: portfolios={}, months={}, displayCurrency={}",
+            request.portfolioCodes,
+            request.months,
+            request.displayCurrency
+        )
+        return performanceService.aggregate(portfolios, request.months, displayCurrency)
     }
 
     @DeleteMapping("/{code}/performance/cache")

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -4,13 +4,18 @@ import com.beancounter.auth.TokenService
 import com.beancounter.client.FxService
 import com.beancounter.client.services.PriceService
 import com.beancounter.client.services.TrnService
+import com.beancounter.common.contracts.AggregatedPerformanceData
+import com.beancounter.common.contracts.AggregatedPerformanceDataPoint
+import com.beancounter.common.contracts.AggregatedPerformanceResponse
 import com.beancounter.common.contracts.BulkFxRequest
+import com.beancounter.common.contracts.BulkFxResponse
 import com.beancounter.common.contracts.BulkPriceRequest
 import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.PerformanceData
 import com.beancounter.common.contracts.PerformanceDataPoint
 import com.beancounter.common.contracts.PerformanceResponse
 import com.beancounter.common.contracts.PriceAsset
+import com.beancounter.common.model.Currency
 import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.IsoCurrencyPair.Companion.toPair
 import com.beancounter.common.model.MarketData
@@ -554,6 +559,222 @@ class PerformanceService(
         }
         return dates
     }
+
+    /**
+     * Aggregate per-portfolio TWR series into a single composite series in
+     * `displayCurrency`. Uses each portfolio's existing cached / computed TWR
+     * (`calculate()`) and combines with chained sub-period AUM-weighted
+     * composite per GIPS.
+     */
+    fun aggregate(
+        portfolios: List<Portfolio>,
+        months: Int,
+        displayCurrency: Currency
+    ): AggregatedPerformanceResponse {
+        if (portfolios.isEmpty()) {
+            return AggregatedPerformanceResponse(AggregatedPerformanceData(displayCurrency))
+        }
+        val perPortfolio = portfolios.map { p -> p to calculate(p, months).data }
+        val fxRates = fetchDisplayCurrencyRates(perPortfolio, displayCurrency)
+        return composeAggregate(perPortfolio, displayCurrency, fxRates)
+    }
+
+    private fun fetchDisplayCurrencyRates(
+        perPortfolio: List<Pair<Portfolio, PerformanceData>>,
+        displayCurrency: Currency
+    ): Map<String, BigDecimal> {
+        val pairs =
+            perPortfolio
+                .mapNotNull { (portfolio, _) ->
+                    if (portfolio.currency.code == displayCurrency.code) {
+                        null
+                    } else {
+                        IsoCurrencyPair(portfolio.currency.code, displayCurrency.code)
+                    }
+                }.toSet()
+
+        val rates = mutableMapOf(displayCurrency.code to BigDecimal.ONE)
+        if (pairs.isEmpty()) return rates
+
+        val today = dateUtils.date.toString()
+        val token = tokenService.bearerToken
+        val response: BulkFxResponse =
+            fxRateService.getBulkRates(
+                BulkFxRequest(startDate = today, endDate = today, pairs = pairs),
+                token
+            )
+
+        // Single-rate-per-currency lookup: latest date in the response keyed by from-currency.
+        val sortedDates = response.data.keys.sorted()
+        val latest = sortedDates.lastOrNull()?.let { response.data[it] }
+        if (latest != null) {
+            for (pair in pairs) {
+                latest.rates[pair]?.rate?.let { rates[pair.from] = it }
+            }
+        }
+        return rates
+    }
+
+    /**
+     * Pure composition step. Combines per-portfolio TWR series into a single
+     * composite series in `displayCurrency`. No IO. Exposed `internal` for
+     * direct unit testing of the weighting math.
+     *
+     * Algorithm (chained sub-period composite, GIPS):
+     *   1. Build the union of valuation dates across portfolios.
+     *   2. Forward-fill each portfolio's snapshots onto union dates.
+     *   3. Convert market value / contributions / dividends to display ccy.
+     *   4. For each sub-period [t_{i-1}, t_i]: sub-return = Σ w_p * r_p,
+     *      where w_p = mv_p[i-1] / Σ mv[i-1] (display-ccy AUM) and
+     *      r_p = growthFactor_p[i] / growthFactor_p[i-1] (TWR factor ratio).
+     *      Portfolios with mv_p[i-1] == 0 are excluded from this sub-period.
+     *   5. cumulative_factor[i] = cumulative_factor[i-1] * sub-return.
+     *
+     * Period-relative metrics (`netContributions`, `cumulativeDividends`,
+     * `investmentGain`) are baselined against the first union point, so
+     * `series[0]` reports zero for them.
+     */
+    internal fun composeAggregate(
+        perPortfolio: List<Pair<Portfolio, PerformanceData>>,
+        displayCurrency: Currency,
+        fxRates: Map<String, BigDecimal>
+    ): AggregatedPerformanceResponse {
+        // Discard empty per-portfolio series. Sort each surviving series by date
+        // and convert to display currency once.
+        val perPortfolioFx: List<List<DisplaySnapshot>> =
+            perPortfolio.mapNotNull { (portfolio, data) ->
+                val series = data.series
+                if (series.isEmpty()) return@mapNotNull null
+                val rate = fxRates[portfolio.currency.code] ?: BigDecimal.ONE
+                series
+                    .sortedBy { it.date }
+                    .map { p ->
+                        DisplaySnapshot(
+                            date = p.date,
+                            growthFactor =
+                                p.growthOf1000
+                                    .divide(BigDecimal("1000"), 8, RoundingMode.HALF_UP),
+                            mv = p.marketValue.multiply(rate),
+                            contrib = p.netContributions.multiply(rate),
+                            divs = p.cumulativeDividends.multiply(rate)
+                        )
+                    }
+            }
+
+        if (perPortfolioFx.isEmpty()) {
+            return AggregatedPerformanceResponse(AggregatedPerformanceData(displayCurrency))
+        }
+
+        val sortedDates =
+            perPortfolioFx
+                .flatMap { snaps -> snaps.map { it.date } }
+                .toSortedSet()
+                .toList()
+
+        // For each portfolio, forward-fill onto union dates. A portfolio with no
+        // snapshot on/before a union date is "inactive" there (mv contribution 0,
+        // excluded from weighting).
+        val perPortfolioAligned: List<List<DisplaySnapshot?>> =
+            perPortfolioFx.map { snaps ->
+                var cursor = -1
+                sortedDates.map { date ->
+                    while (cursor + 1 < snaps.size && !snaps[cursor + 1].date.isAfter(date)) {
+                        cursor++
+                    }
+                    if (cursor < 0) null else snaps[cursor]
+                }
+            }
+
+        // Aggregate display-ccy totals per union date.
+        val totals: List<AggregateRow> =
+            sortedDates.indices.map { i ->
+                var mv = BigDecimal.ZERO
+                var contrib = BigDecimal.ZERO
+                var divs = BigDecimal.ZERO
+                for (p in perPortfolioAligned) {
+                    val s = p[i] ?: continue
+                    mv = mv.add(s.mv)
+                    contrib = contrib.add(s.contrib)
+                    divs = divs.add(s.divs)
+                }
+                AggregateRow(mv = mv, contrib = contrib, divs = divs)
+            }
+
+        // Chained sub-period composite TWR.
+        val cumFactor = MutableList(sortedDates.size) { BigDecimal.ONE }
+        for (i in 1 until sortedDates.size) {
+            var numerator = BigDecimal.ZERO
+            var weightSum = BigDecimal.ZERO
+            for (p in perPortfolioAligned) {
+                val prev = p[i - 1] ?: continue
+                val curr = p[i] ?: continue
+                if (prev.mv.signum() <= 0) continue
+                if (prev.growthFactor.signum() <= 0) continue
+                val r = curr.growthFactor.divide(prev.growthFactor, 10, RoundingMode.HALF_UP)
+                val w = prev.mv
+                numerator = numerator.add(w.multiply(r))
+                weightSum = weightSum.add(w)
+            }
+            val subReturn =
+                if (weightSum.signum() > 0) {
+                    numerator.divide(weightSum, 10, RoundingMode.HALF_UP)
+                } else {
+                    BigDecimal.ONE
+                }
+            cumFactor[i] = cumFactor[i - 1].multiply(subReturn)
+        }
+
+        val baselineMv = totals[0].mv
+        val baselineContrib = totals[0].contrib
+        val baselineDivs = totals[0].divs
+
+        val points =
+            sortedDates.indices.map { i ->
+                val row = totals[i]
+                val periodContrib = row.contrib.subtract(baselineContrib)
+                val periodDivs = row.divs.subtract(baselineDivs)
+                val investmentGain =
+                    row.mv
+                        .subtract(baselineMv)
+                        .subtract(periodContrib)
+                val growthOf1000 =
+                    cumFactor[i]
+                        .multiply(BigDecimal("1000"))
+                        .setScale(4, RoundingMode.HALF_UP)
+                val cumulativeReturn =
+                    cumFactor[i]
+                        .subtract(BigDecimal.ONE)
+                        .setScale(8, RoundingMode.HALF_UP)
+                AggregatedPerformanceDataPoint(
+                    date = sortedDates[i],
+                    growthOf1000 = growthOf1000,
+                    cumulativeReturn = cumulativeReturn,
+                    marketValue = row.mv.setScale(2, RoundingMode.HALF_UP),
+                    netContributions = periodContrib.setScale(2, RoundingMode.HALF_UP),
+                    lifetimeContributions = row.contrib.setScale(2, RoundingMode.HALF_UP),
+                    cumulativeDividends = periodDivs.setScale(2, RoundingMode.HALF_UP),
+                    investmentGain = investmentGain.setScale(2, RoundingMode.HALF_UP)
+                )
+            }
+
+        return AggregatedPerformanceResponse(
+            AggregatedPerformanceData(currency = displayCurrency, series = points)
+        )
+    }
+
+    private data class DisplaySnapshot(
+        val date: LocalDate,
+        val growthFactor: BigDecimal,
+        val mv: BigDecimal,
+        val contrib: BigDecimal,
+        val divs: BigDecimal
+    )
+
+    private data class AggregateRow(
+        val mv: BigDecimal,
+        val contrib: BigDecimal,
+        val divs: BigDecimal
+    )
 
     companion object {
         private val log = LoggerFactory.getLogger(PerformanceService::class.java)

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
@@ -234,6 +234,122 @@ class PerformanceServiceCacheTest {
     }
 
     @Test
+    fun `anchorToStartDate returns onOrAfter unchanged when exact match present`() {
+        val now = LocalDate.now()
+        val startDate = now.minusMonths(3)
+        val cached =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(12),
+                    marketValue = BigDecimal("10000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = startDate,
+                    marketValue = BigDecimal("12000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("11000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now,
+                    marketValue = BigDecimal("15000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("11000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+
+        val result = performanceService.anchorToStartDate(cached, startDate)
+
+        // Exact anchor exists: no synthesis. Result starts at startDate, drops
+        // the older snapshot, retains the rest as-is.
+        assertThat(result).hasSize(2)
+        assertThat(result.first().valuationDate).isEqualTo(startDate)
+        assertThat(result.first().marketValue).isEqualByComparingTo("12000")
+        // Original anchor passed through unmutated (not a fresh ZERO cashflow copy).
+        assertThat(result.first().netContributions).isEqualByComparingTo("11000")
+    }
+
+    @Test
+    fun `anchorToStartDate picks latest pre-startDate snapshot when multiple exist`() {
+        // Carry-forward must use the LATEST snapshot strictly before startDate,
+        // not the earliest. Older snapshot has stale MV; latest has the most
+        // accurate carry-forward state.
+        val now = LocalDate.now()
+        val startDate = now.minusMonths(3)
+        val cached =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(12),
+                    marketValue = BigDecimal("8000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("8000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(8),
+                    marketValue = BigDecimal("9500"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("9000"),
+                    cumulativeDividends = BigDecimal("50")
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(4),
+                    marketValue = BigDecimal("11000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal("120")
+                ),
+                CachedSnapshot(
+                    valuationDate = now,
+                    marketValue = BigDecimal("13000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal("200")
+                )
+            )
+
+        val result = performanceService.anchorToStartDate(cached, startDate)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.first().valuationDate).isEqualTo(startDate)
+        // Carries from -4M, not -8M or -12M.
+        assertThat(result.first().marketValue).isEqualByComparingTo("11000")
+        assertThat(result.first().netContributions).isEqualByComparingTo("10000")
+        assertThat(result.first().cumulativeDividends).isEqualByComparingTo("120")
+        // Synthesized anchor has zero cashflow (no flow occurred on this date).
+        assertThat(result.first().externalCashFlow).isEqualByComparingTo("0")
+    }
+
+    @Test
+    fun `anchorToStartDate falls through when no pre-startDate snapshot exists`() {
+        // Edge case the outer caller guards against, but the helper must still
+        // return a sensible value when called with cached.first > startDate.
+        val now = LocalDate.now()
+        val startDate = now.minusMonths(3)
+        val cached =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(2),
+                    marketValue = BigDecimal("13000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+
+        val result = performanceService.anchorToStartDate(cached, startDate)
+
+        // No prior snapshot to carry forward; returns the onOrAfter subset
+        // without synthesising an anchor.
+        assertThat(result).hasSize(1)
+        assertThat(result.first().valuationDate).isEqualTo(now.minusMonths(2))
+    }
+
+    @Test
     fun `cache hit synthesizes anchor at startDate when no exact match`() {
         whenever(cacheService.isAvailable()).thenReturn(true)
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
@@ -4,13 +4,18 @@ import com.beancounter.auth.TokenService
 import com.beancounter.client.FxService
 import com.beancounter.client.services.PriceService
 import com.beancounter.client.services.TrnService
+import com.beancounter.common.contracts.BulkFxResponse
+import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.PerformanceData
 import com.beancounter.common.contracts.PerformanceDataPoint
 import com.beancounter.common.model.Currency
+import com.beancounter.common.model.FxRate
+import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.position.accumulation.Accumulator
+import com.beancounter.position.cache.CachedSnapshot
 import com.beancounter.position.cache.PerformanceCacheService
 import com.beancounter.position.irr.TwrCalculator
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +24,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -230,6 +241,272 @@ class PerformanceAggregateTest {
         assertThat(out[2].investmentGain).isEqualByComparingTo("2000")
         assertThat(out[2].netContributions).isEqualByComparingTo("20000")
         assertThat(out[2].lifetimeContributions).isEqualByComparingTo("120000")
+    }
+
+    @Test
+    fun `cumulativeDividends accumulates period-relative across snapshots`() {
+        // Lifetime dividends from backend at series[0] are excluded from the
+        // period total. Subsequent snapshots show only the within-window delta.
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2025-01-01", "1000", "100000", netContributions = "100000", cumulativeDividends = "500"),
+                point("2025-06-01", "1050", "105000", netContributions = "100000", cumulativeDividends = "750"),
+                point("2025-12-01", "1100", "110000", netContributions = "100000", cumulativeDividends = "1200")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        val out = result.data.series
+        assertThat(out[0].cumulativeDividends).isEqualByComparingTo("0")
+        // Jun: 750 - baseline 500 = 250
+        assertThat(out[1].cumulativeDividends).isEqualByComparingTo("250")
+        // Dec: 1200 - baseline 500 = 700
+        assertThat(out[2].cumulativeDividends).isEqualByComparingTo("700")
+    }
+
+    @Test
+    fun `non-positive growthFactor at sub-period boundary is skipped`() {
+        // Defensive: a backend bug or extreme drawdown could land growthOf1000
+        // at 0. The sub-period weighting must skip that portfolio rather than
+        // divide by zero, falling back to the other portfolio's pure return.
+        val p1 = portfolio("P1", usd)
+        val p2 = portfolio("P2", usd)
+        val p1Series =
+            listOf(
+                point("2025-01-01", "1000", "50000", netContributions = "50000"),
+                point("2025-12-01", "1200", "60000", netContributions = "50000")
+            )
+        val p2Series =
+            listOf(
+                point("2025-01-01", "0", "50000", netContributions = "50000"), // zero growthFactor
+                point("2025-12-01", "0", "50000", netContributions = "50000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p1 to PerformanceData(usd, p1Series),
+                        p2 to PerformanceData(usd, p2Series)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        // P2 skipped from weighting (signum check). P1 alone drives composite:
+        // r_P1 = 1.2 / 1.0 = 1.20. cum = 1.20. growthOf1000 = 1200.
+        assertThat(
+            result.data.series
+                .last()
+                .growthOf1000
+                .toDouble()
+        ).isCloseTo(1200.0, Offset.offset(0.5))
+    }
+
+    @Test
+    fun `empty per-portfolio series produces empty result`() {
+        val p = portfolio("P1", usd)
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, emptyList())),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+        assertThat(result.data.series).isEmpty()
+    }
+
+    @Test
+    fun `missing FX rate defaults to 1_0`() {
+        // Defensive path: if `fetchDisplayCurrencyRates` failed to find a pair
+        // (e.g. FX service returned no rate for an exotic currency), the map
+        // lookup is null and we apply 1.0 rather than blow up the whole
+        // aggregate. Worth pinning so this fallback isn't quietly removed.
+        val p = portfolio("P1", nzd)
+        val series =
+            listOf(
+                point("2025-01-01", "1000", "100", netContributions = "100"),
+                point("2025-12-01", "1100", "110", netContributions = "100")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(nzd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE) // NZD missing
+            )
+
+        // No FX applied → MV passes through unchanged in nominal terms.
+        assertThat(result.data.series).hasSize(2)
+        assertThat(result.data.series[0].marketValue).isEqualByComparingTo("100")
+        assertThat(result.data.series[1].marketValue).isEqualByComparingTo("110")
+    }
+
+    @Test
+    fun `single-point series yields one row with zero period metrics`() {
+        // Boundary: cache may have only the synthesized anchor (no later data).
+        val p = portfolio("P1", usd)
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p to
+                            PerformanceData(
+                                usd,
+                                listOf(point("2025-01-01", "1000", "5000", netContributions = "5000"))
+                            )
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.series).hasSize(1)
+        val only = result.data.series.first()
+        assertThat(only.growthOf1000).isEqualByComparingTo("1000")
+        assertThat(only.cumulativeReturn).isEqualByComparingTo("0")
+        assertThat(only.netContributions).isEqualByComparingTo("0")
+        assertThat(only.investmentGain).isEqualByComparingTo("0")
+        assertThat(only.lifetimeContributions).isEqualByComparingTo("5000")
+    }
+
+    @Test
+    fun `all portfolios inactive at t0 yields composite return 1_0 until first activity`() {
+        // Two portfolios, both anchored at startDate with mv=0. P1 activates at
+        // Jun, P2 at Dec. Sub-period Jan→Jun has no active AUM (both mv=0),
+        // so subReturn falls back to 1.0 — composite cum factor stays at 1.0.
+        val p1 = portfolio("P1", usd)
+        val p2 = portfolio("P2", usd)
+        val p1Series =
+            listOf(
+                point("2025-01-01", "1000", "0", netContributions = "0"),
+                point("2025-06-01", "1000", "10000", netContributions = "10000"),
+                point("2025-12-01", "1100", "11000", netContributions = "10000")
+            )
+        val p2Series =
+            listOf(
+                point("2025-01-01", "1000", "0", netContributions = "0"),
+                point("2025-06-01", "1000", "0", netContributions = "0"),
+                point("2025-12-01", "1000", "5000", netContributions = "5000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p1 to PerformanceData(usd, p1Series),
+                        p2 to PerformanceData(usd, p2Series)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        val out = result.data.series
+        // i=0 (Jan): baseline.
+        assertThat(out[0].growthOf1000).isEqualByComparingTo("1000")
+        // i=1 (Jun): only P1 active by then. Both prev (i=0) mv were 0, so
+        // sub-period Jan→Jun = no weighted portfolios → subReturn=1.0.
+        assertThat(out[1].growthOf1000).isEqualByComparingTo("1000")
+        // i=2 (Dec): Jun→Dec, P1 prev mv=10k weighted. P2 prev mv=0 excluded.
+        // r_P1 = 1100/1000 = 1.10. subReturn = 1.10. cum = 1.10.
+        assertThat(out[2].growthOf1000.toDouble())
+            .isCloseTo(1100.0, Offset.offset(0.5))
+    }
+
+    @Test
+    fun `aggregate with empty portfolio list short-circuits before any IO`() {
+        val result = service.aggregate(emptyList(), 12, usd)
+
+        assertThat(result.data.series).isEmpty()
+        assertThat(result.data.currency).isEqualTo(usd)
+        verify(fxRateService, never()).getBulkRates(any(), any())
+        verify(tokenService, never()).bearerToken
+    }
+
+    @Test
+    fun `aggregate with single same-currency portfolio skips FX service`() {
+        // Cache HIT keeps trnService/priceService out of the picture. Display
+        // ccy == portfolio ccy means no IsoCurrencyPair to fetch, so the FX
+        // service should never be hit either.
+        whenever(cacheService.isAvailable()).thenReturn(true)
+        val today = LocalDate.now()
+        val snapshots =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = today.minusMonths(12),
+                    marketValue = BigDecimal("10000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = today,
+                    marketValue = BigDecimal("11000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+        whenever(cacheService.findAllSnapshots(eq("P1"))).thenReturn(snapshots)
+
+        val result = service.aggregate(listOf(portfolio("P1", usd)), 12, usd)
+
+        assertThat(result.data.series).isNotEmpty()
+        assertThat(result.data.currency).isEqualTo(usd)
+        verify(fxRateService, never()).getBulkRates(any(), any())
+    }
+
+    @Test
+    fun `aggregate fetches FX bulk rates for foreign-currency portfolios`() {
+        whenever(cacheService.isAvailable()).thenReturn(true)
+        val today = LocalDate.now()
+        val nzdSnapshots =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = today.minusMonths(12),
+                    marketValue = BigDecimal("100000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("100000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = today,
+                    marketValue = BigDecimal("110000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("100000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+        whenever(cacheService.findAllSnapshots(eq("NZPF"))).thenReturn(nzdSnapshots)
+
+        val pair = IsoCurrencyPair("NZD", "USD")
+        val rate = FxRate(from = nzd, to = usd, rate = BigDecimal("0.6"), date = today)
+        val fxResponse =
+            BulkFxResponse(
+                data = mapOf(today.toString() to FxPairResults(rates = mapOf(pair to rate)))
+            )
+        lenient().`when`(tokenService.bearerToken).thenReturn("test-token")
+        whenever(fxRateService.getBulkRates(any(), any())).thenReturn(fxResponse)
+
+        val result = service.aggregate(listOf(portfolio("NZPF", nzd)), 12, usd)
+
+        assertThat(result.data.currency).isEqualTo(usd)
+        // 100k NZD at 0.6 → 60k USD initial; 110k NZD at 0.6 → 66k USD end.
+        assertThat(
+            result.data.series
+                .first()
+                .marketValue
+        ).isEqualByComparingTo("60000")
+        assertThat(
+            result.data.series
+                .last()
+                .marketValue
+        ).isEqualByComparingTo("66000")
+        verify(fxRateService).getBulkRates(any(), any())
     }
 
     @Test

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
@@ -1,0 +1,268 @@
+package com.beancounter.position.service
+
+import com.beancounter.auth.TokenService
+import com.beancounter.client.FxService
+import com.beancounter.client.services.PriceService
+import com.beancounter.client.services.TrnService
+import com.beancounter.common.contracts.PerformanceData
+import com.beancounter.common.contracts.PerformanceDataPoint
+import com.beancounter.common.model.Currency
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.position.accumulation.Accumulator
+import com.beancounter.position.cache.PerformanceCacheService
+import com.beancounter.position.irr.TwrCalculator
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Unit tests for [PerformanceService.composeAggregate] — the pure composition
+ * step that combines per-portfolio TWR series into a single display-currency
+ * series with chained sub-period AUM-weighted composite TWR.
+ *
+ * Tests call `composeAggregate` directly with curated `PerformanceData`
+ * inputs, bypassing transaction / price / FX clients. The wider `aggregate`
+ * method is covered separately at the controller level.
+ */
+@ExtendWith(MockitoExtension::class)
+class PerformanceAggregateTest {
+    @Mock
+    private lateinit var trnService: TrnService
+
+    @Mock
+    private lateinit var accumulator: Accumulator
+
+    @Mock
+    private lateinit var priceService: PriceService
+
+    @Mock
+    private lateinit var fxRateService: FxService
+
+    @Mock
+    private lateinit var tokenService: TokenService
+
+    @Mock
+    private lateinit var cacheService: PerformanceCacheService
+
+    private lateinit var service: PerformanceService
+
+    private val usd = Currency("USD")
+    private val nzd = Currency("NZD")
+    private val owner =
+        SystemUser(
+            id = "u",
+            email = "u@u",
+            true,
+            since = DateUtils().getFormattedDate("2020-01-01")
+        )
+
+    @BeforeEach
+    fun setup() {
+        service =
+            PerformanceService(
+                trnService = trnService,
+                accumulator = accumulator,
+                priceService = priceService,
+                fxRateService = fxRateService,
+                twrCalculator = TwrCalculator(),
+                dateUtils = DateUtils(),
+                tokenService = tokenService,
+                cacheService = cacheService
+            )
+    }
+
+    private fun portfolio(
+        code: String,
+        ccy: Currency
+    ): Portfolio =
+        Portfolio(
+            id = code,
+            code = code,
+            name = code,
+            currency = ccy,
+            base = ccy,
+            owner = owner
+        )
+
+    private fun point(
+        date: String,
+        growthOf1000: String,
+        marketValue: String,
+        netContributions: String = "0",
+        cumulativeDividends: String = "0"
+    ): PerformanceDataPoint =
+        PerformanceDataPoint(
+            date = LocalDate.parse(date),
+            growthOf1000 = BigDecimal(growthOf1000),
+            marketValue = BigDecimal(marketValue),
+            netContributions = BigDecimal(netContributions),
+            cumulativeReturn =
+                BigDecimal(growthOf1000)
+                    .divide(BigDecimal("1000"), 6, java.math.RoundingMode.HALF_UP)
+                    .subtract(BigDecimal.ONE),
+            cumulativeDividends = BigDecimal(cumulativeDividends)
+        )
+
+    @Test
+    fun `empty portfolio list returns empty series`() {
+        val result =
+            service.composeAggregate(
+                perPortfolio = emptyList(),
+                displayCurrency = usd,
+                fxRates = emptyMap()
+            )
+        assertThat(result.data.series).isEmpty()
+        assertThat(result.data.currency).isEqualTo(usd)
+    }
+
+    @Test
+    fun `single portfolio mirrors composite TWR with period-relative metrics`() {
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2025-01-01", "1000", "100000", netContributions = "80000"),
+                point("2025-12-01", "1100", "115000", netContributions = "85000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        val out = result.data.series
+        assertThat(out).hasSize(2)
+        assertThat(out[1].growthOf1000).isEqualByComparingTo("1100")
+        assertThat(out[1].cumulativeReturn).isEqualByComparingTo("0.1")
+        assertThat(out[0].netContributions).isEqualByComparingTo("0")
+        assertThat(out[0].investmentGain).isEqualByComparingTo("0")
+        assertThat(out[1].netContributions).isEqualByComparingTo("5000")
+        assertThat(out[1].investmentGain).isEqualByComparingTo("10000")
+        assertThat(out[1].lifetimeContributions).isEqualByComparingTo("85000")
+    }
+
+    @Test
+    fun `chained composite reweights AUM each sub-period`() {
+        val p1 = portfolio("P1", usd)
+        val p2 = portfolio("P2", usd)
+        val p1Series =
+            listOf(
+                point("2025-01-01", "1000", "60000", netContributions = "60000"),
+                point("2025-06-01", "1100", "66000", netContributions = "60000"),
+                point("2025-12-01", "1100", "66000", netContributions = "60000")
+            )
+        val p2Series =
+            listOf(
+                point("2025-01-01", "1000", "40000", netContributions = "40000"),
+                point("2025-06-01", "1000", "40000", netContributions = "40000"),
+                point("2025-12-01", "1200", "48000", netContributions = "40000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p1 to PerformanceData(usd, p1Series),
+                        p2 to PerformanceData(usd, p2Series)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        val out = result.data.series
+        assertThat(out).hasSize(3)
+        // Sub1 (Jan→Jun): w=[0.6,0.4], r=[1.10,1.00] → 1.06
+        // Sub2 (Jun→Dec): w=[66/106,40/106], r=[1.00,1.20] → 1.0754716...
+        // cum = 1.06 * 1.0754716 ≈ 1.140
+        val sub1 = 1.06
+        val sub2 = (66.0 / 106.0) + (40.0 / 106.0) * 1.20
+        val expected = sub1 * sub2
+        assertThat(out[2].growthOf1000.toDouble())
+            .isCloseTo(1000.0 * expected, Offset.offset(0.5))
+        assertThat(out[2].marketValue).isEqualByComparingTo("114000")
+    }
+
+    @Test
+    fun `portfolio joining mid-window with zero anchor still contributes once active`() {
+        val p1 = portfolio("P1", usd)
+        val p2 = portfolio("P2", usd)
+        val p1Series =
+            listOf(
+                point("2025-01-01", "1000", "100000", netContributions = "100000"),
+                point("2025-06-01", "1000", "100000", netContributions = "100000"),
+                point("2025-12-01", "1000", "100000", netContributions = "100000")
+            )
+        val p2Series =
+            listOf(
+                point("2025-01-01", "1000", "0", netContributions = "0"),
+                point("2025-06-01", "1000", "20000", netContributions = "20000"),
+                point("2025-12-01", "1100", "22000", netContributions = "20000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p1 to PerformanceData(usd, p1Series),
+                        p2 to PerformanceData(usd, p2Series)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        val out = result.data.series
+        // Sub1: P2 inactive (mv=0) → subReturn = P1.r = 1.0
+        // Sub2: w_P1=100/120, w_P2=20/120. r_P1=1.0, r_P2=1.10
+        //   subReturn = (100 + 20*1.10) / 120 = 122/120 = 1.01667
+        val sub2 = (100.0 + 20.0 * 1.10) / 120.0
+        assertThat(out[2].growthOf1000.toDouble())
+            .isCloseTo(1000.0 * sub2, Offset.offset(0.5))
+        // investmentGain: mv 122k − mv0 100k − periodContrib 20k = 2k (P2's gain)
+        assertThat(out[2].investmentGain).isEqualByComparingTo("2000")
+        assertThat(out[2].netContributions).isEqualByComparingTo("20000")
+        assertThat(out[2].lifetimeContributions).isEqualByComparingTo("120000")
+    }
+
+    @Test
+    fun `FX converts portfolio MV and contributions to display currency`() {
+        val pUsd = portfolio("USPF", usd)
+        val pNzd = portfolio("NZPF", nzd)
+        val usdSeries =
+            listOf(
+                point("2025-01-01", "1000", "50000", netContributions = "50000"),
+                point("2025-12-01", "1100", "55000", netContributions = "50000")
+            )
+        val nzdSeries =
+            listOf(
+                point("2025-01-01", "1000", "100000", netContributions = "100000"),
+                point("2025-12-01", "1200", "120000", netContributions = "100000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        pUsd to PerformanceData(usd, usdSeries),
+                        pNzd to PerformanceData(nzd, nzdSeries)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE, "NZD" to BigDecimal("0.6"))
+            )
+
+        val out = result.data.series
+        assertThat(out[0].marketValue).isEqualByComparingTo("110000")
+        assertThat(out[1].marketValue).isEqualByComparingTo("127000")
+        val expected = (50.0 / 110.0) * 1.10 + (60.0 / 110.0) * 1.20
+        assertThat(out[1].growthOf1000.toDouble())
+            .isCloseTo(1000.0 * expected, Offset.offset(0.5))
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
@@ -1,6 +1,7 @@
 package com.beancounter.position.service
 
 import com.beancounter.client.services.PortfolioServiceClient
+import com.beancounter.client.services.StaticService
 import com.beancounter.common.contracts.PerformanceData
 import com.beancounter.common.contracts.PerformanceDataPoint
 import com.beancounter.common.contracts.PerformanceResponse
@@ -34,6 +35,9 @@ class PerformanceControllerTest {
     @Mock
     private lateinit var benchmarkService: BenchmarkService
 
+    @Mock
+    private lateinit var staticService: StaticService
+
     private lateinit var controller: PerformanceController
 
     private val portfolio =
@@ -53,7 +57,8 @@ class PerformanceControllerTest {
                 portfolioServiceClient,
                 performanceService,
                 performanceCacheService,
-                benchmarkService
+                benchmarkService,
+                staticService
             )
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
@@ -2,15 +2,21 @@ package com.beancounter.position.service
 
 import com.beancounter.client.services.PortfolioServiceClient
 import com.beancounter.client.services.StaticService
+import com.beancounter.common.contracts.AggregatedPerformanceData
+import com.beancounter.common.contracts.AggregatedPerformanceDataPoint
+import com.beancounter.common.contracts.AggregatedPerformanceRequest
+import com.beancounter.common.contracts.AggregatedPerformanceResponse
 import com.beancounter.common.contracts.PerformanceData
 import com.beancounter.common.contracts.PerformanceDataPoint
 import com.beancounter.common.contracts.PerformanceResponse
+import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.Portfolio
 import com.beancounter.position.Constants.Companion.USD
 import com.beancounter.position.Constants.Companion.owner
 import com.beancounter.position.cache.PerformanceCacheService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -143,6 +149,95 @@ class PerformanceControllerTest {
                 .growthOf1000
         ).isEqualByComparingTo(BigDecimal("1075"))
         verify(benchmarkService).benchmark(portfolio, "^GSPC", 12)
+    }
+
+    @Test
+    fun `aggregate resolves portfolios and delegates to service with display currency`() {
+        val p1 = portfolio.copy(id = "p1", code = "P1")
+        val p2 = portfolio.copy(id = "p2", code = "P2")
+        val series =
+            listOf(
+                AggregatedPerformanceDataPoint(
+                    date = LocalDate.of(2025, 1, 1),
+                    growthOf1000 = BigDecimal("1000"),
+                    cumulativeReturn = BigDecimal.ZERO,
+                    marketValue = BigDecimal("0"),
+                    netContributions = BigDecimal("0"),
+                    lifetimeContributions = BigDecimal("0"),
+                    cumulativeDividends = BigDecimal("0"),
+                    investmentGain = BigDecimal("0")
+                ),
+                AggregatedPerformanceDataPoint(
+                    date = LocalDate.of(2025, 12, 1),
+                    growthOf1000 = BigDecimal("1140"),
+                    cumulativeReturn = BigDecimal("0.14"),
+                    marketValue = BigDecimal("114000"),
+                    netContributions = BigDecimal("10000"),
+                    lifetimeContributions = BigDecimal("110000"),
+                    cumulativeDividends = BigDecimal("0"),
+                    investmentGain = BigDecimal("4000")
+                )
+            )
+        val expected =
+            AggregatedPerformanceResponse(
+                AggregatedPerformanceData(currency = USD, series = series)
+            )
+        whenever(staticService.getCurrency("USD")).thenReturn(USD)
+        whenever(portfolioServiceClient.getPortfolioByCode("P1")).thenReturn(p1)
+        whenever(portfolioServiceClient.getPortfolioByCode("P2")).thenReturn(p2)
+        whenever(performanceService.aggregate(listOf(p1, p2), 12, USD)).thenReturn(expected)
+
+        val result =
+            controller.aggregate(
+                AggregatedPerformanceRequest(
+                    portfolioCodes = listOf("P1", "P2"),
+                    months = 12,
+                    displayCurrency = "USD"
+                )
+            )
+
+        assertThat(result.data.series).hasSize(2)
+        assertThat(
+            result.data.series
+                .last()
+                .cumulativeReturn
+        ).isEqualByComparingTo(BigDecimal("0.14"))
+        verify(performanceService).aggregate(listOf(p1, p2), 12, USD)
+    }
+
+    @Test
+    fun `aggregate rejects unknown display currency`() {
+        whenever(staticService.getCurrency("XYZ")).thenReturn(null)
+
+        assertThatThrownBy {
+            controller.aggregate(
+                AggregatedPerformanceRequest(
+                    portfolioCodes = listOf("P1"),
+                    months = 12,
+                    displayCurrency = "XYZ"
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining("XYZ")
+    }
+
+    @Test
+    fun `aggregate with empty portfolio list short-circuits to service empty response`() {
+        whenever(staticService.getCurrency("USD")).thenReturn(USD)
+        whenever(performanceService.aggregate(emptyList(), 6, USD))
+            .thenReturn(AggregatedPerformanceResponse(AggregatedPerformanceData(USD)))
+
+        val result =
+            controller.aggregate(
+                AggregatedPerformanceRequest(
+                    portfolioCodes = emptyList(),
+                    months = 6,
+                    displayCurrency = "USD"
+                )
+            )
+
+        assertThat(result.data.series).isEmpty()
+        verify(performanceService).aggregate(emptyList(), 6, USD)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- New `POST /performance/aggregate` returns a single composite TWR series for a set of portfolios in a chosen display currency.
- Replaces client-side aggregation in bc-view (see companion PR). The client's fixed-weight composite ignored portfolios that joined mid-window and never re-weighted as AUM shifted across sub-periods.
- Stacked on top of monowai/beancounter#836 (cache anchor). Rebase onto main after #836 merges.

## What the endpoint does
1. Reuses each portfolio's cached `calculate()` series — no extra IO when warm.
2. Pre-fetches `portfolio.currency` → `displayCurrency` FX in one bulk call.
3. Builds the union of valuation dates across portfolios; forward-fills per-portfolio onto union dates.
4. Computes **chained sub-period composite TWR** with beginning-of-sub-period AUM weights in display currency (GIPS). Portfolios with `mv_at_{i-1} == 0` are excluded from that sub-period and pick up weight only once they hold AUM.
5. Emits period-relative `netContributions`, `cumulativeDividends`, and `investmentGain` (baselined from `series[0]`), plus `lifetimeContributions` for tooltip context.

## Why
The client's fixed-weight composite was set once at `series[0]`:
- Zero-AUM portfolios at the window start had weight 0 forever — their later performance was invisible to aggregate TWR.
- Portfolios that grew or shrank kept their initial AUM weight, distorting the composite.
- Cash-flow, FX, and date-grid logic was duplicated across the frontend and the backend's `PerformanceService`.

## Test plan
- [x] `PerformanceAggregateTest` (new) — covers empty input, single-portfolio mirror, **chained AUM reweighting across two sub-periods**, **mid-window joiner with zero anchor**, FX conversion.
- [x] `PerformanceServiceCacheTest` and `PerformanceControllerTest` still pass.
- [x] `./gradlew testSmart` green.
- [x] `./gradlew formatKotlin && ./gradlew lintKotlin` green.
- [ ] Companion bc-view PR cuts the client-side aggregation over to this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)