### PR TITLE
feat(svc-admin): M2M token fetch for SBA background scrapes

### DIFF
--- a/svc-admin/src/main/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProvider.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProvider.kt
@@ -24,13 +24,19 @@ import java.util.concurrent.atomic.AtomicReference
  *     happens inside a request thread carrying a Spring SecurityContext).
  *  2. The most recently observed user token, cached after each interactive
  *     request — used by background polling threads. Cleared once expired so
- *     it does not block the static fallback.
- *  3. An optional static token from `BC_ADMIN_M2M_TOKEN` — final fallback
- *     when no admin has logged in this boot and any cached token has aged out.
+ *     it does not block the M2M fallback.
+ *  3. An Auth0 M2M token fetched via client_credentials using
+ *     AUTH0_SERVICE_ID / AUTH0_SERVICE_SECRET. Keeps the SBA monitor
+ *     scrape working when no admin is logged in — without it, actuator
+ *     discovery returns only the health endpoint and the SBA UI shows
+ *     no metrics.
+ *  4. An optional static token from `BC_ADMIN_M2M_TOKEN` — emergency
+ *     override when the M2M fetch path is unavailable.
  */
 @Component
 class BearerTokenHttpHeadersProvider(
     private val authorizedClientService: OAuth2AuthorizedClientService,
+    private val m2mTokenService: M2mTokenService,
     @Value("\${beancounter.admin.client.bearer-token:}")
     private val staticFallbackToken: String
 ) : HttpHeadersProvider {
@@ -39,7 +45,11 @@ class BearerTokenHttpHeadersProvider(
 
     override fun getHeaders(instance: Instance): HttpHeaders {
         val headers = HttpHeaders()
-        val token = currentUserToken() ?: validCachedToken() ?: staticFallbackToken.takeIf { it.isNotBlank() }
+        val token =
+            currentUserToken()
+                ?: validCachedToken()
+                ?: m2mTokenService.token()
+                ?: staticFallbackToken.takeIf { it.isNotBlank() }
         token?.let { headers.setBearerAuth(it) }
         return headers
     }

--- a/svc-admin/src/main/kotlin/com/beancounter/admin/M2mTokenService.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/M2mTokenService.kt
@@ -1,0 +1,94 @@
+package com.beancounter.admin
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Fetches and caches an Auth0 M2M access token for background scrape
+ * threads in [BearerTokenHttpHeadersProvider]. SBA's monitor schedule
+ * runs outside any user request, so the OIDC pass-through path has
+ * nothing to read. Without a working M2M fallback, scrapes against
+ * actuator endpoints get 401, the actuator discovery returns the
+ * health endpoint only, and the SBA UI shows no metrics.
+ *
+ * Uses the same M2M client (AUTH0_SERVICE_ID / AUTH0_SERVICE_SECRET)
+ * that bc-data, bc-event etc. already use for inter-service calls —
+ * the issued token carries `beancounter:system`, which jar-auth's
+ * actuator filter accepts alongside `beancounter:admin`.
+ *
+ * Tokens are cached until 30s before their `exp`. A failed exchange
+ * returns null and is retried on the next request (no negative cache).
+ */
+@Service
+class M2mTokenService(
+    @Value("\${auth.uri:}")
+    private val authIssuerUri: String,
+    @Value("\${auth.audience:https://holdsworth.app}")
+    private val audience: String,
+    @Value("\${auth0.service.id:\${AUTH0_SERVICE_ID:}}")
+    private val clientId: String,
+    @Value("\${auth0.service.secret:\${AUTH0_SERVICE_SECRET:}}")
+    private val clientSecret: String
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val restTemplate = RestTemplate()
+    private val cached = AtomicReference<CachedM2m?>(null)
+    private val refreshSkewSeconds = 30L
+
+    fun token(): String? {
+        cached.get()?.let { existing ->
+            if (Instant.now().isBefore(existing.expiresAt.minusSeconds(refreshSkewSeconds))) {
+                return existing.value
+            }
+        }
+        if (clientId.isBlank() || clientSecret.isBlank() || authIssuerUri.isBlank()) {
+            return null
+        }
+        return fetch()?.also { cached.set(it) }?.value
+    }
+
+    private fun fetch(): CachedM2m? {
+        val formData =
+            LinkedMultiValueMap<String, String>().apply {
+                add("grant_type", "client_credentials")
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("audience", audience)
+            }
+        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+        val tokenUrl = "${authIssuerUri.trimEnd('/')}/oauth/token"
+        return try {
+            val response =
+                restTemplate.postForObject(
+                    tokenUrl,
+                    HttpEntity(formData, headers),
+                    Auth0TokenResponse::class.java
+                )
+            response?.access_token?.let { CachedM2m(it, Instant.now().plusSeconds(response.expires_in)) }
+        } catch (ex: RestClientException) {
+            log.warn("M2M token fetch failed at {}: {}", tokenUrl, ex.message)
+            null
+        }
+    }
+
+    private data class CachedM2m(
+        val value: String,
+        val expiresAt: Instant
+    )
+
+    @Suppress("PropertyName", "ConstructorParameterNaming")
+    private data class Auth0TokenResponse(
+        val access_token: String? = null,
+        val token_type: String? = null,
+        val expires_in: Long = 0
+    )
+}

--- a/svc-admin/src/main/resources/application.yml
+++ b/svc-admin/src/main/resources/application.yml
@@ -58,11 +58,15 @@ spring:
             issuer-uri: https://${AUTH0_DOMAIN:beancounter.eu.auth0.com}/
 
 auth:
+  # Auth0 issuer URI, used by M2mTokenService when fetching a
+  # client_credentials token for background SBA scrapes. Must end with
+  # a trailing slash to match the OIDC issuer format.
+  uri: https://${AUTH0_DOMAIN:beancounter.eu.auth0.com}/
   # Auth0 API audience injected into the authorization request via
   # OAuth2AuthorizationRequestResolver. Without it Auth0 issues a
   # generic OIDC token with no `beancounter:*` permissions in the
   # `scope` claim, so SecurityConfig's `SCOPE_beancounter:admin`
-  # authority check 403s every login.
+  # authority check 403s every login. Reused by M2mTokenService.
   audience: ${AUTH_AUDIENCE:https://holdsworth.app}
 
 beancounter:

--- a/svc-admin/src/test/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProviderTest.kt
+++ b/svc-admin/src/test/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProviderTest.kt
@@ -18,6 +18,7 @@ import java.time.Instant
 class BearerTokenHttpHeadersProviderTest {
     private val instance: Instance = mock()
     private val authorizedClientService: OAuth2AuthorizedClientService = mock()
+    private val m2mTokenService: M2mTokenService = mock { on { token() } doReturn null }
 
     @AfterEach
     fun clearContext() {
@@ -46,7 +47,7 @@ class BearerTokenHttpHeadersProviderTest {
             }
         SecurityContextHolder.getContext().authentication = auth
 
-        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, "")
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2mTokenService, "")
 
         val headers = provider.getHeaders(instance)
 
@@ -64,7 +65,7 @@ class BearerTokenHttpHeadersProviderTest {
         whenever(authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(eq("auth0"), eq("u")))
             .thenReturn(client)
 
-        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, "")
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2mTokenService, "")
 
         // First call inside a request thread — populates the cache.
         val auth: OAuth2AuthenticationToken =
@@ -83,7 +84,7 @@ class BearerTokenHttpHeadersProviderTest {
 
     @Test
     fun `falls back to static M2M token when no user has authenticated`() {
-        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, "static.m2m.token")
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2mTokenService, "static.m2m.token")
 
         val headers = provider.getHeaders(instance)
 
@@ -109,7 +110,7 @@ class BearerTokenHttpHeadersProviderTest {
             }
         SecurityContextHolder.getContext().authentication = auth
 
-        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, "static.m2m.token")
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2mTokenService, "static.m2m.token")
         // Populate the cache. Inside the request thread the current-user lookup still returns
         // the (about-to-be-expired) token — getHeaders will Bearer it. We only care that the
         // next background call falls through to the static fallback.
