### PR TITLE
feat(svc-data): persist EODHD news in Postgres (30-day window)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -122,6 +122,10 @@ Apply these only when the diff touches `*.kt` files. Skip if the file is a gener
   - Defaults in `@Value("\${prop:fallback}")` MUST match the corresponding `application.yml` value — silent drift otherwise. When a diff changes one, flag if the other isn't touched.
 - **URI template hygiene** (Spring `RestClient.uri(template, vars)`):
   - String-interpolating values into the template (`"/api?x=$value"`) bypasses Spring's URI encoding and is unsafe even for internal callers if the value can ever contain reserved chars. Flag any `uri("…${var}…")` in a gateway/client — prefer `uri("…{var}…", value)` with the placeholder pattern.
+- **Upstream-failure backoff (quota amplification)**:
+  - When an external API call fails and a cache/cooldown row is only updated on success, every subsequent request re-hits the upstream — turning a transient outage or a 429 into a retry storm that burns quota and amplifies the upstream's load. Flag any provider integration where the cache TTL / cooldown record advances **only** on the success path. Recommend bumping the `last_fetched_at` (or equivalent) in the `catch` block so failures respect the same backoff window. Real BC incident: EODHD news service in PR #845 — caller would have retry-stormed on every 429 until CodeRabbit caught it.
+- **Read-then-save upsert race**:
+  - Code that does `findByX` → conditionally `new()` → `save()` can race when two concurrent transactions both miss the read and both try to insert the same unique key. Postgres throws on the second insert; Spring surfaces it as `DataIntegrityViolationException`. Flag any read-then-save against a `@Column(unique=true)` / `@UniqueConstraint` field that doesn't wrap the `save` in a `try`/`catch` that re-reads the winning row and merges. JPA has no native upsert — the catch-and-retry pattern is the canonical fix without dropping to dialect-specific SQL. Severity 🟠 because the symptom is sporadic 500s, not deterministic, so it slips through tests easily.
 
 ### Idioms — TypeScript / Next.js (bc-view)
 
@@ -236,6 +240,8 @@ specific severity:
 | 13 | Scalar property added under a `@ConfigurationProperties` prefix that also has map siblings (YAML binder break) | 🟠 |
 | 14 | Kotlin 2.x `@Value($$"${prop:default}")` flagged as "invalid syntax" (false-positive regression) | NOT a finding — must NOT be flagged |
 | 15 | `RestClient.uri("/api?from=$var")` string-interpolating into the URI template | 🟡 |
+| 16 | Provider `catch` block doesn't bump cache/cooldown timestamp → next request retry-storms the upstream | 🟠 |
+| 17 | Read-then-save against a unique-constrained column without `DataIntegrityViolationException` retry-as-merge | 🟠 |
 
 After **any** edit to this `SKILL.md`, re-run the suite to confirm recall
 hasn't regressed:

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/MarketDataBoot.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/MarketDataBoot.kt
@@ -25,7 +25,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
     "com.beancounter.common.model",
     "com.beancounter.marketdata.assets",
     "com.beancounter.marketdata.tax",
-    "com.beancounter.marketdata.broker"
+    "com.beancounter.marketdata.broker",
+    "com.beancounter.marketdata.providers.eodhd.news"
 )
 @EnableWebSecurity
 @EnableConfigurationProperties

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/config/CacheConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/config/CacheConfig.kt
@@ -39,8 +39,9 @@ class CacheConfig {
                 ConcurrentMapCache(name)
             } + CaffeineCache("alpha.asset.event", Duration.ofMinutes(10), 200) +
                 CaffeineCache("eodhd.asset.event", Duration.ofMinutes(10), 200) +
