### PR TITLE
ci(svc-admin): wire build + package-admin Docker job into CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ jobs:
             echo "📦 Phase 4: Building svc-event..."
             ./gradlew :svc-event:build --parallel
 
-            # Phase 5: svc-agent (needs jar-client, jar-auth, jar-common)
-            echo "📦 Phase 5: Building svc-agent..."
-            ./gradlew :svc-agent:build --parallel
+            # Phase 5: svc-agent + svc-admin (leaf services, no stub deps)
+            echo "📦 Phase 5: Building svc-agent and svc-admin..."
+            ./gradlew :svc-agent:build :svc-admin:build --parallel
 
             echo "✅ Build completed!"
 
@@ -85,6 +85,8 @@ jobs:
           file: ./svc-event/build/reports/jacoco/test/jacocoTestReport.xml
       - codecov/upload:
           file: ./svc-agent/build/reports/jacoco/test/jacocoTestReport.xml
+      - codecov/upload:
+          file: ./svc-admin/build/reports/jacoco/test/jacocoTestReport.xml
 
       # Save build cache for faster subsequent builds
       - run:
@@ -121,6 +123,7 @@ jobs:
             cp -r ~/project/svc-position/build/libs/* ~/artifacts/services/ 2>/dev/null || echo "No svc-position artifacts"
             cp -r ~/project/svc-event/build/libs/* ~/artifacts/services/ 2>/dev/null || echo "No svc-event artifacts"
             cp -r ~/project/svc-agent/build/libs/* ~/artifacts/services/ 2>/dev/null || echo "No svc-agent artifacts"
+            cp -r ~/project/svc-admin/build/libs/* ~/artifacts/services/ 2>/dev/null || echo "No svc-admin artifacts"
       - store_artifacts:
           path: ~/artifacts/services
           destination: services
@@ -158,6 +161,7 @@ jobs:
             cp -r ~/project/svc-position/build/libs/* ~/workspace-artifacts/build-artifacts/ 2>/dev/null || echo "No svc-position artifacts"
             cp -r ~/project/svc-event/build/libs/* ~/workspace-artifacts/build-artifacts/ 2>/dev/null || echo "No svc-event artifacts"
             cp -r ~/project/svc-agent/build/libs/* ~/workspace-artifacts/build-artifacts/ 2>/dev/null || echo "No svc-agent artifacts"
+            cp -r ~/project/svc-admin/build/libs/* ~/workspace-artifacts/build-artifacts/ 2>/dev/null || echo "No svc-admin artifacts"
 
             echo "📋 Workspace artifacts prepared:"
             ls -la ~/workspace-artifacts/build-artifacts/
@@ -442,6 +446,61 @@ jobs:
 
             echo "✅ bc-agent image built and pushed successfully"
 
+  package-admin:
+    executor: java-build
+    environment:
+      IMAGE_NAME: bc-admin
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "7e:93:fb:39:b3:21:f7:b6:48:bd:f7:0e:56:5c:ad:87"
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-build-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "settings.gradle.kts" }}
+      - attach_workspace:
+          at: ~/workspace
+      - setup_remote_docker
+      - run:
+          name: Setup Docker Buildx and Registry Login
+          command: |
+            echo "🐳 Setting up Docker buildx and logging into registry..."
+
+            # Install QEMU for multi-platform builds
+            docker run --rm --privileged tonistiigi/binfmt --install all
+
+            # Create and use a new builder instance
+            docker buildx create --name multiarch-builder --use || true
+            docker buildx inspect --bootstrap
+
+            # Login to GitHub Container Registry
+            echo "$GH_GCR" | docker login ghcr.io -u "$DOCKER_USER" --password-stdin
+
+            echo "✅ Docker buildx setup complete"
+      - run:
+          name: Build and Push BC-ADMIN
+          command: |
+            echo "📦 Building and pushing bc-admin Docker image..."
+
+            # Copy built artifacts to expected locations
+            echo "📋 Copying built artifacts from workspace..."
+            mkdir -p ~/project/svc-admin/build/libs/
+            cp ~/workspace/build-artifacts/svc-admin-*.jar ~/project/svc-admin/build/libs/ 2>/dev/null || echo "No svc-admin JAR found in workspace"
+
+            # Verify JAR file exists
+            echo "🔍 Checking for JAR file:"
+            ls -la ~/project/svc-admin/build/libs/ || echo "No build/libs directory"
+
+            # Build and push multi-platform image
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              --tag "ghcr.io/monowai/bc-admin:latest" \
+              --tag "ghcr.io/monowai/bc-admin:${STACK_VER}" \
+              ~/project/svc-admin/
+
+            echo "✅ bc-admin image built and pushed successfully"
+
   # Security scanning - runs only on main to save time on feature branches
   security-scan:
     executor: java-build
@@ -539,6 +598,14 @@ workflows:
           requires:
             - build-and-test
       - package-agent:
+          filters:
+            branches:
+              only:
+                - main
+                - /^deploy\/.*/
+          requires:
+            - build-and-test
+      - package-admin:
           filters:
             branches:
               only:

