### PR TITLE
feat: SBA client in bc-position, bc-event, bc-agent

### DIFF
--- a/svc-agent/build.gradle.kts
+++ b/svc-agent/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation(libs.spring.boot.starter.actuator)
+    implementation("de.codecentric:spring-boot-admin-starter-client:3.5.4")
     implementation(libs.spring.boot.starter.integration)
     // micrometer-tracing-bridge-otel comes via jar-common (api dep) so
     // Spring AI's `spring.ai.chat.client` / `gen_ai.*` observations

--- a/svc-agent/src/main/resources/application.yml
+++ b/svc-agent/src/main/resources/application.yml
@@ -114,6 +114,20 @@ resilience4j:
 spring:
   application:
     name: bc-agent
+  boot:
+    admin:
+      client:
+        # Spring Boot Admin client. Disabled by default; enabled in kauri via
+        # SBA_CLIENT_ENABLED=true + SBA_SERVER_URL=http://bc-admin:9530.
+        enabled: ${SBA_CLIENT_ENABLED:false}
+        url: ${SBA_SERVER_URL:http://localhost:9530}
+        username: ${SBA_REGISTRATION_USERNAME:admin}
+        password: ${SBA_REGISTRATION_PASSWORD:}
+        instance:
+          management-base-url: ${MANAGEMENT_BASE_URL:http://localhost:9531}
+          metadata:
+            tags:
+              service: bc-agent
   security:
     oauth2:
       resourceserver:

--- a/svc-event/build.gradle.kts
+++ b/svc-event/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-resource-server")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation(libs.spring.boot.starter.actuator)
+    implementation("de.codecentric:spring-boot-admin-starter-client:3.5.4")
     implementation(libs.spring.boot.starter.integration)
     implementation(libs.spring.doc)
     implementation(libs.spring.doc.mvc)

--- a/svc-event/src/main/resources/application.yml
+++ b/svc-event/src/main/resources/application.yml
@@ -80,6 +80,20 @@ auth:
 spring:
   application:
     name: bc-event
+  boot:
+    admin:
+      client:
+        # Spring Boot Admin client. Disabled by default; enabled in kauri via
+        # SBA_CLIENT_ENABLED=true + SBA_SERVER_URL=http://bc-admin:9530.
+        enabled: ${SBA_CLIENT_ENABLED:false}
+        url: ${SBA_SERVER_URL:http://localhost:9530}
+        username: ${SBA_REGISTRATION_USERNAME:admin}
+        password: ${SBA_REGISTRATION_PASSWORD:}
+        instance:
+          management-base-url: ${MANAGEMENT_BASE_URL:http://localhost:9521}
+          metadata:
+            tags:
+              service: bc-event
   cache:
     cache-names: auth.m2m
   flyway:

--- a/svc-position/build.gradle.kts
+++ b/svc-position/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.springframework.security:spring-security-oauth2-resource-server")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation(libs.spring.boot.starter.actuator)
+    implementation("de.codecentric:spring-boot-admin-starter-client:3.5.4")
     implementation(libs.spring.boot.starter.integration)
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation(libs.jackson.kotlin)

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -64,6 +64,20 @@ auth:
 spring:
   application:
     name: bc-position
+  boot:
+    admin:
+      client:
+        # Spring Boot Admin client. Disabled by default; enabled in kauri via
+        # SBA_CLIENT_ENABLED=true + SBA_SERVER_URL=http://bc-admin:9530.
+        enabled: ${SBA_CLIENT_ENABLED:false}
+        url: ${SBA_SERVER_URL:http://localhost:9530}
+        username: ${SBA_REGISTRATION_USERNAME:admin}
+        password: ${SBA_REGISTRATION_PASSWORD:}
+        instance:
+          management-base-url: ${MANAGEMENT_BASE_URL:http://localhost:9501}
+          metadata:
+            tags:
+              service: bc-position
   datasource:
     url: jdbc:h2:mem:position;DB_CLOSE_DELAY=-1
   jpa:


### PR DESCRIPTION
## Summary

Adds `spring-boot-admin-starter-client:3.5.4` + the standard `spring.boot.admin.client` block to the three remaining monorepo services. Same pattern PR #848 introduced for bc-data — no functional change beyond optional registration with the bc-admin SBA server.

## Per service

| Service | Mgmt port (local) | Service tag |
|---------|-------------------|-------------|
| bc-position | 9501 | bc-position |
| bc-event | 9521 | bc-event |
| bc-agent | 9531 | bc-agent |

## Why

User wants bc-admin to monitor all backend services, not just bc-data. With the client wired in, each service registers itself when `SBA_CLIENT_ENABLED=true` + `SBA_SERVER_URL=http://bc-admin:9530`, posts its actuator URL, and tags itself. bc-admin then exposes JVM, HTTP, DB pool, RabbitMQ health, log levels, scheduled tasks, etc. per service.

Existing actuator security (jar-auth `SCOPE_ADMIN`/`SCOPE_SYSTEM`) is unchanged — the SBA server's `BearerTokenHttpHeadersProvider` already attaches a token (PR #854) so the background scrape works.

## bc-deploy companion

`bc-deploy/env/kauri.yaml` needs `SBA_CLIENT_ENABLED: "true"` + `SBA_SERVER_URL: "http://bc-admin:9530"` + `MANAGEMENT_BASE_URL: "http://bc-<svc>.default.svc.cluster.local:8000"` per service. Tracked separately.

## Test plan

- [x] `./gradlew :svc-position:test :svc-event:test :svc-agent:test`
- [ ] After deploy, hit `/instances` on bc-admin and confirm 4 services UP (bc-data, bc-position, bc-event, bc-agent) with > health endpoint each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated Spring Boot Admin client support across all services, enabling centralized monitoring and administrative capabilities.
  * Services now support environment-variable-driven configuration for flexible deployment and operational management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->