### PR TITLE
fix(svc-admin): two filter chains so OIDC beats Basic-auth on browser hits

### DIFF
--- a/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
@@ -3,6 +3,8 @@ package com.beancounter.admin
 import de.codecentric.boot.admin.server.config.AdminServerProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.Customizer.withDefaults
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.SecurityFilterChain
@@ -12,25 +14,46 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 /**
  * SBA server security.
  *
- * Reuses bc-view's Auth0 application for OIDC login — no separate
- * "BC Admin Server" app needed. Admins already carry the
- * `beancounter:admin` claim in their bc-view session; the SBA UI is gated on
- * the same claim. The Auth0 application must list this server's callback URL
- * (`https://kauri.monowai.com:30530/login/oauth2/code/auth0`) alongside
- * bc-view's existing callback.
+ * Two filter chains, ordered:
  *
- * CSRF: `CookieCsrfTokenRepository.withHttpOnlyFalse()` writes an XSRF-TOKEN
- * cookie the SBA SPA reads + echoes back as `X-XSRF-TOKEN`. The cookie is
- * intentionally not HttpOnly — the SPA needs to read it. SBA client
- * registration POSTs to `/instances` and proxied actuator calls bypass CSRF
- * because they come from server-to-server (no browser session).
+ *  1. Client registration chain (instances + actuator paths) — SBA
+ *     clients (bc-data, bc-position, etc.) POST their actuator metadata
+ *     using HTTP Basic with the user supplied via
+ *     spring.security.user.name + spring.security.user.password.
+ *     Browsers never hit these paths, so Basic-auth is the correct
+ *     primary entry-point here.
+ *
+ *  2. UI chain (everything else) — interactive browser sessions use
+ *     Auth0 OIDC. Reuses bc-view's Auth0 application so admins log in
+ *     with their existing beancounter:admin claim. The Auth0 app must
+ *     list this server's callback URL alongside bc-view's:
+ *       https://bc-admin.monowai.com/login/oauth2/code/auth0
+ *
+ * Splitting the chains stops the Basic-auth WWW-Authenticate challenge
+ * from beating OIDC redirect on browser hits to root.
+ *
+ * CSRF: CookieCsrfTokenRepository.withHttpOnlyFalse writes an XSRF-TOKEN
+ * cookie the SBA SPA reads + echoes back as X-XSRF-TOKEN. The cookie is
+ * intentionally not HttpOnly so the SPA can read it.
  */
 @Configuration
 class SecurityConfig(
     private val adminServer: AdminServerProperties
 ) {
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    fun clientRegistrationFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val contextPath = adminServer.contextPath
+        http
+            .securityMatcher("$contextPath/instances/**", "$contextPath/actuator/**")
+            .authorizeHttpRequests { it.anyRequest().authenticated() }
+            .httpBasic(withDefaults())
+            .csrf { it.disable() }
+        return http.build()
+    }
+
+    @Bean
+    fun uiFilterChain(http: HttpSecurity): SecurityFilterChain {
         val contextPath = adminServer.contextPath
         val successHandler =
             org.springframework.security.web.authentication
@@ -57,23 +80,8 @@ class SecurityConfig(
                 oauth2.successHandler(successHandler)
                 oauth2.loginProcessingUrl("$contextPath/login/oauth2/code/*")
             }.logout { logout -> logout.logoutUrl("$contextPath/logout") }
-            .httpBasic(withDefaults())
             .csrf { csrf ->
-                csrf
-                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                    .ignoringRequestMatchers(
-                        AntPathRequestMatcher(
-                            "$contextPath/instances",
-                            org.springframework.http.HttpMethod.POST
-                                .name()
-                        ),
-                        AntPathRequestMatcher(
-                            "$contextPath/instances/*",
-                            org.springframework.http.HttpMethod.DELETE
-                                .name()
-                        ),
-                        AntPathRequestMatcher("$contextPath/actuator/**")
-                    )
+                csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
             }
 
         return http.build()

--- a/svc-admin/src/main/resources/application.yml
+++ b/svc-admin/src/main/resources/application.yml
@@ -29,13 +29,19 @@ spring:
         connect-timeout: 5s
         read-timeout: 10s
   security:
+    # In-memory user used by the client registration filter chain only —
+    # SBA clients POST /instances with HTTP Basic credentials matching
+    # this user. Browsers never see this; UI auth is OIDC.
+    user:
+      name: ${SPRING_SECURITY_USER_NAME:admin}
+      password: ${SPRING_SECURITY_USER_PASSWORD:not-set}
     oauth2:
       client:
         registration:
           auth0:
             # Reuses bc-view's Auth0 application — the same client-id/secret.
             # Auth0 app must list this server's callback URL alongside bc-view's:
-            #   https://kauri.monowai.com:30530/login/oauth2/code/auth0
+            #   https://bc-admin.monowai.com/login/oauth2/code/auth0
             client-id: ${AUTH0_CLIENT_ID:not-set}
             client-secret: ${AUTH0_CLIENT_SECRET:not-set}
             client-authentication-method: client_secret_post


### PR DESCRIPTION
## Summary
- `SecurityConfig` now exposes two `SecurityFilterChain` beans:
  - **Chain 1** (`@Order(HIGHEST_PRECEDENCE)`) scoped to `/instances/**` + `/actuator/**`. HTTP Basic with a user from `spring.security.user.{name,password}`. CSRF disabled (server-to-server registration POSTs).
  - **Chain 2** (default order) for everything else. OIDC login only; CSRF cookie for the SPA. Anonymous browser requests now hit the OAuth2 entry-point and redirect to Auth0.
- `application.yml` re-introduces `spring.security.user` driven by `SPRING_SECURITY_USER_NAME` / `SPRING_SECURITY_USER_PASSWORD` env vars (Chain 1 needs them).
- KDoc callback URL bumped to `https://bc-admin.monowai.com/login/oauth2/code/auth0` to match the new Caddy route.

## Why
Browser hits to `https://bc-admin.monowai.com/` returned HTTP 401 with `WWW-Authenticate: Basic Realm` — Spring picked the Basic entry-point because both `.httpBasic()` and `.oauth2Login()` lived on the same chain. Result: Basic prompt blocked OIDC redirect.

Splitting chains is the documented SBA pattern.

## Test plan
- [x] `./gradlew :svc-admin:test` — context-loads + bearer-token tests green
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [x] `semgrep --config=auto` on changed files — 0 findings
- [ ] Post-deploy: `curl -sI https://bc-admin.monowai.com/` → expect 302 to `/oauth2/authorization/auth0`, not 401 Basic.
- [ ] Post-deploy: confirm bc-data + bc-position + bc-event register in SBA UI (clients POSTing to `/instances` with SBA_REGISTRATION_PASSWORD basic creds).

## Companion changes (separate PRs / pushes)
- bc-deploy `bc-admin.configMap.SPRING_SECURITY_USER_NAME=admin` + `bc-admin.secrets.SPRING_SECURITY_USER_PASSWORD=<sba_registration_password>`.
- bc-view admin hub link bumped from `kauri.monowai.com:30530` to `https://bc-admin.monowai.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Separated authentication mechanisms: API endpoints now use HTTP Basic authentication, while the admin UI uses OIDC login.
  * Updated OIDC callback URL configuration to reference the new admin service endpoint.
  * Improved security filter chain organization for better access control enforcement.

* **Chores**
  * Added in-memory user configuration for API authentication support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->