--- a/svc-admin/Dockerfile
+++ b/svc-admin/Dockerfile
@@ -1,0 +1,25 @@
+FROM ghcr.io/monowai/eclipse-temurin:25-jre-alpine-sentry8.40.0
+
+# Fail the build if the base image's bundled Sentry OpenTelemetry agent does
+# not match the SDK version the app is compiled against.
+ARG EXPECTED_SENTRY_VERSION=8.40.0
+RUN test -f /app/sentry-opentelemetry-agent-${EXPECTED_SENTRY_VERSION}.jar \
+    || (echo "ERROR: expected sentry-opentelemetry-agent-${EXPECTED_SENTRY_VERSION}.jar in base image; got:" \
+        && ls /app/sentry-opentelemetry-agent-*.jar 2>/dev/null \
+        && exit 1)
+
+#docker build . -t monowai/bc-admin
+ARG JAR_FILE=build/libs/svc-admin-0.1.1.jar
+
+ARG GIT_COMMIT
+ARG VERSION
+
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV VERSION=${VERSION}
+
+WORKDIR /app
+
+COPY ${JAR_FILE} app.jar
+
+
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- Adds `svc-admin` to the existing CircleCI build pipeline: Phase 5 build (parallel with svc-agent), jacoco/codecov upload, artifact + workspace persistence.
- New `package-admin` Docker job mirrors `package-agent` — pulls the workspace JAR, multi-arch buildx, pushes `ghcr.io/monowai/bc-admin:{latest, <pipeline-number>}`. Filtered to main + `deploy/*` branches.
- New `svc-admin/Dockerfile` cloned from `svc-event/Dockerfile` (same temurin-sentry base, same `JAR_FILE=build/libs/svc-admin-0.1.1.jar` + entrypoint).

## Why
PR #848 (svc-admin module) and bc-deploy's bc-admin Helm chart both landed without an image-build path. Until this PR merges, `helm upgrade bc-admin` will fail with `ImagePullBackOff`. This unblocks the rollout via `bc-deploy/scripts/deploy.sh`.

## Test plan
- [x] `./gradlew :svc-admin:build` — produces `svc-admin-0.1.1.jar` matching `Dockerfile` ARG `JAR_FILE`.
- [x] CircleCI config parses (YAML valid).
- [x] `semgrep --config=auto` — only finding is the pre-existing "no USER directive" pattern shared by every other BC service Dockerfile (svc-event, svc-data, …). Not addressed here; treat as repo-wide cleanup if/when prioritised.
- [ ] First green CI run on this branch will produce `ghcr.io/monowai/bc-admin:<pipeline-number>`; verify visible under https://github.com/monowai/beancounter/pkgs/container/bc-admin.

## Notes
- Build phase 5 was previously svc-agent-only; now runs both leaf services together. No extra wall-clock cost — Gradle `--parallel` picks them up concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD pipeline to build, test, and package the admin service alongside existing services.
  * Implemented automated Docker image creation with multi-architecture support for the admin service.
  * Integrated code coverage tracking and artifact management for the admin service in the deployment workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->