### PR TITLE
feat(svc-data): expose entity counts as Micrometer gauges

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
@@ -153,6 +153,17 @@ interface AssetRepository : CrudRepository<Asset, String> {
     fun countByAccountingTypeId(id: String): Long
 
     /**
+     * Group asset count by [Asset.marketCode]. Surfaced as the
+     * `beancounter.asset.count.by_market` MultiGauge — see
+     * [com.beancounter.marketdata.metrics.EntityCountMetrics].
+     */
+    @Query(
+        "SELECT new com.beancounter.marketdata.metrics.MarketCount(a.marketCode, COUNT(a)) " +
+            "FROM Asset a GROUP BY a.marketCode ORDER BY COUNT(a) DESC"
+    )
+    fun countByMarketCode(): List<com.beancounter.marketdata.metrics.MarketCount>
+
+    /**
      * Search all assets in the database by code or name (case-insensitive partial match).
      * Used for local-only asset lookup to find assets without calling external providers.
      * Returns distinct assets to avoid duplicates when same asset is held in multiple portfolios.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityBreakdowns.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityBreakdowns.kt
@@ -1,0 +1,22 @@
+package com.beancounter.marketdata.metrics
+
+/**
+ * Projection DTOs for grouped entity counts. Used as JPQL constructor expressions
+ * (e.g. `SELECT new com.beancounter.marketdata.metrics.MarketCount(a.marketCode, COUNT(a)) ...`)
+ * and as the row type for [io.micrometer.core.instrument.MultiGauge] breakdowns
+ * registered by [EntityCountMetrics].
+ */
+data class MarketCount(
+    val market: String,
+    val count: Long
+)
+
+data class TypeCount(
+    val type: String,
+    val count: Long
+)
+
+data class SourceCount(
+    val source: String,
+    val count: Long
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityCountMetrics.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityCountMetrics.kt
@@ -1,0 +1,157 @@
+package com.beancounter.marketdata.metrics
+
+import com.beancounter.marketdata.assets.AccountingTypeRepository
+import com.beancounter.marketdata.assets.AssetRepository
+import com.beancounter.marketdata.assets.PrivateAssetConfigRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
+import com.beancounter.marketdata.portfolio.PortfolioRepository
+import com.beancounter.marketdata.providers.MarketDataRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
+import com.beancounter.marketdata.registration.SystemUserRepository
+import com.beancounter.marketdata.tax.TaxRateRepository
+import com.beancounter.marketdata.trn.TrnRepository
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.MultiGauge
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Tags
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.repository.CrudRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Exposes svc-data persistence counts as Micrometer gauges so they can be
+ * scraped by Prometheus or rendered by Spring Boot Admin.
+ *
+ * Two flavours of metric:
+ *  - `beancounter.entity.count{entity=…}` — single per-entity total. Gauge supplier
+ *    runs `repo.count()` on every actuator scrape. Suppliers are wrapped in
+ *    [safeCount] so a failing repo returns NaN (rendered as `—`) instead of
+ *    breaking the whole `/actuator/metrics` response.
+ *  - `beancounter.<entity>.count.by_<dim>{<dim>=…}` — grouped breakdown. Backed by
+ *    a [MultiGauge] refreshed on a [Scheduled] tick, not on scrape, because
+ *    `GROUP BY` on large tables is too expensive to run every 10s.
+ */
+@Component
+class EntityCountMetrics(
+    private val meterRegistry: MeterRegistry,
+    private val systemUserRepository: SystemUserRepository,
+    private val assetRepository: AssetRepository,
+    private val marketDataRepo: MarketDataRepo,
+    private val portfolioRepository: PortfolioRepository,
+    private val trnRepository: TrnRepository,
+    private val newsArticleRepo: NewsArticleRepo,
+    private val newsFetchRepo: NewsFetchRepo,
+    private val brokerSettlementAccountRepository: BrokerSettlementAccountRepository,
+    private val taxRateRepository: TaxRateRepository,
+    private val privateAssetConfigRepository: PrivateAssetConfigRepository,
+    private val accountingTypeRepository: AccountingTypeRepository,
+    @Value("\${beancounter.metrics.entity-count.refresh-ms:300000}")
+    private val breakdownRefreshMs: Long
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val assetsByMarket: MultiGauge =
+        MultiGauge
+            .builder("beancounter.asset.count.by_market")
+            .description("Asset row count grouped by marketCode")
+            .register(meterRegistry)
+
+    private val marketDataByMarket: MultiGauge =
+        MultiGauge
+            .builder("beancounter.market_data.count.by_market")
+            .description("MarketData row count grouped by owning asset's marketCode")
+            .register(meterRegistry)
+
+    private val transactionsByType: MultiGauge =
+        MultiGauge
+            .builder("beancounter.transaction.count.by_type")
+            .description("Transaction row count grouped by trnType")
+            .register(meterRegistry)
+
+    private val newsBySource: MultiGauge =
+        MultiGauge
+            .builder("beancounter.news.count.by_source")
+            .description("NewsArticle row count grouped by source")
+            .register(meterRegistry)
+
+    @PostConstruct
+    fun registerEntityGauges() {
+        registerCount("systemUser", systemUserRepository)
+        registerCount("asset", assetRepository)
+        registerCount("marketData", marketDataRepo)
+        registerCount("portfolio", portfolioRepository)
+        registerCount("transaction", trnRepository)
+        registerCount("newsArticle", newsArticleRepo)
+        registerCount("newsFetch", newsFetchRepo)
+        registerCount("brokerSettlementAccount", brokerSettlementAccountRepository)
+        registerCount("taxRate", taxRateRepository)
+        registerCount("privateAssetConfig", privateAssetConfigRepository)
+        registerCount("accountingType", accountingTypeRepository)
+    }
+
+    /**
+     * Refresh breakdown gauges on a fixed delay. Configured via
+     * `beancounter.metrics.entity-count.refresh-ms` (default 5 minutes).
+     * Uses fixedDelay so a slow query doesn't queue overlapping runs.
+     */
+    @Scheduled(fixedDelayString = "\${beancounter.metrics.entity-count.refresh-ms:300000}")
+    fun refreshBreakdowns() {
+        refresh("assetsByMarket", assetsByMarket, "market") {
+            assetRepository.countByMarketCode().map { it.market to it.count }
+        }
+        refresh("marketDataByMarket", marketDataByMarket, "market") {
+            marketDataRepo.countByMarketCode().map { it.market to it.count }
+        }
+        refresh("transactionsByType", transactionsByType, "type") {
+            trnRepository.countByTrnType().map { it.type to it.count }
+        }
+        refresh("newsBySource", newsBySource, "source") {
+            newsArticleRepo.countBySource().map { it.source to it.count }
+        }
+    }
+
+    private fun registerCount(
+        entity: String,
+        repository: CrudRepository<*, *>
+    ) {
+        Gauge
+            .builder("beancounter.entity.count") { safeCount(entity, repository) }
+            .tag("entity", entity)
+            .description("Total $entity rows")
+            .strongReference(true)
+            .register(meterRegistry)
+    }
+
+    private fun safeCount(
+        entity: String,
+        repository: CrudRepository<*, *>
+    ): Double =
+        try {
+            repository.count().toDouble()
+        } catch (ex: Exception) {
+            log.warn("entity count gauge failed for {}: {}", entity, ex.message)
+            Double.NaN
+        }
+
+    private fun refresh(
+        label: String,
+        multi: MultiGauge,
+        tagKey: String,
+        supplier: () -> List<Pair<String, Long>>
+    ) {
+        try {
+            val rows =
+                supplier().map { (key, value) ->
+                    MultiGauge.Row.of(Tags.of(Tag.of(tagKey, key)), value.toDouble())
+                }
+            multi.register(rows, true)
+        } catch (ex: Exception) {
+            log.warn("breakdown gauge refresh failed for {}: {}", label, ex.message)
+        }
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
@@ -81,4 +81,16 @@ interface MarketDataRepo : CrudRepository<MarketData, String> {
      * Used when cascading asset deletion.
      */
     fun deleteByAssetId(assetId: String)
+
+    /**
+     * Group MarketData row count by the owning asset's marketCode.
+     * Surfaced as the `beancounter.market_data.count.by_market` MultiGauge.
+     * Note: heavy query on large tables — refreshed via @Scheduled rather than
+     * on every actuator scrape (see EntityCountMetrics).
+     */
+    @Query(
+        "SELECT new com.beancounter.marketdata.metrics.MarketCount(md.asset.marketCode, COUNT(md)) " +
+            "FROM MarketData md GROUP BY md.asset.marketCode ORDER BY COUNT(md) DESC"
+    )
+    fun countByMarketCode(): List<com.beancounter.marketdata.metrics.MarketCount>
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticleRepo.kt
@@ -31,4 +31,14 @@ interface NewsArticleRepo : CrudRepository<NewsArticle, String> {
     fun deleteByPublishedBefore(
         @Param("threshold") threshold: LocalDateTime
     ): Int
+
+    /**
+     * Group news article count by [NewsArticle.source]. Surfaced as the
+     * `beancounter.news.count.by_source` MultiGauge.
+     */
+    @Query(
+        "SELECT new com.beancounter.marketdata.metrics.SourceCount(a.source, COUNT(a)) " +
+            "FROM NewsArticle a GROUP BY a.source ORDER BY COUNT(a) DESC"
+    )
+    fun countBySource(): List<com.beancounter.marketdata.metrics.SourceCount>
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -319,4 +319,14 @@ interface TrnRepository :
             "where t.portfolio.id in (?1)"
     )
     fun findDistinctAssetIdsByPortfolioIds(portfolioIds: Collection<String>): Collection<String>
+
+    /**
+     * Group transaction count by [com.beancounter.common.model.TrnType].
+     * Surfaced as the `beancounter.transaction.count.by_type` MultiGauge.
+     */
+    @Query(
+        "SELECT new com.beancounter.marketdata.metrics.TypeCount(CAST(t.trnType AS string), COUNT(t)) " +
+            "FROM Trn t GROUP BY t.trnType ORDER BY COUNT(t) DESC"
+    )
+    fun countByTrnType(): List<com.beancounter.marketdata.metrics.TypeCount>
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/metrics/EntityCountMetricsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/metrics/EntityCountMetricsTest.kt
@@ -1,0 +1,174 @@
+package com.beancounter.marketdata.metrics
+
+import com.beancounter.marketdata.assets.AccountingTypeRepository
+import com.beancounter.marketdata.assets.AssetRepository
+import com.beancounter.marketdata.assets.PrivateAssetConfigRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
+import com.beancounter.marketdata.portfolio.PortfolioRepository
+import com.beancounter.marketdata.providers.MarketDataRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsArticleRepo
+import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
+import com.beancounter.marketdata.registration.SystemUserRepository
+import com.beancounter.marketdata.tax.TaxRateRepository
+import com.beancounter.marketdata.trn.TrnRepository
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+
+class EntityCountMetricsTest {
+    private lateinit var meterRegistry: MeterRegistry
+    private lateinit var systemUserRepository: SystemUserRepository
+    private lateinit var assetRepository: AssetRepository
+    private lateinit var marketDataRepo: MarketDataRepo
+    private lateinit var portfolioRepository: PortfolioRepository
+    private lateinit var trnRepository: TrnRepository
+    private lateinit var newsArticleRepo: NewsArticleRepo
+    private lateinit var newsFetchRepo: NewsFetchRepo
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
+    private lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var privateAssetConfigRepository: PrivateAssetConfigRepository
+    private lateinit var accountingTypeRepository: AccountingTypeRepository
+    private lateinit var metrics: EntityCountMetrics
+
+    @BeforeEach
+    fun setUp() {
+        meterRegistry = SimpleMeterRegistry()
+        systemUserRepository = mock { on { count() } doReturn 7L }
+        assetRepository =
+            mock {
+                on { count() } doReturn 100L
+                on { countByMarketCode() } doReturn
+                    listOf(
+                        MarketCount("NASDAQ", 60),
+                        MarketCount("NYSE", 40)
+                    )
+            }
+        marketDataRepo =
+            mock {
+                on { count() } doReturn 12_000L
+                on { countByMarketCode() } doReturn listOf(MarketCount("NASDAQ", 12_000))
+            }
+        portfolioRepository = mock { on { count() } doReturn 5L }
+        trnRepository =
+            mock {
+                on { count() } doReturn 250L
+                on { countByTrnType() } doReturn
+                    listOf(
+                        TypeCount("BUY", 150),
+                        TypeCount("SELL", 100)
+                    )
+            }
+        newsArticleRepo =
+            mock {
+                on { count() } doReturn 80L
+                on { countBySource() } doReturn listOf(SourceCount("EODHD", 80))
+            }
+        newsFetchRepo = mock { on { count() } doReturn 12L }
+        brokerSettlementAccountRepository = mock { on { count() } doReturn 3L }
+        taxRateRepository = mock { on { count() } doReturn 4L }
+        privateAssetConfigRepository = mock { on { count() } doReturn 2L }
+        accountingTypeRepository = mock { on { count() } doReturn 6L }
+
+        metrics =
+            EntityCountMetrics(
+                meterRegistry = meterRegistry,
+                systemUserRepository = systemUserRepository,
+                assetRepository = assetRepository,
+                marketDataRepo = marketDataRepo,
+                portfolioRepository = portfolioRepository,
+                trnRepository = trnRepository,
+                newsArticleRepo = newsArticleRepo,
+                newsFetchRepo = newsFetchRepo,
+                brokerSettlementAccountRepository = brokerSettlementAccountRepository,
+                taxRateRepository = taxRateRepository,
+                privateAssetConfigRepository = privateAssetConfigRepository,
+                accountingTypeRepository = accountingTypeRepository,
+                breakdownRefreshMs = 300_000L
+            )
+        metrics.registerEntityGauges()
+    }
+
+    @Test
+    fun `registers one gauge per entity tagged with entity name`() {
+        val entities =
+            listOf(
+                "systemUser" to 7.0,
+                "asset" to 100.0,
+                "marketData" to 12_000.0,
+                "portfolio" to 5.0,
+                "transaction" to 250.0,
+                "newsArticle" to 80.0,
+                "newsFetch" to 12.0,
+                "brokerSettlementAccount" to 3.0,
+                "taxRate" to 4.0,
+                "privateAssetConfig" to 2.0,
+                "accountingType" to 6.0
+            )
+
+        entities.forEach { (entity, expected) ->
+            val gauge = meterRegistry.find("beancounter.entity.count").tag("entity", entity).gauge()
+            assertThat(gauge)
+                .describedAs("gauge for entity=%s", entity)
+                .isNotNull
+            assertThat(gauge!!.value()).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `repository failure surfaces NaN instead of throwing`() {
+        accountingTypeRepository.stub { on { count() } doThrow RuntimeException("db down") }
+
+        val gauge = meterRegistry.find("beancounter.entity.count").tag("entity", "accountingType").gauge()
+        assertThat(gauge).isNotNull
+        assertThat(gauge!!.value()).isNaN
+    }
+
+    @Test
+    fun `refreshBreakdowns populates assets-by-market multi-gauge`() {
+        metrics.refreshBreakdowns()
+
+        val nasdaq = meterRegistry.find("beancounter.asset.count.by_market").tag("market", "NASDAQ").gauge()
+        val nyse = meterRegistry.find("beancounter.asset.count.by_market").tag("market", "NYSE").gauge()
+        assertThat(nasdaq?.value()).isEqualTo(60.0)
+        assertThat(nyse?.value()).isEqualTo(40.0)
+    }
+
+    @Test
+    fun `refreshBreakdowns populates transactions-by-type multi-gauge`() {
+        metrics.refreshBreakdowns()
+
+        val buy = meterRegistry.find("beancounter.transaction.count.by_type").tag("type", "BUY").gauge()
+        val sell = meterRegistry.find("beancounter.transaction.count.by_type").tag("type", "SELL").gauge()
+        assertThat(buy?.value()).isEqualTo(150.0)
+        assertThat(sell?.value()).isEqualTo(100.0)
+    }
+
+    @Test
+    fun `refreshBreakdowns populates news-by-source multi-gauge`() {
+        metrics.refreshBreakdowns()
+
+        val eodhd = meterRegistry.find("beancounter.news.count.by_source").tag("source", "EODHD").gauge()
+        assertThat(eodhd?.value()).isEqualTo(80.0)
+    }
+
+    @Test
+    fun `breakdown refresh swallows repository failure for a single section`() {
+        assetRepository.stub { on { countByMarketCode() } doThrow RuntimeException("group by timeout") }
+
+        metrics.refreshBreakdowns()
+
+        // failed section absent from registry, but other sections still register
+        assertThat(
+            meterRegistry.find("beancounter.asset.count.by_market").gauges()
+        ).isEmpty()
+        assertThat(
+            meterRegistry.find("beancounter.transaction.count.by_type").tag("type", "BUY").gauge()
+        ).isNotNull
+    }
+}


### PR DESCRIPTION
## Summary
- New `EntityCountMetrics` registers `beancounter.entity.count{entity=…}` for SystemUser, Asset, MarketData, Portfolio, Transaction, NewsArticle, NewsFetch, BrokerSettlementAccount, TaxRate, PrivateAssetConfig, AccountingType.
- Four `MultiGauge` breakdowns: assets-by-market, market_data-by-market, transactions-by-type, news-by-source. Refreshed on a 5-min `fixedDelay` (configurable via `beancounter.metrics.entity-count.refresh-ms`) — GROUP BY does not run on every actuator scrape.
- Per-gauge fail-soft: a failing repo logs and returns `NaN` (rendered `—`) rather than 500-ing `/actuator/metrics`.
- Adds 4 grouping `@Query` methods (`AssetRepository.countByMarketCode`, `MarketDataRepo.countByMarketCode`, `TrnRepository.countByTrnType`, `NewsArticleRepo.countBySource`) returning constructor-expression DTOs (`MarketCount`, `TypeCount`, `SourceCount`).

## Why
Foundation for the upcoming Spring Boot Admin (`bc-admin`) deployable. With this PR alone, anyone with `SCOPE_beancounter:admin` can already curl `http://<host>:9511/actuator/metrics/beancounter.entity.count?tag=entity:asset` and get live counts. The SBA UI lands in a follow-up PR.

## Test plan
- [x] `./gradlew :svc-data:test --tests EntityCountMetricsTest` — 6 tests pass (per-entity gauges, NaN on failure, three MultiGauge happy paths, fail-soft per-section)
- [x] `./gradlew testSmart` — full svc-data + svc-position + svc-event suite green
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [x] `semgrep --config=auto` on changed files — 0 findings (124 rules)
- [ ] Manual verification post-deploy: `curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:9511/actuator/metrics/beancounter.entity.count?tag=entity:systemUser`

## Risks
- `MarketDataRepo.count()` and `countByMarketCode()` do full scans — fine on dev, may need caching once the table grows. Plan covers swap to `pg_class.reltuples` estimate if `EXPLAIN ANALYZE` shows >2s.
- No new endpoints, no new auth surface — actuator security (`SCOPE_admin`/`SCOPE_system`) already gates `/actuator/**`.

## Follow-up
- PR #2: add `spring-boot-admin-starter-client` dep + config to svc-data, scaffold new `svc-admin` module with `@EnableAdminServer`, OIDC login, and outbound M2M `HttpHeadersProvider`.
- PR #3 (bc-deploy): Helm chart for `bc-admin`, env wiring for the SBA client URL on bc-data.
- PR #4 (bc-view): add a "Service Metrics" card to the admin hub linking to the SBA UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity count metrics and monitoring gauges for improved system observability
  * Introduced breakdown metrics providing visibility into asset distribution by market, transaction distribution by type, and news distribution by source
  * Metrics refresh on a configurable schedule (default 5 minutes) with graceful error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->