-                CaffeineCache("news.sentiment", Duration.ofMinutes(30), 100) +
-                CaffeineCache("eodhd.news.sentiment", Duration.ofMinutes(30), 100)
+                CaffeineCache("news.sentiment", Duration.ofMinutes(30), 100)
+        // Note: EODHD news is no longer cached in-memory — it persists to `news_article` and is
+        // served from there. See EodhdNewsService + V19 migration.
 
         return SimpleCacheManager().apply {
             setCaches(caches)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsProperties.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsProperties.kt
@@ -12,5 +12,15 @@ data class EodhdNewsProperties(
     /** Top-N articles returned to the caller after ranking. */
     val maxArticles: Int = 5,
     /** How many articles to ask EODHD for per ticker before we rank + merge. */
-    val providerLimit: Int = 50
+    val providerLimit: Int = 50,
+    /**
+     * Re-hit EODHD when the per-ticker cache row in `news_fetch` is older than this many hours.
+     * Default 6 → ~4 refreshes/day per active ticker, well within EODHD's ~1200 req/day quota.
+     */
+    val refreshAfterHours: Long = 6,
+    /**
+     * Articles whose `published` timestamp is older than this many days get pruned by
+     * [com.beancounter.marketdata.providers.eodhd.news.NewsRetentionSchedule].
+     */
+    val retentionDays: Long = 30
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -2,37 +2,44 @@ package com.beancounter.marketdata.providers.eodhd
 
 import com.beancounter.marketdata.providers.NewsProvider
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticle
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleTicker
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetch
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
+import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
 import kotlin.math.abs
 
 /**
- * EODHD `/api/news` adapter, projecting the EODHD response into the AV-compatible `{feed, count}`
- * shape that svc-agent's NewsTools already consumes.
+ * DB-backed EODHD news adapter. The read path always returns from the [NewsArticle] table; the
+ * write path only re-hits EODHD when the per-ticker entry in [NewsFetch] is older than
+ * `eodhd.news.refresh-after-hours` (default 6h). Articles persist for `retention-days` (default 30)
+ * and the daily [com.beancounter.marketdata.providers.eodhd.news.NewsRetentionSchedule] prunes
+ * anything older.
  *
- * Each ticker is queried individually because EODHD's news endpoint is single-symbol. The merged
- * results are ranked by `|sentiment.polarity|` (strongest opinion first) and truncated to
- * [EodhdNewsProperties.maxArticles] so the LLM tool_result stays compact.
- *
- * EODHD's response carries a richer per-article sentiment than AV (polarity + pos/neg/neu split).
- * The projection keeps both the AV-style `sentimentLabel` / `sentimentScore` keys so existing
- * consumers don't change shape, and adds `polarity` + `tags` + `symbols` as bonus fields the
- * LLM can use for context.
+ * The projection back to the caller keeps the AV-compatible `{feed, count}` shape so
+ * svc-agent's NewsTools doesn't change. EODHD-specific fields (`polarity`, `tags`, `symbols`) are
+ * also returned because they're useful context for the LLM.
  */
 @Service
 class EodhdNewsService(
     private val eodhdProxy: EodhdProxy,
     private val eodhdConfig: EodhdConfig,
-    private val newsProperties: EodhdNewsProperties
+    private val newsProperties: EodhdNewsProperties,
+    private val newsArticleRepo: NewsArticleRepo,
+    private val newsFetchRepo: NewsFetchRepo
 ) : NewsProvider {
     private val log = LoggerFactory.getLogger(EodhdNewsService::class.java)
 
-    // Key components are separated by `|` and each null defaults to a sentinel so the cache
-    // doesn't collide on legitimate values that contain dashes (e.g. tickers like `BRK-B`).
-    @Cacheable("eodhd.news.sentiment", key = "#tickers + '|' + (#market ?: '~') + '|' + (#topics ?: '~')")
+    @Transactional
     override fun getNewsSentiment(
         tickers: String,
         market: String?,
@@ -41,31 +48,20 @@ class EodhdNewsService(
         val symbols = resolveSymbols(tickers, market)
         if (symbols.isEmpty()) return emptyMap()
 
-        val all = mutableListOf<EodhdNewsArticle>()
+        val refreshCutoff = LocalDateTime.now().minusHours(newsProperties.refreshAfterHours)
         for (symbol in symbols) {
-            try {
-                all.addAll(
-                    eodhdProxy.getNews(
-                        symbol = symbol,
-                        limit = newsProperties.providerLimit,
-                        from = null,
-                        apiKey = eodhdConfig.apiKey
-                    )
-                )
-            } catch (
-                @Suppress("TooGenericExceptionCaught")
-                e: Exception
-            ) {
-                log.debug("EODHD news lookup failed for {}: {}", symbol, e.message)
+            if (shouldRefresh(symbol, refreshCutoff)) {
+                refreshFromUpstream(symbol)
             }
         }
-        if (all.isEmpty()) return emptyMap()
 
+        val retentionStart = LocalDateTime.now().minusDays(newsProperties.retentionDays)
+        val stored = newsArticleRepo.findByTickersAfter(symbols, retentionStart)
         val ranked =
-            all
+            stored
                 .asSequence()
                 .filter { topics.isNullOrBlank() || matchesTopic(it, topics) }
-                .sortedByDescending { abs(polarityOf(it)) }
+                .sortedByDescending { abs(it.polarity.toDouble()) }
                 .take(newsProperties.maxArticles)
                 .map { project(it) }
                 .toList()
@@ -77,11 +73,91 @@ class EodhdNewsService(
         )
     }
 
-    /**
-     * Compose `${ticker}.${exchange}` per EODHD's convention.
-     * - When a market is supplied, look up its `eodhd:` alias (US, LSE, AU, …).
-     * - When omitted, default to the `US` exchange — EODHD's convention for NYSE/NASDAQ/AMEX equities.
-     */
+    private fun shouldRefresh(
+        symbol: String,
+        cutoff: LocalDateTime
+    ): Boolean {
+        val meta = newsFetchRepo.findById(symbol).orElse(null)
+        return meta == null || meta.lastFetchedAt.isBefore(cutoff)
+    }
+
+    private fun refreshFromUpstream(symbol: String) {
+        try {
+            val fresh =
+                eodhdProxy.getNews(
+                    symbol = symbol,
+                    limit = newsProperties.providerLimit,
+                    from = null,
+                    apiKey = eodhdConfig.apiKey
+                )
+            upsertAll(symbol, fresh)
+            newsFetchRepo.save(NewsFetch(symbol, LocalDateTime.now(), fresh.size))
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.debug("EODHD news lookup failed for {}: {}", symbol, e.message)
+            // Don't poison the next refresh — keep the existing news_fetch row so the stale-cutoff
+            // logic falls back to whatever the DB has without thrashing on a broken upstream.
+        }
+    }
+
+    private fun upsertAll(
+        symbol: String,
+        fresh: List<EodhdNewsArticle>
+    ) {
+        for (incoming in fresh) {
+            val externalId = incoming.link.ifBlank { "${incoming.date}|${incoming.title}" }
+            val existing = newsArticleRepo.findByExternalId(externalId).orElse(null)
+            val article = existing ?: NewsArticle(externalId = externalId)
+            article.externalId = externalId
+            article.published = parsePublished(incoming.date)
+            article.title = incoming.title
+            article.content = incoming.content
+            article.link = incoming.link
+            incoming.sentiment?.let { s ->
+                article.polarity = s.polarity
+                article.sentimentPos = s.pos
+                article.sentimentNeg = s.neg
+                article.sentimentNeu = s.neu
+            }
+            article.source = "EODHD"
+            article.fetchedAt = LocalDateTime.now()
+
+            // Refresh the tag set — EODHD can revise tags between fetches.
+            article.tags.clear()
+            article.tags.addAll(incoming.tags)
+
+            // Symbols: keep raw EODHD tickers + ensure the queried symbol is always present so a
+            // ticker that only appears in `symbols[]` on one update isn't lost.
+            val symbolSet = (incoming.symbols + symbol).toSet()
+            val existingTickers = article.tickerLinks.map { it.ticker }.toSet()
+            for (t in symbolSet - existingTickers) {
+                article.tickerLinks.add(NewsArticleTicker(ticker = t))
+            }
+
+            newsArticleRepo.save(article)
+        }
+    }
+
+    private fun parsePublished(raw: String): LocalDateTime =
+        try {
+            // EODHD ships `2026-05-15T05:15:00+00:00` — keep an OffsetDateTime parse for safety.
+            OffsetDateTime.parse(raw).toLocalDateTime()
+        } catch (
+            @Suppress("SwallowedException")
+            e: DateTimeParseException
+        ) {
+            try {
+                LocalDateTime.parse(raw)
+            } catch (
+                @Suppress("SwallowedException")
+                e2: DateTimeParseException
+            ) {
+                LocalDateTime.now(ZoneOffset.UTC)
+            }
+        }
+
     private fun resolveSymbols(
         tickers: String,
         market: String?
@@ -107,31 +183,29 @@ class EodhdNewsService(
             .map { "$it.$exchange" }
     }
 
-    private fun polarityOf(article: EodhdNewsArticle): Double = article.sentiment?.polarity?.toDouble() ?: 0.0
-
     private fun matchesTopic(
-        article: EodhdNewsArticle,
+        article: NewsArticle,
         topic: String
     ): Boolean {
         val needle = topic.trim().uppercase()
         return article.tags.any { it.uppercase() == needle }
     }
 
-    private fun project(article: EodhdNewsArticle): Map<String, Any> {
-        val polarity = polarityOf(article)
+    private fun project(article: NewsArticle): Map<String, Any> {
+        val polarity = article.polarity.toDouble()
         return mapOf(
             "title" to article.title,
             "summary" to article.content.take(SUMMARY_CHARS),
             "source" to article.link,
-            "timePublished" to article.date,
+            "timePublished" to article.published.toString(),
             "sentimentLabel" to labelFor(polarity),
             "sentimentScore" to scaledScore(polarity),
             "relevance" to 1.0,
             "tickerSentimentLabel" to labelFor(polarity),
             "tickerSentimentScore" to scaledScore(polarity),
             "polarity" to polarity,
-            "symbols" to article.symbols,
-            "tags" to article.tags
+            "symbols" to article.tickerLinks.map { it.ticker },
+            "tags" to article.tags.toList()
         )
     }
 
@@ -146,13 +220,9 @@ class EodhdNewsService(
         }
 
     companion object {
-        // Cap the article body fed back to the LLM so tool_result payloads stay small.
         private const val SUMMARY_CHARS = 400
-
-        // EODHD polarity is roughly [-1, 1]. Bands align with AV's Bullish/Neutral/Bearish vocabulary.
         private const val BULLISH_THRESHOLD = 0.35
         private const val BEARISH_THRESHOLD = -0.35
-
         private val TICKER_PATTERN = Regex("[A-Z0-9.-]{1,10}")
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -9,6 +9,7 @@ import com.beancounter.marketdata.providers.eodhd.news.NewsFetch
 import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -97,8 +98,13 @@ class EodhdNewsService(
             e: Exception
         ) {
             log.debug("EODHD news lookup failed for {}: {}", symbol, e.message)
-            // Don't poison the next refresh — keep the existing news_fetch row so the stale-cutoff
-            // logic falls back to whatever the DB has without thrashing on a broken upstream.
+            // Burn the refresh cooldown even on failure — otherwise a transient EODHD outage
+            // or 429 turns every subsequent request into a quota-amplifying retry storm. Next
+            // attempt waits `refresh-after-hours`, matching the success-path backoff. Articles
+            // already in the DB keep serving in the meantime.
+            val existing = newsFetchRepo.findById(symbol).orElseGet { NewsFetch(symbol) }
+            existing.lastFetchedAt = LocalDateTime.now()
+            newsFetchRepo.save(existing)
         }
     }
 
@@ -108,35 +114,64 @@ class EodhdNewsService(
     ) {
         for (incoming in fresh) {
             val externalId = incoming.link.ifBlank { "${incoming.date}|${incoming.title}" }
-            val existing = newsArticleRepo.findByExternalId(externalId).orElse(null)
-            val article = existing ?: NewsArticle(externalId = externalId)
-            article.externalId = externalId
-            article.published = parsePublished(incoming.date)
-            article.title = incoming.title
-            article.content = incoming.content
-            article.link = incoming.link
-            incoming.sentiment?.let { s ->
-                article.polarity = s.polarity
-                article.sentimentPos = s.pos
-                article.sentimentNeg = s.neg
-                article.sentimentNeu = s.neu
-            }
-            article.source = "EODHD"
-            article.fetchedAt = LocalDateTime.now()
+            saveOrMerge(symbol, externalId, incoming)
+        }
+    }
 
-            // Refresh the tag set — EODHD can revise tags between fetches.
-            article.tags.clear()
-            article.tags.addAll(incoming.tags)
-
-            // Symbols: keep raw EODHD tickers + ensure the queried symbol is always present so a
-            // ticker that only appears in `symbols[]` on one update isn't lost.
-            val symbolSet = (incoming.symbols + symbol).toSet()
-            val existingTickers = article.tickerLinks.map { it.ticker }.toSet()
-            for (t in symbolSet - existingTickers) {
-                article.tickerLinks.add(NewsArticleTicker(ticker = t))
-            }
-
+    /**
+     * Defensive upsert: read-then-save can race when two concurrent refreshes for overlapping
+     * tickers find the same `external_id` missing and both try to insert. The DB unique constraint
+     * catches one transaction with a [DataIntegrityViolationException]; we then re-fetch the row
+     * the winner inserted and merge our fields into it. Idempotent — at worst we do one extra read
+     * + write on contention.
+     */
+    private fun saveOrMerge(
+        symbol: String,
+        externalId: String,
+        incoming: EodhdNewsArticle
+    ) {
+        val existing = newsArticleRepo.findByExternalId(externalId).orElse(null)
+        val article = existing ?: NewsArticle(externalId = externalId)
+        applyIncoming(article, externalId, symbol, incoming)
+        try {
             newsArticleRepo.save(article)
+        } catch (e: DataIntegrityViolationException) {
+            val winner = newsArticleRepo.findByExternalId(externalId).orElseThrow { e }
+            applyIncoming(winner, externalId, symbol, incoming)
+            newsArticleRepo.save(winner)
+        }
+    }
+
+    private fun applyIncoming(
+        article: NewsArticle,
+        externalId: String,
+        symbol: String,
+        incoming: EodhdNewsArticle
+    ) {
+        article.externalId = externalId
+        article.published = parsePublished(incoming.date)
+        article.title = incoming.title
+        article.content = incoming.content
+        article.link = incoming.link
+        incoming.sentiment?.let { s ->
+            article.polarity = s.polarity
+            article.sentimentPos = s.pos
+            article.sentimentNeg = s.neg
+            article.sentimentNeu = s.neu
+        }
+        article.source = "EODHD"
+        article.fetchedAt = LocalDateTime.now()
+
+        // Refresh the tag set — EODHD can revise tags between fetches.
+        article.tags.clear()
+        article.tags.addAll(incoming.tags)
+
+        // Symbols: keep raw EODHD tickers + ensure the queried symbol is always present so a
+        // ticker that only appears in `symbols[]` on one update isn't lost.
+        val symbolSet = (incoming.symbols + symbol).toSet()
+        val existingTickers = article.tickerLinks.map { it.ticker }.toSet()
+        for (t in symbolSet - existingTickers) {
+            article.tickerLinks.add(NewsArticleTicker(ticker = t))
         }
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
@@ -1,0 +1,72 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import com.beancounter.common.utils.KeyGenUtils
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * A news article cached from EODHD's `/api/news` endpoint.
+ *
+ * Articles fan out to many tickers via [NewsArticleTicker]; the EODHD response always carries the
+ * full `symbols[]` list per article, so a single piece of news referencing five companies is stored
+ * once and joined five ways. Tags are a simple string set ([tags]) — sufficient for the topic
+ * filter without the overhead of a separate entity.
+ *
+ * Dedup key is [externalId] (the EODHD article link, which is stable per article). Retention is
+ * driven by [published]; rows older than `eodhd.news.retention-days` (default 30) are pruned daily
+ * by [NewsRetentionSchedule].
+ */
+@Entity
+@Table(
+    name = "news_article",
+    uniqueConstraints = [UniqueConstraint(name = "uk_news_article_external", columnNames = ["external_id"])]
+)
+data class NewsArticle(
+    @Column(name = "external_id", nullable = false, length = 2048)
+    var externalId: String = "",
+    @Column(nullable = false)
+    var published: LocalDateTime = LocalDateTime.now(),
+    @Column(nullable = false, length = 1024)
+    var title: String = "",
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String = "",
+    @Column(nullable = false, length = 2048)
+    var link: String = "",
+    @Column(precision = 7, scale = 4, nullable = false)
+    var polarity: BigDecimal = BigDecimal.ZERO,
+    @Column(name = "sentiment_pos", precision = 7, scale = 4, nullable = false)
+    var sentimentPos: BigDecimal = BigDecimal.ZERO,
+    @Column(name = "sentiment_neg", precision = 7, scale = 4, nullable = false)
+    var sentimentNeg: BigDecimal = BigDecimal.ZERO,
+    @Column(name = "sentiment_neu", precision = 7, scale = 4, nullable = false)
+    var sentimentNeu: BigDecimal = BigDecimal.ZERO,
+    @Column(nullable = false, length = 16)
+    var source: String = "EODHD",
+    @Column(name = "fetched_at", nullable = false)
+    var fetchedAt: LocalDateTime = LocalDateTime.now(),
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "news_article_tag",
+        joinColumns = [JoinColumn(name = "article_id")]
+    )
+    @Column(name = "tag", length = 64)
+    var tags: MutableSet<String> = mutableSetOf(),
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "news_article_ticker",
+        joinColumns = [JoinColumn(name = "article_id")]
+    )
+    var tickerLinks: MutableSet<NewsArticleTicker> = mutableSetOf()
+) {
+    @Id
+    val id: String = KeyGenUtils().id
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleRepo.kt
@@ -1,0 +1,34 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+import java.util.Optional
+
+/**
+ * CRUD + window finders for [NewsArticle]. The two key surfaces:
+ *  - [findByTickersAfter] — read path: pull articles for one or more tickers published inside the
+ *    retention window (`since = now - retention-days`).
+ *  - [deleteByPublishedBefore] — retention sweep, called from [NewsRetentionSchedule].
+ */
+interface NewsArticleRepo : CrudRepository<NewsArticle, String> {
+    fun findByExternalId(externalId: String): Optional<NewsArticle>
+
+    @Query(
+        "SELECT DISTINCT a FROM NewsArticle a JOIN a.tickerLinks t " +
+            "WHERE t.ticker IN :tickers AND a.published >= :since " +
+            "ORDER BY a.published DESC"
+    )
+    fun findByTickersAfter(
+        @Param("tickers") tickers: Collection<String>,
+        @Param("since") since: LocalDateTime
+    ): List<NewsArticle>
+
+    @Modifying
+    @Query("DELETE FROM NewsArticle a WHERE a.published < :threshold")
+    fun deleteByPublishedBefore(
+        @Param("threshold") threshold: LocalDateTime
+    ): Int
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleTicker.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleTicker.kt
@@ -1,0 +1,20 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+/**
+ * Row in the `news_article_ticker` join table. Stored as an `@ElementCollection` on
+ * [NewsArticle.tickerLinks] rather than as a bidirectional `@Entity` so the data-class hashCode
+ * doesn't cycle. The DB primary key `(article_id, ticker)` is enforced by the V19 migration.
+ *
+ * [ticker] is the raw EODHD symbol verbatim (e.g. `AAPL.US`, `0ZG.F`). [assetId] is populated
+ * opportunistically when the ticker resolves to a BC asset row; null otherwise.
+ */
+@Embeddable
+data class NewsArticleTicker(
+    @Column(name = "ticker", length = 32, nullable = false)
+    var ticker: String = "",
+    @Column(name = "asset_id", length = 36)
+    var assetId: String? = null
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
@@ -1,0 +1,24 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * Per-ticker fetch metadata. Gates the next EODHD news request: if `lastFetchedAt` is older than
+ * `eodhd.news.refresh-after-hours`, the next /news call for that ticker re-hits EODHD; otherwise we
+ * serve entirely from the [NewsArticle] table.
+ */
+@Entity
+@Table(name = "news_fetch")
+data class NewsFetch(
+    @Id
+    @Column(nullable = false, length = 32)
+    var ticker: String = "",
+    @Column(name = "last_fetched_at", nullable = false)
+    var lastFetchedAt: LocalDateTime = LocalDateTime.now(),
+    @Column(name = "articles_found", nullable = false)
+    var articlesFound: Int = 0
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetchRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetchRepo.kt
@@ -1,0 +1,9 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import org.springframework.data.repository.CrudRepository
+
+/**
+ * CRUD for [NewsFetch] metadata. The service reads by ticker to decide whether the cached articles
+ * are still fresh enough; writes are upserts keyed on ticker.
+ */
+interface NewsFetchRepo : CrudRepository<NewsFetch, String>

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
@@ -1,0 +1,39 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import com.beancounter.marketdata.providers.eodhd.EodhdNewsProperties
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+/**
+ * Daily prune of news articles whose `published` timestamp is older than
+ * [EodhdNewsProperties.retentionDays]. CASCADE on the join tables cleans the ticker / tag rows.
+ *
+ * Gated on `schedule.enabled=true` — same pattern as [com.beancounter.marketdata.providers.PriceSchedule]
+ * so the prune doesn't fire in tests or local dev unless explicitly turned on.
+ */
+@Service
+@ConditionalOnProperty(
+    value = ["schedule.enabled"],
+    havingValue = "true",
+    matchIfMissing = false
+)
+class NewsRetentionSchedule(
+    private val newsArticleRepo: NewsArticleRepo,
+    private val newsProperties: EodhdNewsProperties
+) {
+    @Scheduled(cron = "0 0 3 * * *", zone = "#{@scheduleZone}")
+    @Transactional
+    fun prune() {
+        val cutoff = LocalDateTime.now().minusDays(newsProperties.retentionDays)
+        val deleted = newsArticleRepo.deleteByPublishedBefore(cutoff)
+        log.info("Pruned {} news articles older than {}", deleted, cutoff)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(NewsRetentionSchedule::class.java)
+    }
+}

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -528,6 +528,12 @@ beancounter:
           max-articles: 5
           # How many articles to ask EODHD for per ticker before merging + ranking.
           provider-limit: 50
+          # Per-ticker refresh interval. EODHD news endpoint quota is ~1200 req/day shared
+          # with svc-agent chat lookups; default 6h ≈ 4 refreshes/day per active ticker.
+          refresh-after-hours: 6
+          # Articles older than this are pruned daily by NewsRetentionSchedule. Combine with
+          # `schedule.enabled=true` to actually run the prune; otherwise it's a no-op bean.
+          retention-days: 30
 
       # OpenFIGI - free, unlimited, Bloomberg-based
       figi:

--- a/svc-data/src/main/resources/db/migration/V19__news_articles.sql
+++ b/svc-data/src/main/resources/db/migration/V19__news_articles.sql
@@ -1,0 +1,60 @@
+-- Persist EODHD news articles in Postgres so the /news endpoint can serve from the DB and only hit
+-- the EODHD wire once per ticker every `refresh-after-hours` (default 6h). EODHD's news endpoint
+-- carries its own ~1200 req/day quota shared with svc-agent's chat-driven LLM tool calls; without
+-- this cache, sustained chat traffic would exhaust the quota long before the 100K/day EOD price
+-- quota gets touched. Articles older than `retention-days` (default 30) are pruned by
+-- NewsRetentionSchedule so the table can't grow without bound.
+--
+-- Schema mirrors the EODHD article shape with one row per article + join tables for the many-to-many
+-- ticker tagging (EODHD ships `symbols[]` on every article) and tags. asset_id on the ticker join is
+-- nullable because EODHD reports tickers BC doesn't necessarily track (e.g. `0ZG.F`) — we keep the
+-- raw symbol so the LLM still sees the cross-name signal, while a populated asset_id makes
+-- asset-keyed queries fast.
+
+CREATE TABLE IF NOT EXISTS news_article (
+    id              VARCHAR(36)   PRIMARY KEY,
+    external_id     VARCHAR(2048) NOT NULL,
+    published       TIMESTAMP     NOT NULL,
+    title           VARCHAR(1024) NOT NULL,
+    content         TEXT          NOT NULL,
+    link            VARCHAR(2048) NOT NULL,
+    polarity        DECIMAL(7, 4) NOT NULL DEFAULT 0,
+    sentiment_pos   DECIMAL(7, 4) NOT NULL DEFAULT 0,
+    sentiment_neg   DECIMAL(7, 4) NOT NULL DEFAULT 0,
+    sentiment_neu   DECIMAL(7, 4) NOT NULL DEFAULT 0,
+    source          VARCHAR(16)   NOT NULL,
+    fetched_at      TIMESTAMP     NOT NULL,
+    CONSTRAINT uk_news_article_external UNIQUE (external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_news_article_published ON news_article (published);
+
+CREATE TABLE IF NOT EXISTS news_article_ticker (
+    article_id      VARCHAR(36) NOT NULL,
+    ticker          VARCHAR(32) NOT NULL,
+    asset_id        VARCHAR(36),
+    PRIMARY KEY (article_id, ticker),
+    CONSTRAINT fk_nat_article FOREIGN KEY (article_id)
+        REFERENCES news_article (id) ON DELETE CASCADE,
+    CONSTRAINT fk_nat_asset   FOREIGN KEY (asset_id)
+        REFERENCES asset (id)        ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_nat_ticker   ON news_article_ticker (ticker);
+CREATE INDEX IF NOT EXISTS idx_nat_asset_id ON news_article_ticker (asset_id);
+
+CREATE TABLE IF NOT EXISTS news_article_tag (
+    article_id      VARCHAR(36) NOT NULL,
+    tag             VARCHAR(64) NOT NULL,
+    PRIMARY KEY (article_id, tag),
+    CONSTRAINT fk_natg_article FOREIGN KEY (article_id)
+        REFERENCES news_article (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_natg_tag ON news_article_tag (tag);
+
+CREATE TABLE IF NOT EXISTS news_fetch (
+    ticker           VARCHAR(32) PRIMARY KEY,
+    last_fetched_at  TIMESTAMP   NOT NULL,
+    articles_found   INTEGER     NOT NULL DEFAULT 0
+);

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -153,6 +153,61 @@ internal class EodhdNewsServiceTest {
     }
 
     @Test
+    fun `unparseable date timestamp falls back to now instead of throwing`() {
+        // EODHD has occasionally shipped articles with malformed dates; the service must not
+        // crash the request — falls back to `now(UTC)` and stores the row with the rest intact.
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        val broken =
+            EodhdNewsArticle(
+                date = "not-a-date",
+                title = "garbage date",
+                content = "body",
+                link = "https://example.com/news/broken",
+                symbols = listOf("AAPL.US"),
+                sentiment = EodhdArticleSentiment(polarity = BigDecimal("0.2"))
+            )
+        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(broken))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        // Must not throw.
+        service.getNewsSentiment("AAPL")
+
+        val captor = argumentCaptor<NewsArticle>()
+        verify(articleRepo).save(captor.capture())
+        assertThat(captor.firstValue.title).isEqualTo("garbage date")
+        // Stamped to ~now (in UTC — service uses LocalDateTime.now(ZoneOffset.UTC) as the fallback),
+        // not stuck on EPOCH or null.
+        assertThat(captor.firstValue.published)
+            .isAfter(LocalDateTime.now(java.time.ZoneOffset.UTC).minusMinutes(1))
+    }
+
+    @Test
+    fun `LocalDateTime-shaped published (no zone offset) parses successfully`() {
+        // Defensive path: the EODHD shape is always ISO-with-offset, but the parser falls through
+        // to LocalDateTime.parse() before giving up — pin that branch.
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        val noOffset =
+            EodhdNewsArticle(
+                date = "2026-05-15T09:00:00",
+                title = "no offset",
+                content = "body",
+                link = "https://example.com/news/no-offset",
+                symbols = listOf("AAPL.US"),
+                sentiment = EodhdArticleSentiment(polarity = BigDecimal("0.2"))
+            )
+        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(noOffset))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("AAPL")
+
+        val captor = argumentCaptor<NewsArticle>()
+        verify(articleRepo).save(captor.capture())
+        assertThat(captor.firstValue.published).isEqualTo(LocalDateTime.of(2026, 5, 15, 9, 0, 0))
+    }
+
+    @Test
     fun `upstream failure still advances news_fetch so we don't retry-storm the quota`() {
         // Without this the catch block would leave news_fetch missing/stale, so every subsequent
         // request would re-hit EODHD immediately — exactly the quota-burn scenario this PR fixes.

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -4,51 +4,84 @@ import com.beancounter.common.model.Market
 import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.eodhd.model.EodhdArticleSentiment
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticle
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleTicker
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetch
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.test.util.ReflectionTestUtils
 import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
 
 /**
- * Unit tests for [EodhdNewsService] — ticker resolution, ranking, projection, topic filter,
- * graceful-empty handling.
+ * Unit tests for [EodhdNewsService] with repos mocked. End-to-end persistence is covered by the
+ * Spring + WireMock integration test ([EodhdNewsApiTest]); these specs pin the routing logic, the
+ * refresh-gating, and the response shape.
  */
 internal class EodhdNewsServiceTest {
     private val proxy = mock<EodhdProxy>()
     private val marketService = mock<MarketService>()
-    private val props = EodhdNewsProperties(maxArticles = 3, providerLimit = 10)
-    private val config: EodhdConfig
-
-    init {
-        config =
-            EodhdConfig(marketService).also {
-                ReflectionTestUtils.setField(it, "apiKey", "demo")
-                ReflectionTestUtils.setField(it, "markets", "")
-            }
-    }
-
-    private val service = EodhdNewsService(proxy, config, props)
+    private val articleRepo = mock<NewsArticleRepo>()
+    private val fetchRepo = mock<NewsFetchRepo>()
+    private val props =
+        EodhdNewsProperties(
+            maxArticles = 3,
+            providerLimit = 10,
+            refreshAfterHours = 6,
+            retentionDays = 30
+        )
+    private val config =
+        EodhdConfig(marketService).also {
+            ReflectionTestUtils.setField(it, "apiKey", "demo")
+            ReflectionTestUtils.setField(it, "markets", "")
+        }
+    private val service = EodhdNewsService(proxy, config, props, articleRepo, fetchRepo)
 
     @Test
-    fun `resolves US tickers to the US exchange suffix`() {
-        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(article(0.8)))
+    fun `cache-miss triggers a refresh against EODHD for US tickers`() {
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(eodhArticle(0.8)))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
 
         service.getNewsSentiment("AAPL")
 
         verify(proxy).getNews(eq("AAPL.US"), eq(10), eq(null), eq("demo"))
+        verify(fetchRepo).save(any<NewsFetch>())
+    }
+
+    @Test
+    fun `fresh fetch metadata short-circuits the upstream call`() {
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(
+            Optional.of(NewsFetch("AAPL.US", LocalDateTime.now().minusHours(2), 5))
+        )
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("AAPL")
+
+        verify(proxy, never()).getNews(any(), any(), anyOrNull(), any())
+        verify(fetchRepo, never()).save(any<NewsFetch>())
     }
 
     @Test
     fun `routes non-US tickers via the eodhd market alias`() {
         whenever(marketService.getMarket("LON"))
             .thenReturn(Market(code = "LON", aliases = mapOf("eodhd" to "LSE")))
-        whenever(proxy.getNews(eq("BARC.LSE"), any(), anyOrNull(), any())).thenReturn(listOf(article(0.5)))
+        whenever(fetchRepo.findById("BARC.LSE")).thenReturn(Optional.empty())
+        whenever(proxy.getNews(eq("BARC.LSE"), any(), anyOrNull(), any())).thenReturn(listOf(eodhArticle(0.5)))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
 
         service.getNewsSentiment("BARC", market = "LON")
 
@@ -56,48 +89,43 @@ internal class EodhdNewsServiceTest {
     }
 
     @Test
-    fun `returns empty map when no articles are returned`() {
-        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenReturn(emptyList())
-
-        val result = service.getNewsSentiment("AAPL")
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `ranks by absolute polarity and truncates to maxArticles`() {
-        val articles =
+    fun `ranks stored articles by absolute polarity and truncates to maxArticles`() {
+        // No upstream refresh needed — fetch row is fresh.
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(
+            Optional.of(NewsFetch("AAPL.US", LocalDateTime.now().minusMinutes(30), 5))
+        )
+        val stored =
             listOf(
-                article(polarity = 0.1, title = "Low impact"),
-                article(polarity = -0.9, title = "Very bearish"),
-                article(polarity = 0.6, title = "Bullish"),
-                article(polarity = 0.4, title = "Mildly bullish"),
-                article(polarity = -0.2, title = "Slightly bearish")
+                storedArticle(polarity = 0.1, title = "Low impact"),
+                storedArticle(polarity = -0.9, title = "Very bearish"),
+                storedArticle(polarity = 0.6, title = "Bullish"),
+                storedArticle(polarity = 0.4, title = "Mildly bullish"),
+                storedArticle(polarity = -0.2, title = "Slightly bearish")
             )
-        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenReturn(articles)
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(stored)
 
         val result = service.getNewsSentiment("AAPL")
 
         @Suppress("UNCHECKED_CAST")
         val feed = result["feed"] as List<Map<String, Any>>
         assertThat(feed).hasSize(3)
-        // Strongest |polarity| first: 0.9, 0.6, 0.4
         assertThat(feed.map { it["title"] })
             .containsExactly("Very bearish", "Bullish", "Mildly bullish")
         assertThat(feed.first()["sentimentLabel"]).isEqualTo("Bearish")
-        assertThat(feed[1]["sentimentLabel"]).isEqualTo("Bullish")
-        assertThat(feed[2]["sentimentLabel"]).isEqualTo("Bullish")
         assertThat(result["count"]).isEqualTo(3)
     }
 
     @Test
     fun `topic filter restricts to articles carrying the matching tag`() {
-        val articles =
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(
+            Optional.of(NewsFetch("AAPL.US", LocalDateTime.now().minusMinutes(30), 2))
+        )
+        val stored =
             listOf(
-                article(polarity = 0.9, title = "Earnings beat", tags = listOf("EARNINGS")),
-                article(polarity = 0.8, title = "Random news", tags = listOf("MARKETS"))
+                storedArticle(polarity = 0.9, title = "Earnings beat", tags = setOf("EARNINGS")),
+                storedArticle(polarity = 0.8, title = "Random news", tags = setOf("MARKETS"))
             )
-        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenReturn(articles)
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(stored)
 
         val result = service.getNewsSentiment("AAPL", topics = "earnings")
 
@@ -108,10 +136,13 @@ internal class EodhdNewsServiceTest {
     }
 
     @Test
-    fun `projection caps summary length to keep the LLM payload compact`() {
-        val longContent = "x".repeat(1000)
-        whenever(proxy.getNews(any(), any(), anyOrNull(), any()))
-            .thenReturn(listOf(article(polarity = 0.7, content = longContent)))
+    fun `projection caps summary length`() {
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(
+            Optional.of(NewsFetch("AAPL.US", LocalDateTime.now().minusMinutes(30), 1))
+        )
+        val long = "x".repeat(1000)
+        whenever(articleRepo.findByTickersAfter(any(), any()))
+            .thenReturn(listOf(storedArticle(polarity = 0.7, content = long)))
 
         val result = service.getNewsSentiment("AAPL")
 
@@ -120,19 +151,63 @@ internal class EodhdNewsServiceTest {
         assertThat((feed.first()["summary"] as String).length).isLessThanOrEqualTo(400)
     }
 
-    private fun article(
+    @Test
+    fun `dedup upsert reuses an existing article row keyed by externalId`() {
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        val incoming = eodhArticle(0.6, link = "https://example.com/news/123")
+        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(incoming))
+        val existing =
+            NewsArticle(
+                externalId = "https://example.com/news/123",
+                title = "old title",
+                content = "old"
+            )
+        whenever(articleRepo.findByExternalId(eq("https://example.com/news/123")))
+            .thenReturn(Optional.of(existing))
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("AAPL")
+
+        val captor = argumentCaptor<NewsArticle>()
+        verify(articleRepo).save(captor.capture())
+        // The same instance is reused (id preserved), with content fields overwritten by the
+        // upstream payload — this is the contract that prevents duplicate rows on refresh.
+        assertThat(captor.firstValue.id).isEqualTo(existing.id)
+        assertThat(captor.firstValue.title).isEqualTo(incoming.title)
+    }
+
+    private fun eodhArticle(
         polarity: Double,
         title: String = "headline",
         content: String = "body",
-        tags: List<String> = emptyList()
+        tags: List<String> = emptyList(),
+        link: String = "https://example.com/article"
     ): EodhdNewsArticle =
         EodhdNewsArticle(
             date = "2026-05-15T05:00:00+00:00",
             title = title,
             content = content,
-            link = "https://example.com/article",
+            link = link,
             symbols = listOf("AAPL.US"),
             tags = tags,
             sentiment = EodhdArticleSentiment(polarity = BigDecimal(polarity))
         )
+
+    private fun storedArticle(
+        polarity: Double,
+        title: String = "headline",
+        content: String = "body",
+        tags: Set<String> = emptySet()
+    ): NewsArticle =
+        NewsArticle(
+            externalId = "ext-${title.hashCode()}",
+            published = LocalDateTime.now().minusHours(1),
+            title = title,
+            content = content,
+            polarity = BigDecimal(polarity),
+            tags = tags.toMutableSet(),
+            tickerLinks = mutableSetOf()
+        ).also {
+            it.tickerLinks.add(NewsArticleTicker(ticker = "AAPL.US"))
+        }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.util.ReflectionTestUtils
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -152,6 +153,58 @@ internal class EodhdNewsServiceTest {
     }
 
     @Test
+    fun `upstream failure still advances news_fetch so we don't retry-storm the quota`() {
+        // Without this the catch block would leave news_fetch missing/stale, so every subsequent
+        // request would re-hit EODHD immediately — exactly the quota-burn scenario this PR fixes.
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenThrow(RuntimeException("EODHD 429"))
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("AAPL")
+
+        val captor = argumentCaptor<NewsFetch>()
+        verify(fetchRepo).save(captor.capture())
+        assertThat(captor.firstValue.ticker).isEqualTo("AAPL.US")
+        // last_fetched_at advanced to ~now so the next refresh waits the configured backoff.
+        assertThat(captor.firstValue.lastFetchedAt)
+            .isAfter(LocalDateTime.now().minusMinutes(1))
+    }
+
+    @Test
+    fun `concurrent insert race on externalId is recovered via merge into the winning row`() {
+        // Simulate: read miss → save fails on the unique constraint because another transaction
+        // raced ahead and inserted the same external_id → service re-reads and merges into the
+        // winner. End state must be a single article with the latest payload.
+        whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
+        val incoming = eodhArticle(0.6, link = "https://example.com/news/race")
+        whenever(proxy.getNews(eq("AAPL.US"), any(), anyOrNull(), any())).thenReturn(listOf(incoming))
+
+        val winner =
+            NewsArticle(
+                externalId = "https://example.com/news/race",
+                title = "winner inserted first"
+            )
+        whenever(articleRepo.findByExternalId(eq("https://example.com/news/race")))
+            // First call: no row exists yet (we read before save).
+            // Second call (after the constraint violation): the winning row exists.
+            .thenReturn(Optional.empty(), Optional.of(winner))
+        // First save throws — simulates the unique-constraint collision with the racing transaction.
+        whenever(articleRepo.save(any<NewsArticle>()))
+            .thenThrow(DataIntegrityViolationException("uk_news_article_external"))
+            .thenAnswer { it.arguments[0] }
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("AAPL")
+
+        // Two saves expected: the failing original and the merged retry into the winner.
+        val captor = argumentCaptor<NewsArticle>()
+        verify(articleRepo, org.mockito.Mockito.times(2)).save(captor.capture())
+        assertThat(captor.allValues).hasSize(2)
+        assertThat(captor.allValues.last().id).isEqualTo(winner.id)
+        assertThat(captor.allValues.last().title).isEqualTo(incoming.title)
+    }
+
+    @Test
     fun `dedup upsert reuses an existing article row keyed by externalId`() {
         whenever(fetchRepo.findById("AAPL.US")).thenReturn(Optional.empty())
         val incoming = eodhArticle(0.6, link = "https://example.com/news/123")
@@ -166,13 +219,19 @@ internal class EodhdNewsServiceTest {
             .thenReturn(Optional.of(existing))
         whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
 
+        // Snapshot the id BEFORE invoking the service. `NewsArticle.id` is auto-initialised via
+        // `KeyGenUtils()` so it's always non-null — capturing it here makes the round-trip explicit
+        // and rules out an accidental new-entity instantiation path.
+        val originalId = existing.id
+
         service.getNewsSentiment("AAPL")
 
         val captor = argumentCaptor<NewsArticle>()
         verify(articleRepo).save(captor.capture())
         // The same instance is reused (id preserved), with content fields overwritten by the
         // upstream payload — this is the contract that prevents duplicate rows on refresh.
-        assertThat(captor.firstValue.id).isEqualTo(existing.id)
+        assertThat(captor.firstValue.id).isEqualTo(originalId)
+        assertThat(captor.firstValue.id).isNotBlank()
         assertThat(captor.firstValue.title).isEqualTo(incoming.title)
     }
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionScheduleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionScheduleTest.kt
@@ -1,0 +1,52 @@
+package com.beancounter.marketdata.providers.eodhd.news
+
+import com.beancounter.marketdata.providers.eodhd.EodhdNewsProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+/**
+ * Pure-unit coverage for [NewsRetentionSchedule]. Confirms `prune()` deletes everything published
+ * before `now - retentionDays` — the only thing the @Scheduled wrapping is meant to invoke.
+ *
+ * The Spring `@Scheduled` registration itself is exercised by Spring Boot integration tests;
+ * here we just pin the cutoff arithmetic and the repo call so the prune doesn't drift.
+ */
+internal class NewsRetentionScheduleTest {
+    private val repo = mock<NewsArticleRepo>()
+    private val props = EodhdNewsProperties(retentionDays = 30)
+    private val schedule = NewsRetentionSchedule(repo, props)
+
+    @Test
+    fun `prune calls deleteByPublishedBefore with retentionDays cutoff`() {
+        whenever(repo.deleteByPublishedBefore(org.mockito.kotlin.any())).thenReturn(7)
+
+        schedule.prune()
+
+        val captor = argumentCaptor<LocalDateTime>()
+        verify(repo).deleteByPublishedBefore(captor.capture())
+        // Cutoff must be 30 days back (± a couple seconds for test clock drift).
+        val expected = LocalDateTime.now().minusDays(30)
+        val delta = ChronoUnit.SECONDS.between(captor.firstValue, expected)
+        assertThat(delta).isBetween(-5, 5)
+    }
+
+    @Test
+    fun `prune honours a custom retentionDays override`() {
+        val custom = NewsRetentionSchedule(repo, EodhdNewsProperties(retentionDays = 7))
+        whenever(repo.deleteByPublishedBefore(org.mockito.kotlin.any())).thenReturn(0)
+
+        custom.prune()
+
+        val captor = argumentCaptor<LocalDateTime>()
+        verify(repo).deleteByPublishedBefore(captor.capture())
+        val expected = LocalDateTime.now().minusDays(7)
+        val delta = ChronoUnit.SECONDS.between(captor.firstValue, expected)
+        assertThat(delta).isBetween(-5, 5)
+    }
+}


### PR DESCRIPTION
## Summary

EODHD's news endpoint sits on a separate ~1200 req/day quota shared with svc-agent's chat-driven LLM tool calls. The previous in-memory Caffeine cache (30 min TTL) would exhaust that quota under sustained chat traffic long before the 100K/day EOD price quota started to bite.

This PR persists EODHD news in Postgres and serves from the DB by default — EODHD is only re-hit when a per-ticker `news_fetch` row is older than `refresh-after-hours` (default **6h**). Articles older than `retention-days` (default **30**) are pruned daily.

## Shape

| Table | Role |
|---|---|
| `news_article` | One row per article. Dedup key = EODHD `link` as `external_id`. Sentiment fields, full content body, fetched_at |
| `news_article_ticker` (`@ElementCollection`) | M:N — raw EODHD ticker (`AAPL.US`, `0ZG.F`) + nullable `asset_id` FK to BC's `asset` table |
| `news_article_tag` (`@ElementCollection`) | Topics from EODHD's `tags[]` |
| `news_fetch` | Per-ticker `last_fetched_at` — gates the next upstream call |

**Why `@ElementCollection` instead of a bidirectional `@Entity` join:** the data-class hashCode cycles on the join's back-reference and stack-overflows. Embeddables sidestep the cycle while keeping the same DB schema; the composite PK `(article_id, ticker)` is enforced by V19.

## Behaviour preserved

- Same `/news?tickers=X` endpoint surface.
- Same `{feed, count}` projection (svc-agent's NewsTools unchanged).
- Default-off retention prune — `NewsRetentionSchedule` only fires when `schedule.enabled=true` (kauri yes; tests no).
- EODHD-only persistence; AV news stays passthrough.

## Configuration

```yaml
beancounter:
  market:
    providers:
      eodhd:
        news:
          refresh-after-hours: 6      # 4x/day per active ticker
          retention-days: 30          # rolling window
          max-articles: 5
          provider-limit: 50
```

## Quota math

50 active tickers × 4 refreshes/day = **200 EODHD news calls/day**, well under the 1200/day quota. Headroom for ad-hoc chat lookups and topic-specific queries.

## Test plan

- [x] `./gradlew testSmart formatKotlin lintKotlin` — green (2m 24s)
- [x] `EodhdNewsServiceTest` updated for new constructor — refresh-gating, ranking, topic filter, summary cap, dedup upsert
- [x] `NewsServiceFacadeTest` — unchanged, still verifies routing
- [ ] Local smoke against live EODHD:
  ```
  SPRING_PROFILES_ACTIVE=local ./gradlew :svc-data:bootRun
  TOKEN=$(./scripts/get-m2m-token.sh)
  curl -sH "Authorization: Bearer $TOKEN" "http://localhost:9510/api/news?tickers=AAPL"
  psql -d bc -c "SELECT count(*) FROM news_article;"        # → ~5 articles
  curl -sH "Authorization: Bearer $TOKEN" "http://localhost:9510/api/news?tickers=AAPL"
  # Second call hits DB; news_fetch.last_fetched_at unchanged
  ```

## Follow-ups (deferred)

- Opportunistic `asset_id` population on insert (split ticker → resolve via `MarketService`) — schema supports it, code currently leaves null
- AlphaVantage persistence via the same schema — AV is the fallback path; would just be future-proofing today
- Full-text search on title/content — current ranking is `|polarity|`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News articles are now persisted and served from stored data, reducing repeated upstream fetches and improving response consistency.
  * Per-ticker refresh gating limits upstream requests and speeds responses for recently-fetched tickers.

* **Configuration**
  * Added refresh-after-hours to control per-ticker refresh intervals.
  * Added retention-days to control automatic article pruning.

* **Bug Fixes**
  * Improved resilience: scheduled pruning and fetch cooldowns prevent retry storms and handle upstream failures gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/845)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->