### PR TITLE
fix(svc-admin): permit anonymous on /actuator/health for K8s probes

### DIFF
--- a/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
@@ -14,11 +14,17 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 /**
  * SBA server security.
  *
- * Two filter chains, ordered:
+ * Three filter chains, ordered:
  *
- *  1. Client registration chain (instances + actuator paths) — SBA
- *     clients (bc-data, bc-position, etc.) POST their actuator metadata
- *     using HTTP Basic with the user supplied via
+ *  0. Probe chain — K8s liveness, readiness and startup probes hit
+ *     the actuator health endpoint (and its sub-paths liveness,
+ *     readiness) unauthenticated. Must run before the Basic-auth
+ *     chain or the kubelet receives a 401 challenge and fails the
+ *     probe.
+ *
+ *  1. Client registration chain (instances + remaining actuator paths)
+ *     — SBA clients (bc-data, bc-position, etc.) POST their actuator
+ *     metadata using HTTP Basic with the user supplied via
  *     spring.security.user.name + spring.security.user.password.
  *     Browsers never hit these paths, so Basic-auth is the correct
  *     primary entry-point here.
@@ -42,6 +48,20 @@ class SecurityConfig(
 ) {
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)
+    fun probeFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val contextPath = adminServer.contextPath
+        http
+            .securityMatcher(
+                "$contextPath/actuator/health",
+                "$contextPath/actuator/health/**",
+                "$contextPath/actuator/info"
+            ).authorizeHttpRequests { it.anyRequest().permitAll() }
+            .csrf { it.disable() }
+        return http.build()
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE + 10)
     fun clientRegistrationFilterChain(http: HttpSecurity): SecurityFilterChain {
         val contextPath = adminServer.contextPath
         http

--- a/svc-admin/src/test/kotlin/com/beancounter/admin/ProbeChainTest.kt
+++ b/svc-admin/src/test/kotlin/com/beancounter/admin/ProbeChainTest.kt
@@ -1,0 +1,75 @@
+package com.beancounter.admin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+
+/**
+ * K8s liveness, readiness and startup probes hit the actuator health
+ * endpoint (and its sub-paths liveness, readiness) unauthenticated.
+ * Verifies the probe filter chain runs before the Basic-auth chain —
+ * otherwise the kubelet receives a 401 and fails the startup probe.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.security.oauth2.client.registration.auth0.client-id=test-client",
+        "spring.security.oauth2.client.registration.auth0.client-secret=test-secret",
+        "spring.security.oauth2.client.registration.auth0.scope=openid,profile,email",
+        "spring.security.oauth2.client.registration.auth0.authorization-grant-type=authorization_code",
+        "spring.security.oauth2.client.registration.auth0.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}",
+        "spring.security.oauth2.client.provider.auth0.authorization-uri=https://example.test/authorize",
+        "spring.security.oauth2.client.provider.auth0.token-uri=https://example.test/oauth/token",
+        "spring.security.oauth2.client.provider.auth0.jwk-set-uri=https://example.test/.well-known/jwks.json",
+        "spring.security.oauth2.client.provider.auth0.user-info-uri=https://example.test/userinfo",
+        "spring.security.oauth2.client.provider.auth0.user-name-attribute=sub",
+        "beancounter.admin.client.bearer-token=",
+        "management.server.port=0",
+        "management.endpoint.health.probes.enabled=true",
+        "management.endpoints.web.exposure.include=health,info,metrics"
+    ]
+)
+class ProbeChainTest {
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    // Actuator endpoints live on a separate management port in production
+    // (application.yml sets management.server.port=9531). Spring Boot binds
+    // a random port at test time and exposes it as local.management.port.
+    @Value("\${local.management.port}")
+    private var managementPort: Int = 0
+
+    @Test
+    fun `actuator health permits anonymous access`() {
+        val response =
+            restTemplate.getForEntity(
+                "http://localhost:$managementPort/actuator/health",
+                String::class.java
+            )
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `actuator health liveness permits anonymous access`() {
+        val response =
+            restTemplate.getForEntity(
+                "http://localhost:$managementPort/actuator/health/liveness",
+                String::class.java
+            )
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `actuator health readiness permits anonymous access`() {
+        val response =
+            restTemplate.getForEntity(
+                "http://localhost:$managementPort/actuator/health/readiness",
+                String::class.java
+            )
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a probe filter chain at `HIGHEST_PRECEDENCE` that `permitAll` on `/actuator/health`, `/actuator/health/**`, `/actuator/info` so kubelet liveness/readiness/startup probes don't get challenged for Basic auth.
- Bumps the existing client-registration (Basic-auth) chain to `HIGHEST_PRECEDENCE + 10` so it still owns the rest of `/actuator/**` and `/instances/**`.
- New `ProbeChainTest` boots the context, resolves the management port via `local.management.port`, and asserts unauthenticated 200 on each health endpoint.

## Why

After PR #851 merged, `bc-admin` on kauri started CrashLoopBackOff because the kubelet's startup probe hit `/actuator/health` and was challenged with Basic auth → kubelet recorded `Startup probe failed: HTTP probe failed with statuscode: 500` (via istio pilot-agent's translation of the 302/401 from oauth2Login + httpBasic).

## Test plan

- [x] `./gradlew :svc-admin:test` — 10 tests pass (3 new health probe tests)
- [x] `./gradlew :svc-admin:formatKotlin :svc-admin:lintKotlin`
- [ ] After merge + image build, redeploy bc-admin and confirm pod reaches `2/2 Running` (probe + readiness clears)
- [ ] `curl -i https://bc-admin.monowai.com/actuator/health` returns 200 unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actuator health and info endpoints are now accessible without authentication, allowing Kubernetes health probes to function seamlessly.

* **Tests**
  * Added integration tests to verify unauthenticated access to health check endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->