### PR TITLE
fix(svc-data): EODHD per-symbol resilience + drop invalid NZX/SGX aliases

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -11,6 +11,7 @@ import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInsta
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDate
 
 /**
@@ -48,7 +49,16 @@ class EodhdPriceService(
             val symbol = providerArguments.batch[batchId] ?: continue
             val asset = providerArguments.getAsset(symbol)
             val priceDate = providerArguments.getBatchConfigs(batchId)?.date ?: dateUtils.today()
-            val rows = eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
+            // A 4xx for one symbol must not abort the whole batch — bc-position
+            // schedules valuations across every portfolio, so one bad ticker would
+            // otherwise halt every portfolio sequenced after it.
+            val rows =
+                try {
+                    eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
+                } catch (e: HttpClientErrorException) {
+                    log.warn("EODHD {} for {} on {} — skipping", e.statusCode, symbol, priceDate)
+                    continue
+                }
             results.addAll(
                 eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows)
             )

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -437,7 +437,8 @@ beancounter:
           mstack: "NZ"
           alpha: "NZ"
           FIGI: "NZ"
-          eodhd: "NZ"
+          # EODHD has no NZ exchange (verified via /api/exchanges-list).
+          # Do not add an eodhd alias here unless the plan adds NZ coverage.
 
       - code: "SGX"
         name: "Singapore Exchange"
@@ -447,7 +448,8 @@ beancounter:
         aliases:
           mstack: "SI"
           FIGI: "SP"
-          eodhd: "SG"
+          # EODHD has no SG/SES exchange (verified via /api/exchanges-list).
+          # Do not add an eodhd alias here unless the plan adds SG coverage.
 
       - code: "LON"
         name: "London Stock Exchange"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -5,7 +5,6 @@ import com.beancounter.common.contracts.PriceAsset
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.model.Market
 import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
-import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants.Companion.AAPL
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.MarketDataBoot
@@ -35,8 +34,6 @@ import java.math.BigDecimal
 @AutoConfigureWireMock(port = 0)
 @AutoConfigureMockAuth
 internal class EodhdApiTest {
-    private val dateUtils = DateUtils()
-
     @MockitoBean
     private lateinit var jwtDecoder: JwtDecoder
 
@@ -121,6 +118,31 @@ internal class EodhdApiTest {
 
         assertThat(date).isNotNull
         assertThat(date.toString()).matches("\\d{4}-\\d{2}-\\d{2}")
+    }
+
+    @Test
+    fun `404 on one symbol does not abort the whole batch`() {
+        // Regression: a single Ticker-Not-Found used to propagate
+        // HttpClientErrorException out of EodhdPriceService.getMarketData
+        // and abort every other symbol in the same valuation cycle.
+        stubFor(
+            get(urlPathEqualTo("/api/eod/MSFT.US"))
+                .willReturn(aResponse().withStatus(404).withBody("Ticker Not Found."))
+        )
+        stubEod("AAPL.US", "mock/eodhd/AAPL-US.json")
+
+        val result =
+            eodhdPriceService.getMarketData(
+                PriceRequest(
+                    "2024-11-29",
+                    listOf(PriceAsset(MSFT), PriceAsset(AAPL))
+                )
+            )
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().asset).isEqualTo(AAPL)
+        assertThat(result.first().close).isEqualByComparingTo(BigDecimal("237.33"))
+        assertThat(result.first().source).isEqualTo(ID)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Day-1 EODHD rollout on kauri caused every 10-min `PortfolioValuationSchedule` cycle to abort with `404 Ticker Not Found` from `EodhdGateway`. Root cause was twofold:

- `NZX` and `SGX` aliased to `NZ` / `SG` in `application.yml`, but EODHD has neither exchange (verified against `/api/exchanges-list`). `GNE.NZ` etc. always 404.
- `EodhdPriceService.getMarketData` let any `HttpClientErrorException` from `eodhdProxy.getPrice` propagate out of the per-symbol loop, so one bad ticker aborted the whole batch and every portfolio sequenced after it never got valued.

This PR:
- Drops the invalid `eodhd:` aliases on `NZX` and `SGX` (comments warn against re-adding without verified EODHD coverage).
- Catches `HttpClientErrorException` per symbol in `EodhdPriceService.getMarketData`, logs a `WARN` with status/symbol/date, and continues with the rest of the batch.

Paired bc-deploy change (`env/kauri.yaml`) routes `NZX,SGX` back to MarketStack — its pre-EODHD provider.

## Test plan

- [x] New WireMock test `404 on one symbol does not abort the whole batch` — stubs a 404 for `MSFT.US` alongside a 200 for `AAPL.US`, asserts only AAPL returns and no exception propagates.
- [x] `./gradlew testSmart` — green
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [ ] After deploy: confirm 10-min `PortfolioValuationSchedule` cycle on kauri completes without `Ticker Not Found` errors and all 15 portfolios value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market data fetching now gracefully handles 4xx HTTP errors for individual symbols—if one fails, the batch continues instead of aborting the entire request.
  * Removed EODHD exchange alias mappings for unsupported exchanges.

* **Tests**
  * Added regression test verifying that individual symbol request failures don't abort batch market data fetching operations.

* **Chores**
  * Removed unused imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->