### PR TITLE
feat(svc-position): aggregate XIRR (money-weighted return)

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/AggregatedPerformanceResponse.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/AggregatedPerformanceResponse.kt
@@ -38,6 +38,14 @@ data class AggregatedPerformanceDataPoint(
 data class AggregatedPerformanceData(
     val currency: Currency,
     val series: List<AggregatedPerformanceDataPoint> = emptyList(),
+    /**
+     * Aggregate money-weighted return (XIRR) for the requested window, as an
+     * annualised decimal (0.10 = +10% p.a.). Null when the solver could not
+     * converge or there were insufficient flows. For windows shorter than
+     * ~1 year, IrrCalculator falls back to simple ROI on the pooled flows;
+     * consumers should label sub-year results as "cumulative", not "p.a."
+     */
+    val xirr: BigDecimal? = null,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonSerialize(using = LocalDateSerializer::class)
     @JsonDeserialize(using = LocalDateDeserializer::class)

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -57,6 +57,7 @@ class PerformanceService(
     private val priceService: PriceService,
     private val fxRateService: FxService,
     private val twrCalculator: TwrCalculator,
+    private val irrCalculator: com.beancounter.position.irr.IrrCalculator,
     private val dateUtils: DateUtils,
     private val tokenService: TokenService,
     private val cacheService: PerformanceCacheService,
@@ -757,9 +758,68 @@ class PerformanceService(
                 )
             }
 
+        val xirr = computeAggregateXirr(perPortfolioFx)
+
         return AggregatedPerformanceResponse(
-            AggregatedPerformanceData(currency = displayCurrency, series = points)
+            AggregatedPerformanceData(currency = displayCurrency, series = points, xirr = xirr)
         )
+    }
+
+    /**
+     * Pool per-portfolio investor cash flows over the window into a single
+     * `PeriodicCashFlows` and solve for XIRR via the shared `IrrCalculator`.
+     *
+     * Sign convention is investor-POV:
+     *   - At series[0] (window start): −marketValue (capital invested).
+     *   - Between snapshots: −Δ netContributions (deposit = money out of wallet).
+     *   - At series[last] (window end): +marketValue (capital realised).
+     *
+     * Inputs are already FX-converted to the display currency, so all flows
+     * land in a single denomination. `IrrCalculator` itself handles short-
+     * window fallback to simple ROI and bails to 0.0 when the solver fails.
+     */
+    private fun computeAggregateXirr(perPortfolioFx: List<List<DisplaySnapshot>>): BigDecimal? {
+        if (perPortfolioFx.isEmpty()) return null
+        val flows = mutableListOf<com.beancounter.common.model.CashFlow>()
+        for (snaps in perPortfolioFx) {
+            if (snaps.isEmpty()) continue
+            val first = snaps.first()
+            if (first.mv.signum() > 0) {
+                flows.add(
+                    com.beancounter.common.model.CashFlow(
+                        amount = first.mv.negate().toDouble(),
+                        date = first.date
+                    )
+                )
+            }
+            for (i in 1 until snaps.size) {
+                val delta = snaps[i].contrib.subtract(snaps[i - 1].contrib)
+                if (delta.signum() != 0) {
+                    flows.add(
+                        com.beancounter.common.model.CashFlow(
+                            amount = delta.negate().toDouble(),
+                            date = snaps[i].date
+                        )
+                    )
+                }
+            }
+            val last = snaps.last()
+            if (last.mv.signum() > 0) {
+                flows.add(
+                    com.beancounter.common.model.CashFlow(
+                        amount = last.mv.toDouble(),
+                        date = last.date
+                    )
+                )
+            }
+        }
+        if (flows.size < 2) return null
+        val periodic =
+            com.beancounter.common.model
+                .PeriodicCashFlows()
+        periodic.addAll(flows)
+        val xirr = irrCalculator.calculate(periodic)
+        return BigDecimal(xirr).setScale(6, RoundingMode.HALF_UP)
     }
 
     private data class DisplaySnapshot(

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
@@ -16,6 +16,7 @@ import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.position.accumulation.Accumulator
+import com.beancounter.position.irr.IrrCalculator
 import com.beancounter.position.irr.TwrCalculator
 import com.beancounter.position.service.PerformanceService
 import org.assertj.core.api.Assertions.assertThat
@@ -94,6 +95,7 @@ class PerformanceServiceCacheTest {
                 priceService = priceService,
                 fxRateService = fxRateService,
                 twrCalculator = twrCalculator,
+                irrCalculator = IrrCalculator(minHoldingDays = 365, dateUtils = dateUtils),
                 dateUtils = dateUtils,
                 tokenService = tokenService,
                 cacheService = cacheService

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceAggregateTest.kt
@@ -17,6 +17,7 @@ import com.beancounter.common.utils.DateUtils
 import com.beancounter.position.accumulation.Accumulator
 import com.beancounter.position.cache.CachedSnapshot
 import com.beancounter.position.cache.PerformanceCacheService
+import com.beancounter.position.irr.IrrCalculator
 import com.beancounter.position.irr.TwrCalculator
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
@@ -77,6 +78,7 @@ class PerformanceAggregateTest {
 
     @BeforeEach
     fun setup() {
+        val dateUtils = DateUtils()
         service =
             PerformanceService(
                 trnService = trnService,
@@ -84,7 +86,12 @@ class PerformanceAggregateTest {
                 priceService = priceService,
                 fxRateService = fxRateService,
                 twrCalculator = TwrCalculator(),
-                dateUtils = DateUtils(),
+                irrCalculator =
+                    IrrCalculator(
+                        minHoldingDays = 365,
+                        dateUtils = dateUtils
+                    ),
+                dateUtils = dateUtils,
                 tokenService = tokenService,
                 cacheService = cacheService
             )
@@ -541,5 +548,156 @@ class PerformanceAggregateTest {
         val expected = (50.0 / 110.0) * 1.10 + (60.0 / 110.0) * 1.20
         assertThat(out[1].growthOf1000.toDouble())
             .isCloseTo(1000.0 * expected, Offset.offset(0.5))
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // XIRR (money-weighted return) — investor's POV over the window
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `xirr for single-portfolio doubling over 1 year is approximately 100 percent`() {
+        // Investor invests $1000 at startDate, realises $2000 at endDate.
+        // NPV: -1000 + 2000 / (1+r)^1 = 0 → r = 1.0
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2024-01-01", "1000", "1000", netContributions = "1000"),
+                point("2025-01-01", "2000", "2000", netContributions = "1000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.xirr).isNotNull
+        assertThat(result.data.xirr!!.toDouble())
+            .isCloseTo(1.0, Offset.offset(0.01))
+    }
+
+    @Test
+    fun `xirr accounts for mid-window deposit timing`() {
+        // -$1000 at t=0, -$500 deposit at t=0.5, +$1800 at t=1.
+        // Solving: -1000 - 500/(1+r)^0.5 + 1800/(1+r) = 0 ⇒ r ≈ 0.241
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2024-01-01", "1000", "1000", netContributions = "1000"),
+                // ~6 months in: deposit lifts MV (modelled as a step; growthOf1000 unchanged for simplicity)
+                point("2024-07-01", "1000", "1500", netContributions = "1500"),
+                point("2025-01-01", "1800", "1800", netContributions = "1500")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.xirr).isNotNull
+        // Hand-computed root ≈ 0.241; allow a few percent for date-fraction precision.
+        assertThat(result.data.xirr!!.toDouble())
+            .isCloseTo(0.241, Offset.offset(0.02))
+    }
+
+    @Test
+    fun `xirr pools multi-portfolio flows, distinct from average of per-portfolio xirrs`() {
+        // P1: -100 → +200 (100% over 1Y).  P2: -200 → +200 (0% over 1Y).
+        // Pooled: -300 → +400 ⇒ r = 1/3 ≈ 0.333. Average of (1.0, 0.0) = 0.5.
+        // Pooled XIRR must differ from the simple average — proves pooling, not averaging.
+        val p1 = portfolio("P1", usd)
+        val p2 = portfolio("P2", usd)
+        val seriesP1 =
+            listOf(
+                point("2024-01-01", "1000", "100", netContributions = "100"),
+                point("2025-01-01", "2000", "200", netContributions = "100")
+            )
+        val seriesP2 =
+            listOf(
+                point("2024-01-01", "1000", "200", netContributions = "200"),
+                point("2025-01-01", "1000", "200", netContributions = "200")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio =
+                    listOf(
+                        p1 to PerformanceData(usd, seriesP1),
+                        p2 to PerformanceData(usd, seriesP2)
+                    ),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.xirr).isNotNull
+        assertThat(result.data.xirr!!.toDouble())
+            .isCloseTo(0.333, Offset.offset(0.02))
+        // Not the simple average (0.5).
+        assertThat(result.data.xirr!!.toDouble()).isLessThan(0.45)
+    }
+
+    @Test
+    fun `xirr returns simple ROI for sub-year window via IrrCalculator fallback`() {
+        // 6-month window under IrrCalculator's minHoldingDays=365 → simpleRoi
+        // simpleRoi = (returns − investment) / investment = (1100 − 1000) / 1000 = 0.10
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2024-07-01", "1000", "1000", netContributions = "1000"),
+                point("2025-01-01", "1100", "1100", netContributions = "1000")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.xirr).isNotNull
+        assertThat(result.data.xirr!!.toDouble())
+            .isCloseTo(0.10, Offset.offset(0.005))
+    }
+
+    @Test
+    fun `xirr is null when no portfolios produce flows`() {
+        val result =
+            service.composeAggregate(
+                perPortfolio = emptyList(),
+                displayCurrency = usd,
+                fxRates = emptyMap()
+            )
+        assertThat(result.data.xirr).isNull()
+    }
+
+    @Test
+    fun `xirr handles new portfolio with zero anchor and mid-window deposit`() {
+        // Backend's synthesised zero anchor: series[0] has mv=0, contrib=0.
+        // The zero start MV is skipped in the flow stream, so the effective
+        // flow span runs from the deposit (Jul) to year-end — only 6 months.
+        // That's below IrrCalculator.minHoldingDays (365), so the calculator
+        // returns the simple ROI on the actual contributed capital:
+        //   ROI = (22 − 20) / 20 = 0.10
+        val p = portfolio("P1", usd)
+        val series =
+            listOf(
+                point("2024-01-01", "1000", "0", netContributions = "0"),
+                point("2024-07-01", "1000", "20", netContributions = "20"),
+                point("2025-01-01", "1100", "22", netContributions = "20")
+            )
+
+        val result =
+            service.composeAggregate(
+                perPortfolio = listOf(p to PerformanceData(usd, series)),
+                displayCurrency = usd,
+                fxRates = mapOf("USD" to BigDecimal.ONE)
+            )
+
+        assertThat(result.data.xirr).isNotNull
+        assertThat(result.data.xirr!!.toDouble())
+            .isCloseTo(0.10, Offset.offset(0.005))
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
@@ -19,6 +19,7 @@ import com.beancounter.position.Constants.Companion.USD
 import com.beancounter.position.Constants.Companion.owner
 import com.beancounter.position.accumulation.Accumulator
 import com.beancounter.position.cache.NoOpPerformanceCacheService
+import com.beancounter.position.irr.IrrCalculator
 import com.beancounter.position.irr.TwrCalculator
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
@@ -84,6 +85,7 @@ class PerformanceServiceTest {
                 priceService = priceService,
                 fxRateService = fxRateService,
                 twrCalculator = twrCalculator,
+                irrCalculator = IrrCalculator(minHoldingDays = 365, dateUtils = dateUtils),
                 dateUtils = dateUtils,
                 tokenService = tokenService,
                 cacheService = NoOpPerformanceCacheService()


### PR DESCRIPTION
## Summary
- Adds aggregate **money-weighted return (XIRR)** to \`POST /performance/aggregate\`. TWR answers "how did the strategy perform"; XIRR answers "what did MY money earn given when I added it" — for a personal wealth widget, XIRR is the more meaningful headline.
- New field: \`AggregatedPerformanceData.xirr: BigDecimal?\`. Null when fewer than 2 flows or solver bails.

## How
\`PerformanceService.composeAggregate\` pools investor-POV cash flows across all portfolios in the display currency and feeds them to the existing \`IrrCalculator\`:
- t=startDate: \`−marketValue\` (capital invested at window start)
- t=mid: \`−Δ netContributions\` per snapshot (deposit = wallet outflow)
- t=endDate: \`+marketValue\` (capital realised at window end)

\`IrrCalculator\` already handles:
- Short-window fallback to simple ROI when first→last flow span < \`minHoldingDays\` (default 365)
- Brent solver with \`NoBracketingException\` → simple ROI fallback
- Sign-validity, empty/single-flow short-circuits

## Trade-off
FX is applied at today's rate uniformly across the window (consistent with composite TWR). For mixed-currency portfolios with volatile pairs, historical FX per flow date would be more accurate. Documented as a follow-up; no functional change for single-currency or stable-FX setups.

## Test plan
- [x] New \`PerformanceAggregateTest\` cases: 1Y doubling, mid-window deposit, multi-portfolio pooling distinct from average, sub-year fallback, empty portfolios → null, zero-anchor edge.
- [x] \`./gradlew testSmart\` green.
- [x] \`./gradlew formatKotlin && ./gradlew lintKotlin\` green.
- [ ] bc-view companion PR wires the XIRR field into the Wealth Performance card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XIRR (money-weighted return) calculation for aggregated portfolio performance, providing an annualized decimal representation of returns across multiple holdings.
  * XIRR automatically falls back to simple ROI for periods shorter than one year when insufficient data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/839)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->