@@ -123,11 +124,21 @@ class BearerTokenHttpHeadersProviderTest {
 
     @Test
     fun `omits Authorization when nothing configured and no user`() {
-        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, "")
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2mTokenService, "")
 
         val headers = provider.getHeaders(instance)
 
         assertThat(headers.getFirst("Authorization")).isNull()
+    }
+
+    @Test
+    fun `falls back to M2M client_credentials token before static fallback`() {
+        val m2m: M2mTokenService = mock { on { token() } doReturn "fetched.m2m.token" }
+        val provider = BearerTokenHttpHeadersProvider(authorizedClientService, m2m, "static.m2m.token")
+
+        val headers = provider.getHeaders(instance)
+
+        assertThat(headers.getFirst("Authorization")).isEqualTo("Bearer fetched.m2m.token")
     }
 
     private fun <T> eq(value: T): T = org.mockito.ArgumentMatchers.eq(value) ?: value


### PR DESCRIPTION
## Summary

- New `M2mTokenService` fetches an Auth0 access token via `client_credentials` using `AUTH0_SERVICE_ID` / `AUTH0_SERVICE_SECRET`. Cached until 30s before `exp`, re-fetched lazily.
- `BearerTokenHttpHeadersProvider` slots it in as tier 3 (between cached user token and the static `BC_ADMIN_M2M_TOKEN` fallback).
- `application.yml` exposes `auth.uri` (env `AUTH0_DOMAIN`) so the fetcher knows the issuer.
- Test: new assertion that the M2M token is preferred over the static fallback.

## Why

The user reports "the admin opens but there are no metrics." Live SBA shows bc-data registered with `endpoints: [{ id: health }]` only — SBA's discovery scrape against `/actuator` is hitting bc-data on a background thread (no `SecurityContext`), getting 401 from jar-auth, and falling back to the registration-declared health URL. With this PR the scrape carries a `beancounter:system` token and discovery returns the full endpoint list (metrics, env, info, etc).

Same M2M client (`global.auth.service`) that bc-data/bc-event already use — no new secret.

## Bc-deploy companion change

`bc-deploy/charts/bc-admin/templates/bc-svc.yaml` must include `spring.auth` + `spring.auth.service` so `AUTH_URI` / `AUTH0_SERVICE_*` are injected. Tracked separately — direct push to bc-deploy main.

## Test plan

- [x] `./gradlew :svc-admin:test` — 12 tests pass (1 new tier-3 assertion)
- [x] `./gradlew :svc-admin:formatKotlin :svc-admin:lintKotlin`
- [ ] After merge + image build, redeploy bc-admin and confirm `curl -u admin:<pw> -H 'Accept: application/json' http://bc-admin/instances` shows >1 endpoint per registered service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Auth0 Machine-to-Machine token authentication support with automatic caching and refresh mechanisms.
  * Implemented a fallback token resolution chain to ensure reliable authentication across multiple sources.
  * Added configuration support for Auth0 issuer URI.

* **Tests**
  * Updated test coverage to verify M2M token handling and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->