### PR TITLE
chore(secrets): scrub rotated bc-event client_secret from LoginServiceTest

### DIFF
--- a/jar-auth/src/test/kotlin/com/beancounter/auth/LoginServiceTest.kt
+++ b/jar-auth/src/test/kotlin/com/beancounter/auth/LoginServiceTest.kt
@@ -95,12 +95,14 @@ class LoginServiceTest {
 
     @Test
     fun `should mask credentials correctly for logging`() {
-        val secret = "jkVboA25BQq8spZHfg1YR37TWnWOLwn7GSKhBqXeo71gKT4BHilMC1IelrCEAqTY"
+        // Synthetic 64-char fixture; prior literal was a real (since-rotated)
+        // bc-event Auth0 client_secret. Don't put real secrets in test files.
+        val secret = "x".repeat(64)
         val maskedPrefix = secret.take(4)
         val maskedSuffix = secret.takeLast(4)
 
-        assertThat(maskedPrefix).isEqualTo("jkVb")
-        assertThat(maskedSuffix).isEqualTo("AqTY")
+        assertThat(maskedPrefix).isEqualTo("xxxx")
+        assertThat(maskedSuffix).isEqualTo("xxxx")
         assertThat(secret).startsWith(maskedPrefix)
         assertThat(secret).endsWith(maskedSuffix)
     }


### PR DESCRIPTION
## Summary
- `jar-auth/.../LoginServiceTest.kt:98` embedded the literal bc-event Auth0 `client_secret` as a fixture for the prefix/suffix masking assertion.
- The secret has been rotated in Auth0 (independent of this PR), so the literal is now dead — but a public repo should never carry real credentials regardless.
- Replaced with `"x".repeat(64)`; expected prefix/suffix updated to `"xxxx"`. Same code paths exercised.

## Why
Surfaced by a local `gitleaks` scan while staging a secret-scan CI workflow (parked for a separate review pass). Companion to `bc-deploy d3f14cc` which removed the same secret from `values.yaml#global.auth.client`.

## Test plan
- [x] `./gradlew :jar-auth:test --tests LoginServiceTest` — green
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [x] `semgrep --config=auto` on the file — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication logging test to use synthetic credential fixtures instead of actual sensitive values, ensuring test data no longer contains real secrets. Updated assertions to reflect the new fixture format while maintaining test coverage for masking behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->