### PR TITLE
fix(svc-data): correct io.opentelemetry logger key typo

### DIFF
--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -55,7 +55,7 @@ logging:
     netflix: error
     jdk: error
     io:
-      openttelemetry: error
+      opentelemetry: error
       github:
         resilience4j: error
     okhttp3: error


### PR DESCRIPTION
## Summary

`application.yml` had `logging.level.io.openttelemetry: error` — note the double t. The real package is `io.opentelemetry`, so the existing intent (silence OTEL at error level) never took effect. Removing the typo silences the recurring noise that surfaces on every incoming request without B3 headers (any local curl / browser / health probe):

```
B3PropagatorExtractorMultipleHeaders : Invalid TraceId in B3 header: null'. Returning INVALID span context.
BaggageTextMapPropagator             : Will propagate new baggage context for entries {}
```

One-line config change. No behavioural impact — only the logger threshold for the OTEL packages.

## Test plan

- [x] `./gradlew :svc-data:lintKotlin` — green
- [ ] `SPRING_PROFILES_ACTIVE=local ./gradlew :svc-data:bootRun`, hit any endpoint, confirm no more B3/Baggage lines in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a configuration typo that was preventing OpenTelemetry logging from working properly. The logging level for OpenTelemetry is now properly recognized and set to error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/842)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->