### PR TITLE
fix(svc-data): backfill price history when earliest cached > requested from

### DIFF
--- a/jar-client/src/main/kotlin/com/beancounter/client/services/PriceService.kt
+++ b/jar-client/src/main/kotlin/com/beancounter/client/services/PriceService.kt
@@ -3,6 +3,8 @@ package com.beancounter.client.services
 import com.beancounter.auth.TokenService
 import com.beancounter.common.contracts.BulkPriceRequest
 import com.beancounter.common.contracts.BulkPriceResponse
+import com.beancounter.common.contracts.EnsureHistoryRequest
+import com.beancounter.common.contracts.EnsureHistoryResponse
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.exception.BusinessException
@@ -48,6 +50,20 @@ class PriceService(
             .retrieve()
             .body(BulkPriceResponse::class.java)
             ?: throw BusinessException("Failed to get bulk prices")
+
+    fun ensureHistory(
+        ensureHistoryRequest: EnsureHistoryRequest,
+        token: String = tokenService.bearerToken
+    ): EnsureHistoryResponse =
+        restClient
+            .post()
+            .uri("/prices/ensure-history")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(ensureHistoryRequest)
+            .retrieve()
+            .body(EnsureHistoryResponse::class.java)
+            ?: throw BusinessException("Failed to schedule ensure-history")
 
     fun getEvents(assetId: String): PriceResponse =
         restClient

--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/CacheInvalidationEvent.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/CacheInvalidationEvent.kt
@@ -5,7 +5,15 @@ import java.time.LocalDate
 enum class CacheChangeType {
     TRANSACTION,
     PRICE,
-    FX
+    FX,
+
+    // Emitted after a deep price-history backfill completes. Consumers
+    // should invalidate any cached state derived from prices on or after
+    // `fromDate`, regardless of portfolio (the affected portfolios are
+    // whichever held the asset during the backfilled range — broader
+    // invalidation is acceptable here since the event is rare and we
+    // want guaranteed correctness on the next request).
+    PRICE_HISTORY
 }
 
 data class CacheInvalidationEvent(

--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/EnsureHistoryRequest.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/EnsureHistoryRequest.kt
@@ -1,0 +1,19 @@
+package com.beancounter.common.contracts
+
+import java.time.LocalDate
+
+/**
+ * Asks svc-data to ensure each listed asset has price history covering
+ * back to `fromDate`. Scheduling is fire-and-forget — backfills run on
+ * `PriceBackfillCoordinator`, deduped + cooldown-protected. Caller gets
+ * the scheduled count back; the next data fetch returns the widened
+ * range.
+ */
+data class EnsureHistoryRequest(
+    val assetIds: List<String> = listOf(),
+    val fromDate: LocalDate
+)
+
+data class EnsureHistoryResponse(
+    val scheduled: Int
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/MarketDataBoot.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/MarketDataBoot.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 )
 @EnableWebSecurity
 @EnableConfigurationProperties
+@EnableAsync
 class MarketDataBoot
 
 fun main(args: Array<String>) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducer.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducer.kt
@@ -47,6 +47,19 @@ class CacheInvalidationProducer(
         )
     }
 
+    fun sendPriceHistoryEvent(
+        assetId: String,
+        fromDate: LocalDate
+    ) {
+        send(
+            CacheInvalidationEvent(
+                changeType = CacheChangeType.PRICE_HISTORY,
+                assetId = assetId,
+                fromDate = fromDate
+            )
+        )
+    }
+
     private fun send(event: CacheInvalidationEvent) {
         if (!streamEnabled) return
         try {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducer.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducer.kt
@@ -47,6 +47,11 @@ class CacheInvalidationProducer(
         )
     }
 
+    /**
+     * Emitted after a deep-history backfill completes for [assetId]. svc-position
+     * uses this to drop cached performance snapshots from [fromDate] onwards so
+     * the next read recomputes against the widened price series.
+     */
     fun sendPriceHistoryEvent(
         assetId: String,
         fromDate: LocalDate

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.providers
 import com.beancounter.common.model.Asset
 import com.beancounter.marketdata.assets.AssetFinder
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 /**
  * Service for handling market data backfill operations.
@@ -13,14 +14,20 @@ class MarketDataBackfillService(
     private val priceService: PriceService,
     private val assetFinder: AssetFinder
 ) {
-    fun backFill(assetId: String) {
-        backFill(getAsset(assetId))
+    fun backFill(
+        assetId: String,
+        fromDate: LocalDate = LocalDate.now().minusYears(2)
+    ) {
+        backFill(getAsset(assetId), fromDate)
     }
 
-    fun backFill(asset: Asset) {
+    fun backFill(
+        asset: Asset,
+        fromDate: LocalDate = LocalDate.now().minusYears(2)
+    ) {
         val byFactory = providerUtils.splitProviders(providerUtils.getInputs(listOf(asset)))
         for (marketDataProvider in byFactory.keys) {
-            priceService.handle(marketDataProvider.backFill(asset))
+            priceService.handle(marketDataProvider.backFill(asset, fromDate))
         }
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
@@ -2,6 +2,7 @@ package com.beancounter.marketdata.providers
 
 import com.beancounter.common.model.Asset
 import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.defaultBackfillFrom
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -16,14 +17,14 @@ class MarketDataBackfillService(
 ) {
     fun backFill(
         assetId: String,
-        fromDate: LocalDate = LocalDate.now().minusYears(2)
+        fromDate: LocalDate = defaultBackfillFrom()
     ) {
         backFill(getAsset(assetId), fromDate)
     }
 
     fun backFill(
         asset: Asset,
-        fromDate: LocalDate = LocalDate.now().minusYears(2)
+        fromDate: LocalDate = defaultBackfillFrom()
     ) {
         val byFactory = providerUtils.splitProviders(providerUtils.getInputs(listOf(asset)))
         for (marketDataProvider in byFactory.keys) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
@@ -35,9 +35,19 @@ interface MarketDataPriceProvider {
     // (Alpha) or none at all (cash, custom) may ignore it.
     fun backFill(
         asset: Asset,
-        fromDate: LocalDate = LocalDate.now().minusYears(2)
+        fromDate: LocalDate = defaultBackfillFrom()
     ): PriceResponse
 
     // Return true if an external API calls is required
     fun isApiSupported(): Boolean
+
+    companion object {
+        // Default window when no caller-supplied `fromDate`. Matches the
+        // shortest provider plan (EODHD historical / MarketStack base tier
+        // both cover roughly this range). PriceController + ensureHistory
+        // pass an explicit `targetFrom` for deep-history charts.
+        const val DEFAULT_BACKFILL_YEARS = 2L
+
+        fun defaultBackfillFrom(): LocalDate = LocalDate.now().minusYears(DEFAULT_BACKFILL_YEARS)
+    }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
@@ -30,7 +30,13 @@ interface MarketDataPriceProvider {
         priceRequest: PriceRequest
     ): LocalDate
 
-    fun backFill(asset: Asset): PriceResponse
+    // fromDate caps how far back to fetch when the provider supports a date
+    // range. Providers that always return their full available history
+    // (Alpha) or none at all (cash, custom) may ignore it.
+    fun backFill(
+        asset: Asset,
+        fromDate: LocalDate = LocalDate.now().minusYears(2)
+    ): PriceResponse
 
     // Return true if an external API calls is required
     fun isApiSupported(): Boolean

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataService.kt
@@ -32,8 +32,11 @@ class MarketDataService(
     private val priceService: PriceService,
     private val dateUtils: DateUtils
 ) {
-    fun backFill(assetId: String) {
-        backfillService.backFill(assetId)
+    fun backFill(
+        assetId: String,
+        fromDate: LocalDate = LocalDate.now().minusYears(2)
+    ) {
+        backfillService.backFill(assetId, fromDate)
     }
 
     fun getPriceResponse(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataService.kt
@@ -11,6 +11,7 @@ import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.DateUtils.Companion.TODAY
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.defaultBackfillFrom
 import org.springframework.context.annotation.Import
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -34,7 +35,7 @@ class MarketDataService(
 ) {
     fun backFill(
         assetId: String,
-        fromDate: LocalDate = LocalDate.now().minusYears(2)
+        fromDate: LocalDate = defaultBackfillFrom()
     ) {
         backfillService.backFill(assetId, fromDate)
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.providers
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.Instant
@@ -19,6 +20,10 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * In-flight guard prevents two concurrent backfills for the same asset.
  * Cooldown prevents retry storms when the provider call keeps failing.
+ *
+ * The `lastAttempt` map is pruned hourly so it can't grow without bound
+ * across the lifetime of the process — every distinct assetId ever queried
+ * would otherwise stick around forever.
  */
 @Service
 class PriceBackfillCoordinator(
@@ -64,6 +69,21 @@ class PriceBackfillCoordinator(
             log.warn("Async backfill failed for asset {}", assetId, e)
         } finally {
             inFlight.remove(assetId)
+        }
+    }
+
+    /**
+     * Drop cooldown entries older than the cooldown window — they no longer
+     * block any caller, so retaining them just leaks memory in long-running
+     * processes that see a steady stream of distinct assets.
+     */
+    @Scheduled(fixedDelayString = "PT1H")
+    fun pruneStaleCooldowns() {
+        val threshold = Instant.now().minus(ATTEMPT_COOLDOWN)
+        val sizeBefore = lastAttempt.size
+        lastAttempt.entries.removeIf { it.value.isBefore(threshold) }
+        if (sizeBefore != lastAttempt.size) {
+            log.debug("Pruned cooldown entries: {} -> {}", sizeBefore, lastAttempt.size)
         }
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
@@ -34,6 +34,10 @@ class PriceBackfillCoordinator(
         assetId: String,
         fromDate: LocalDate
     ) {
+        if (assetId.isBlank()) {
+            log.debug("Backfill skipped — blank assetId")
+            return
+        }
         val now = Instant.now()
         val previous = lastAttempt[assetId]
         if (previous != null && Duration.between(previous, now) < ATTEMPT_COOLDOWN) {
@@ -57,7 +61,7 @@ class PriceBackfillCoordinator(
             @Suppress("TooGenericExceptionCaught")
             e: Exception
         ) {
-            log.warn("Async backfill failed for asset {}: {}", assetId, e.message)
+            log.warn("Async backfill failed for asset {}", assetId, e)
         } finally {
             inFlight.remove(assetId)
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
@@ -34,6 +34,18 @@ class PriceBackfillCoordinator(
     private val inFlight = ConcurrentHashMap.newKeySet<String>()
     private val lastAttempt = ConcurrentHashMap<String, Instant>()
 
+    /**
+     * Queue a deep backfill for [assetId] reaching back to [fromDate]. Returns
+     * immediately — the actual provider call runs on `priceBackfillExecutor`.
+     *
+     * Three guards short-circuit before any work runs:
+     *  - blank [assetId] is dropped (caller bug, don't spam the executor)
+     *  - cooldown: same asset attempted within [ATTEMPT_COOLDOWN] is dropped
+     *  - in-flight: concurrent backfill for same asset is suppressed
+     *
+     * On success a `PRICE_HISTORY` cache-invalidation event is published so
+     * downstream caches (svc-position snapshots) recompute on the next read.
+     */
     @Async("priceBackfillExecutor")
     fun scheduleBackfill(
         assetId: String,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
@@ -1,0 +1,63 @@
+package com.beancounter.marketdata.providers
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Schedules deep price-history backfills outside the request thread.
+ *
+ * `PriceController.getPriceHistory` returns whatever is in the DB straight
+ * away. When the cached range doesn't cover what the chart asked for, we
+ * trigger an async backfill here so the next request gets the extended
+ * history without blocking the current one on a multi-year provider call.
+ *
+ * In-flight guard prevents two concurrent backfills for the same asset.
+ * Cooldown prevents retry storms when the provider call keeps failing.
+ */
+@Service
+class PriceBackfillCoordinator(
+    private val backfillService: MarketDataBackfillService
+) {
+    private val log = LoggerFactory.getLogger(PriceBackfillCoordinator::class.java)
+    private val inFlight = ConcurrentHashMap.newKeySet<String>()
+    private val lastAttempt = ConcurrentHashMap<String, Instant>()
+
+    @Async("priceBackfillExecutor")
+    fun scheduleBackfill(
+        assetId: String,
+        fromDate: LocalDate
+    ) {
+        val now = Instant.now()
+        val previous = lastAttempt[assetId]
+        if (previous != null && Duration.between(previous, now) < ATTEMPT_COOLDOWN) {
+            log.debug("Backfill cooldown active for {}, skipping", assetId)
+            return
+        }
+        if (!inFlight.add(assetId)) {
+            log.debug("Backfill already running for {}", assetId)
+            return
+        }
+        lastAttempt[assetId] = now
+        try {
+            log.info("Async backfill starting for asset={} fromDate={}", assetId, fromDate)
+            backfillService.backFill(assetId, fromDate)
+            log.info("Async backfill completed for asset={}", assetId)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.warn("Async backfill failed for asset {}: {}", assetId, e.message)
+        } finally {
+            inFlight.remove(assetId)
+        }
+    }
+
+    private companion object {
+        val ATTEMPT_COOLDOWN: Duration = Duration.ofHours(1)
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinator.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers
 
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
@@ -21,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap
  */
 @Service
 class PriceBackfillCoordinator(
-    private val backfillService: MarketDataBackfillService
+    private val backfillService: MarketDataBackfillService,
+    private val cacheInvalidationProducer: CacheInvalidationProducer? = null
 ) {
     private val log = LoggerFactory.getLogger(PriceBackfillCoordinator::class.java)
     private val inFlight = ConcurrentHashMap.newKeySet<String>()
@@ -46,6 +48,10 @@ class PriceBackfillCoordinator(
         try {
             log.info("Async backfill starting for asset={} fromDate={}", assetId, fromDate)
             backfillService.backFill(assetId, fromDate)
+            // Notify downstream caches (e.g. svc-position performance snapshots)
+            // that this asset's history changed so they recompute on the next
+            // request. Producer is optional in tests / cache-disabled profiles.
+            cacheInvalidationProducer?.sendPriceHistoryEvent(assetId, fromDate)
             log.info("Async backfill completed for asset={}", assetId)
         } catch (
             @Suppress("TooGenericExceptionCaught")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillExecutorConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillExecutorConfig.kt
@@ -1,0 +1,30 @@
+package com.beancounter.marketdata.providers
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+/**
+ * Dedicated executor for price-history backfills so a slow provider call
+ * doesn't tie up shared Spring threads.
+ */
+@Configuration
+class PriceBackfillExecutorConfig {
+    @Bean("priceBackfillExecutor")
+    fun priceBackfillExecutor(): TaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = CORE_POOL_SIZE
+        executor.maxPoolSize = MAX_POOL_SIZE
+        executor.queueCapacity = QUEUE_CAPACITY
+        executor.setThreadNamePrefix("price-backfill-")
+        executor.initialize()
+        return executor
+    }
+
+    private companion object {
+        const val CORE_POOL_SIZE = 2
+        const val MAX_POOL_SIZE = 4
+        const val QUEUE_CAPACITY = 64
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillExecutorConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceBackfillExecutorConfig.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.TaskExecutor
@@ -7,24 +8,27 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 /**
  * Dedicated executor for price-history backfills so a slow provider call
- * doesn't tie up shared Spring threads.
+ * doesn't tie up shared Spring threads. Pool sizes are externally tunable
+ * (e.g. `price.backfill.executor.core-pool-size=4` in `application.yml`)
+ * so a chart-traffic spike can be absorbed without a redeploy.
  */
 @Configuration
-class PriceBackfillExecutorConfig {
+class PriceBackfillExecutorConfig(
+    @Value("\${price.backfill.executor.core-pool-size:2}")
+    private val corePoolSize: Int,
+    @Value("\${price.backfill.executor.max-pool-size:4}")
+    private val maxPoolSize: Int,
+    @Value("\${price.backfill.executor.queue-capacity:64}")
+    private val queueCapacity: Int
+) {
     @Bean("priceBackfillExecutor")
     fun priceBackfillExecutor(): TaskExecutor {
         val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = CORE_POOL_SIZE
-        executor.maxPoolSize = MAX_POOL_SIZE
-        executor.queueCapacity = QUEUE_CAPACITY
+        executor.corePoolSize = corePoolSize
+        executor.maxPoolSize = maxPoolSize
+        executor.queueCapacity = queueCapacity
         executor.setThreadNamePrefix("price-backfill-")
         executor.initialize()
         return executor
-    }
-
-    private companion object {
-        const val CORE_POOL_SIZE = 2
-        const val MAX_POOL_SIZE = 4
-        const val QUEUE_CAPACITY = 64
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 /**
  * Market Data MVC for price management operations.
@@ -330,7 +331,7 @@ class PriceController(
         val fromDate = dateUtils.getFormattedDate(from)
         val toDate = dateUtils.getFormattedDate(to)
         val initial = priceService.getPriceHistory(assetId, fromDate, toDate)
-        if (initial.prices.isNotEmpty()) return initial
+        if (!needsBackfill(initial, fromDate)) return initial
         return try {
             marketDataService.backFill(assetId)
             priceService.getPriceHistory(assetId, fromDate, toDate)
@@ -341,6 +342,28 @@ class PriceController(
             log.warn("Price history backfill failed for asset {}: {}", assetId, e.message)
             initial
         }
+    }
+
+    // Backfill is worth attempting when either we have no data at all, or when
+    // the earliest cached price is later than the requested `from` AND still
+    // sits inside the provider's ~2y backfill window with enough headroom that
+    // another fetch can plausibly extend history earlier. The 7-day buffer
+    // stops us re-hitting the provider once the existing earliest is right at
+    // the 2y floor — no new rows would come back.
+    private fun needsBackfill(
+        response: PriceHistoryResponse,
+        requestedFrom: LocalDate
+    ): Boolean {
+        if (response.prices.isEmpty()) return true
+        val earliest = response.prices.minByOrNull { it.priceDate }?.priceDate ?: return true
+        if (earliest <= requestedFrom) return false
+        val backfillFloor = LocalDate.now().minusYears(BACKFILL_WINDOW_YEARS)
+        return earliest > backfillFloor.plusDays(BACKFILL_RETRY_BUFFER_DAYS)
+    }
+
+    private companion object {
+        const val BACKFILL_WINDOW_YEARS = 2L
+        const val BACKFILL_RETRY_BUFFER_DAYS = 7L
     }
 
     @PostMapping("/bulk")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -3,6 +3,8 @@ package com.beancounter.marketdata.providers
 import com.beancounter.auth.model.AuthConstants
 import com.beancounter.common.contracts.BulkPriceRequest
 import com.beancounter.common.contracts.BulkPriceResponse
+import com.beancounter.common.contracts.EnsureHistoryRequest
+import com.beancounter.common.contracts.EnsureHistoryResponse
 import com.beancounter.common.contracts.OffMarketPriceRequest
 import com.beancounter.common.contracts.PriceHistoryResponse
 import com.beancounter.common.contracts.PriceRequest
@@ -417,6 +419,27 @@ class PriceController(
         )
         @PathVariable assetId: String
     ) = marketDataService.backFill(assetId)
+
+    @PostMapping("/ensure-history")
+    @Operation(
+        summary = "Ensure price history coverage for a set of assets",
+        description = """
+            Fire-and-forget hook used by performance / growth views to nudge
+            deep price-history backfills. For each asset, the coordinator
+            schedules an async backfill from the supplied fromDate when the
+            cached earliest is later — concurrent calls are deduplicated and
+            failed backfills back off via a 1h cooldown.
+        """
+    )
+    fun ensureHistory(
+        @RequestBody request: EnsureHistoryRequest
+    ): EnsureHistoryResponse {
+        val targetFrom = request.fromDate.coerceAtLeast(LocalDate.now().minusYears(MAX_BACKFILL_YEARS))
+        request.assetIds.forEach { assetId ->
+            priceBackfillCoordinator.scheduleBackfill(assetId, targetFrom)
+        }
+        return EnsureHistoryResponse(scheduled = request.assetIds.size)
+    }
 
     @PostMapping("/backfill/{code}")
     @Operation(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -435,10 +435,18 @@ class PriceController(
         @RequestBody request: EnsureHistoryRequest
     ): EnsureHistoryResponse {
         val targetFrom = request.fromDate.coerceAtLeast(LocalDate.now().minusYears(MAX_BACKFILL_YEARS))
-        request.assetIds.forEach { assetId ->
+        // Trim and de-duplicate so a sloppy caller (e.g. a portfolio with the same asset across
+        // currencies) doesn't blow the per-asset cooldown budget on phantom IDs, and so the
+        // returned `scheduled` count reflects what we actually queued.
+        val cleanAssetIds =
+            request.assetIds
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .distinct()
+        cleanAssetIds.forEach { assetId ->
             priceBackfillCoordinator.scheduleBackfill(assetId, targetFrom)
         }
-        return EnsureHistoryResponse(scheduled = request.assetIds.size)
+        return EnsureHistoryResponse(scheduled = cleanAssetIds.size)
     }
 
     @PostMapping("/backfill/{code}")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -345,7 +345,7 @@ class PriceController(
                 @Suppress("TooGenericExceptionCaught")
                 e: Exception
             ) {
-                log.warn("Price history backfill failed for asset {}: {}", assetId, e.message)
+                log.warn("Price history backfill failed for asset {}", assetId, e)
                 initial
             }
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -52,7 +52,8 @@ class PriceController(
     private val eventService: EventServiceFacade,
     private val priceService: PriceService,
     private val dateUtils: DateUtils,
-    private val portfolioPriceBackfillService: PortfolioPriceBackfillService
+    private val portfolioPriceBackfillService: PortfolioPriceBackfillService,
+    private val priceBackfillCoordinator: PriceBackfillCoordinator
 ) {
     private val log = LoggerFactory.getLogger(PriceController::class.java)
 
@@ -331,38 +332,39 @@ class PriceController(
         val fromDate = dateUtils.getFormattedDate(from)
         val toDate = dateUtils.getFormattedDate(to)
         val initial = priceService.getPriceHistory(assetId, fromDate, toDate)
-        if (!needsBackfill(initial, fromDate)) return initial
-        return try {
-            marketDataService.backFill(assetId)
-            priceService.getPriceHistory(assetId, fromDate, toDate)
-        } catch (
-            @Suppress("TooGenericExceptionCaught")
-            e: Exception
-        ) {
-            log.warn("Price history backfill failed for asset {}: {}", assetId, e.message)
-            initial
-        }
-    }
+        val targetFrom = fromDate.coerceAtLeast(LocalDate.now().minusYears(MAX_BACKFILL_YEARS))
 
-    // Backfill is worth attempting when either we have no data at all, or when
-    // the earliest cached price is later than the requested `from` AND still
-    // sits inside the provider's ~2y backfill window with enough headroom that
-    // another fetch can plausibly extend history earlier. The 7-day buffer
-    // stops us re-hitting the provider once the existing earliest is right at
-    // the 2y floor — no new rows would come back.
-    private fun needsBackfill(
-        response: PriceHistoryResponse,
-        requestedFrom: LocalDate
-    ): Boolean {
-        if (response.prices.isEmpty()) return true
-        val earliest = response.prices.minByOrNull { it.priceDate }?.priceDate ?: return true
-        if (earliest <= requestedFrom) return false
-        val backfillFloor = LocalDate.now().minusYears(BACKFILL_WINDOW_YEARS)
-        return earliest > backfillFloor.plusDays(BACKFILL_RETRY_BUFFER_DAYS)
+        if (initial.prices.isEmpty()) {
+            // Nothing cached at all — block briefly so the chart isn't empty.
+            return try {
+                marketDataService.backFill(assetId, targetFrom)
+                priceService.getPriceHistory(assetId, fromDate, toDate)
+            } catch (
+                @Suppress("TooGenericExceptionCaught")
+                e: Exception
+            ) {
+                log.warn("Price history backfill failed for asset {}: {}", assetId, e.message)
+                initial
+            }
+        }
+
+        // We have something to render. If the cached range falls short of what
+        // was asked for, schedule an async backfill so the next request can
+        // return the extended history without paying provider latency now.
+        val earliest = initial.prices.minByOrNull { it.priceDate }?.priceDate
+        if (earliest != null && earliest > targetFrom.plusDays(BACKFILL_RETRY_BUFFER_DAYS)) {
+            priceBackfillCoordinator.scheduleBackfill(assetId, targetFrom)
+        }
+        return initial
     }
 
     private companion object {
-        const val BACKFILL_WINDOW_YEARS = 2L
+        // Hard cap on how far back we'll ever ask a provider to go. Matches the
+        // longest range the chart UI exposes.
+        const val MAX_BACKFILL_YEARS = 10L
+
+        // Headroom buffer so we don't re-trigger backfills when the cached
+        // earliest already sits right at the provider's reachable floor.
         const val BACKFILL_RETRY_BUFFER_DAYS = 7L
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.io.IOException
+import java.time.LocalDate
 
 /**
  * Facade. AlphaAdvantage - www.alphavantage.co.
@@ -147,7 +148,10 @@ class AlphaPriceService(
         priceRequest: PriceRequest
     ) = alphaConfig.getMarketDate(market, priceRequest.date, priceRequest.currentMode)
 
-    override fun backFill(asset: Asset): PriceResponse {
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse {
         // TIME_SERIES_DAILY_ADJUSTED returns an error for index symbols (^GSPC, ^IXIC).
         // Fall back to TIME_SERIES_DAILY which works for indices and never carries
         // dividend/split data.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/cash/CashProviderService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/cash/CashProviderService.kt
@@ -59,8 +59,10 @@ class CashProviderService(
         priceRequest: PriceRequest
     ): LocalDate = priceDate!!
 
-    override fun backFill(asset: Asset): PriceResponse =
-        throw UnsupportedOperationException("Cash does not support backfill requests")
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse = throw UnsupportedOperationException("Cash does not support backfill requests")
 
     companion object {
         const val ID = "CASH"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/custom/PrivateMarketDataProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/custom/PrivateMarketDataProvider.kt
@@ -95,8 +95,10 @@ class PrivateMarketDataProvider(
         priceRequest: PriceRequest
     ): LocalDate = dateUtils.getFormattedDate(priceRequest.date)
 
-    override fun backFill(asset: Asset): PriceResponse =
-        throw UnsupportedOperationException("Private market assets do not support backfill requests")
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse = throw UnsupportedOperationException("Private market assets do not support backfill requests")
 
     override fun isApiSupported(): Boolean = false
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -84,11 +84,13 @@ class EodhdPriceService(
             priceRequest.date
         )
 
-    override fun backFill(asset: Asset): PriceResponse {
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse {
         val symbol = eodhdConfig.getPriceCode(asset)
         val dateTo = dateUtils.today()
-        val dateFrom = LocalDate.parse(dateTo).minusYears(2).toString()
-        val rows = eodhdProxy.getHistory(symbol, dateFrom, dateTo, eodhdConfig.apiKey)
+        val rows = eodhdProxy.getHistory(symbol, fromDate.toString(), dateTo, eodhdConfig.apiKey)
         return PriceResponse(eodhdAdapter.toMarketData(asset, LocalDate.parse(dateTo), rows))
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackService.kt
@@ -107,14 +107,16 @@ class MarketStackService(
             priceRequest.date
         )
 
-    override fun backFill(asset: Asset): PriceResponse {
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse {
         val symbol = marketStackConfig.getPriceCode(asset)
         val dateTo = dateUtils.today()
-        val dateFrom = LocalDate.parse(dateTo).minusYears(2).toString()
         val response =
             marketStackGateway.getHistory(
                 symbol,
-                dateFrom,
+                fromDate.toString(),
                 dateTo,
                 marketStackConfig.apiKey
             )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarPriceService.kt
@@ -135,13 +135,14 @@ class MorningstarPriceService(
         priceRequest: PriceRequest
     ): LocalDate = morningstarConfig.getMarketDate(market, priceRequest.date, priceRequest.currentMode)
 
-    override fun backFill(asset: Asset): PriceResponse {
+    override fun backFill(
+        asset: Asset,
+        fromDate: LocalDate
+    ): PriceResponse {
         val priceCode = morningstarConfig.getPriceCode(asset)
         val currencyId = asset.market.currency.code
 
-        // Fetch last year of data
-        val startDate = LocalDate.now().minusYears(1)
-        val json = morningstarProxy.getPrice(priceCode, currencyId, startDate) ?: return PriceResponse(emptyList())
+        val json = morningstarProxy.getPrice(priceCode, currencyId, fromDate) ?: return PriceResponse(emptyList())
 
         val prices = parseHistoricalResponse(json, asset)
         return PriceResponse(prices)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/cache/CacheInvalidationProducerTest.kt
@@ -1,0 +1,72 @@
+package com.beancounter.marketdata.cache
+
+import com.beancounter.common.contracts.CacheChangeType
+import com.beancounter.common.contracts.CacheInvalidationEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.cloud.stream.function.StreamBridge
+import org.springframework.messaging.MessagingException
+import java.time.LocalDate
+
+internal class CacheInvalidationProducerTest {
+    private val streamBridge: StreamBridge = mock()
+    private val producer = CacheInvalidationProducer(streamBridge)
+
+    @Test
+    fun `sendPriceHistoryEvent emits PRICE_HISTORY event with asset and date`() {
+        whenever(streamBridge.send(eq(BINDING), any<CacheInvalidationEvent>())).thenReturn(true)
+        val fromDate = LocalDate.of(2024, 5, 1)
+
+        producer.sendPriceHistoryEvent("asset-1", fromDate)
+
+        val captor = argumentCaptor<CacheInvalidationEvent>()
+        verify(streamBridge).send(eq(BINDING), captor.capture())
+        assertThat(captor.firstValue.changeType).isEqualTo(CacheChangeType.PRICE_HISTORY)
+        assertThat(captor.firstValue.assetId).isEqualTo("asset-1")
+        assertThat(captor.firstValue.fromDate).isEqualTo(fromDate)
+    }
+
+    @Test
+    fun `sendTransactionEvent emits TRANSACTION event with portfolio and date`() {
+        whenever(streamBridge.send(eq(BINDING), any<CacheInvalidationEvent>())).thenReturn(true)
+
+        producer.sendTransactionEvent("portfolio-1", LocalDate.of(2024, 1, 1))
+
+        val captor = argumentCaptor<CacheInvalidationEvent>()
+        verify(streamBridge).send(eq(BINDING), captor.capture())
+        assertThat(captor.firstValue.changeType).isEqualTo(CacheChangeType.TRANSACTION)
+        assertThat(captor.firstValue.portfolioId).isEqualTo("portfolio-1")
+    }
+
+    @Test
+    fun `streamBridge not invoked when stream disabled`() {
+        producer.streamEnabled = false
+
+        producer.sendPriceEvent(LocalDate.now())
+        producer.sendFxEvent(LocalDate.now())
+        producer.sendPriceHistoryEvent("asset-1", LocalDate.now())
+
+        verify(streamBridge, never()).send(eq(BINDING), any<CacheInvalidationEvent>())
+    }
+
+    @Test
+    fun `MessagingException swallowed so a broker outage does not propagate`() {
+        whenever(streamBridge.send(eq(BINDING), any<CacheInvalidationEvent>()))
+            .thenThrow(MessagingException("broker down"))
+
+        // Must not throw — the call site is fire-and-forget.
+        producer.sendPriceHistoryEvent("asset-1", LocalDate.now())
+        verify(streamBridge).send(eq(BINDING), any<CacheInvalidationEvent>())
+    }
+
+    private companion object {
+        const val BINDING = "cacheInvalidation-out-0"
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers
 
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -71,5 +72,30 @@ internal class PriceBackfillCoordinatorTests {
         coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
 
         verify(backfillService, never()).backFill(eq("asset-2"), any())
+    }
+
+    @Test
+    fun is_PriceHistoryEventPublishedAfterSuccessfulBackfill() {
+        val backfillService = mock<MarketDataBackfillService>()
+        val producer = mock<CacheInvalidationProducer>()
+        val coordinator = PriceBackfillCoordinator(backfillService, producer)
+
+        val fromDate = LocalDate.now().minusYears(5)
+        coordinator.scheduleBackfill("asset-1", fromDate)
+
+        verify(producer).sendPriceHistoryEvent(eq("asset-1"), eq(fromDate))
+    }
+
+    @Test
+    fun is_NoEventPublishedWhenBackfillFails() {
+        val backfillService = mock<MarketDataBackfillService>()
+        whenever(backfillService.backFill(eq("asset-1"), any()))
+            .thenThrow(RuntimeException("provider failure"))
+        val producer = mock<CacheInvalidationProducer>()
+        val coordinator = PriceBackfillCoordinator(backfillService, producer)
+
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+
+        verify(producer, never()).sendPriceHistoryEvent(any(), any())
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
@@ -1,0 +1,75 @@
+package com.beancounter.marketdata.providers
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+internal class PriceBackfillCoordinatorTests {
+    @Test
+    fun is_BackfillDelegatedToService() {
+        val backfillService = mock<MarketDataBackfillService>()
+        val coordinator = PriceBackfillCoordinator(backfillService)
+
+        val fromDate = LocalDate.now().minusYears(5)
+        coordinator.scheduleBackfill("asset-1", fromDate)
+
+        verify(backfillService).backFill(eq("asset-1"), eq(fromDate))
+    }
+
+    @Test
+    fun is_CooldownSuppressesRepeatBackfillForSameAsset() {
+        val backfillService = mock<MarketDataBackfillService>()
+        val coordinator = PriceBackfillCoordinator(backfillService)
+
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+
+        verify(backfillService, times(1)).backFill(eq("asset-1"), any())
+    }
+
+    @Test
+    fun is_DifferentAssetsBackfilledIndependently() {
+        val backfillService = mock<MarketDataBackfillService>()
+        val coordinator = PriceBackfillCoordinator(backfillService)
+
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+        coordinator.scheduleBackfill("asset-2", LocalDate.now().minusYears(5))
+
+        verify(backfillService).backFill(eq("asset-1"), any())
+        verify(backfillService).backFill(eq("asset-2"), any())
+    }
+
+    @Test
+    fun is_BackfillFailureDoesNotLeakInFlightFlag() {
+        val backfillService = mock<MarketDataBackfillService>()
+        whenever(backfillService.backFill(eq("asset-1"), any()))
+            .thenThrow(RuntimeException("provider failure"))
+        val coordinator = PriceBackfillCoordinator(backfillService)
+
+        // First call fails inside the catch — the in-flight set should be
+        // cleared in the finally block so a later (post-cooldown) call could
+        // try again. We can't tick the cooldown in a unit test, but we can at
+        // least verify the failure didn't propagate and the second call is
+        // silently suppressed by cooldown rather than crashing.
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+
+        verify(backfillService, times(1)).backFill(eq("asset-1"), any())
+    }
+
+    @Test
+    fun is_BackfillNotInvokedForBlankAsset() {
+        val backfillService = mock<MarketDataBackfillService>()
+        val coordinator = PriceBackfillCoordinator(backfillService)
+
+        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+
+        verify(backfillService, never()).backFill(eq("asset-2"), any())
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceBackfillCoordinatorTests.kt
@@ -69,9 +69,10 @@ internal class PriceBackfillCoordinatorTests {
         val backfillService = mock<MarketDataBackfillService>()
         val coordinator = PriceBackfillCoordinator(backfillService)
 
-        coordinator.scheduleBackfill("asset-1", LocalDate.now().minusYears(5))
+        coordinator.scheduleBackfill("", LocalDate.now().minusYears(5))
+        coordinator.scheduleBackfill("   ", LocalDate.now().minusYears(5))
 
-        verify(backfillService, never()).backFill(eq("asset-2"), any())
+        verify(backfillService, never()).backFill(any<String>(), any<LocalDate>())
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -574,6 +574,37 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
+        fun is_EnsureHistoryEndpointSchedulesPerAsset() {
+            val body =
+                """{"assetIds":["asset-1","asset-2","asset-3"],"fromDate":"2020-01-01"}"""
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/prices/ensure-history")
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(body)
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            org.mockito.Mockito
+                .verify(priceBackfillCoordinator)
+                .scheduleBackfill(eq("asset-1"), any())
+            org.mockito.Mockito
+                .verify(priceBackfillCoordinator)
+                .scheduleBackfill(eq("asset-2"), any())
+            org.mockito.Mockito
+                .verify(priceBackfillCoordinator)
+                .scheduleBackfill(eq("asset-3"), any())
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
         fun is_NoBackfillScheduledWhenCachedRangeCoversRequest() {
             // Earliest cached price is already before (or equal to) the requested
             // `from` plus the retry buffer — nothing to fill, no async schedule.

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -524,9 +525,12 @@ internal class PriceControllerTests
             val response = objectMapper.readValue<PriceHistoryResponse>(json)
             assertThat(response.prices).hasSize(1)
             assertThat(response.prices.first().close).isEqualByComparingTo(BigDecimal("21.00"))
+            val fromCaptor = argumentCaptor<LocalDate>()
             org.mockito.Mockito
                 .verify(marketDataService)
-                .backFill(eq(asset.id), any())
+                .backFill(eq(asset.id), fromCaptor.capture())
+            // `from` (2024-01-01) sits within the 10-year cap, so targetFrom is `from` unchanged.
+            assertThat(fromCaptor.firstValue).isEqualTo(from)
         }
 
         @Test
@@ -559,9 +563,12 @@ internal class PriceControllerTests
                         ).contentType(MediaType.APPLICATION_JSON_VALUE)
                 ).andExpect(MockMvcResultMatchers.status().isOk)
 
+            val asyncFromCaptor = argumentCaptor<LocalDate>()
             org.mockito.Mockito
                 .verify(priceBackfillCoordinator)
-                .scheduleBackfill(eq(asset.id), any())
+                .scheduleBackfill(eq(asset.id), asyncFromCaptor.capture())
+            // `from` (today-12m) is well inside the 10y cap, so targetFrom = from.
+            assertThat(asyncFromCaptor.firstValue).isEqualTo(from)
             // Synchronous backfill must NOT happen — we returned what we had.
             org.mockito.Mockito
                 .verify(marketDataService, org.mockito.Mockito.never())
@@ -588,15 +595,16 @@ internal class PriceControllerTests
                         .content(body)
                 ).andExpect(MockMvcResultMatchers.status().isOk)
 
+            val assetIdCaptor = argumentCaptor<String>()
+            val ensureFromCaptor = argumentCaptor<LocalDate>()
             org.mockito.Mockito
-                .verify(priceBackfillCoordinator)
-                .scheduleBackfill(eq("asset-1"), any())
-            org.mockito.Mockito
-                .verify(priceBackfillCoordinator)
-                .scheduleBackfill(eq("asset-2"), any())
-            org.mockito.Mockito
-                .verify(priceBackfillCoordinator)
-                .scheduleBackfill(eq("asset-3"), any())
+                .verify(priceBackfillCoordinator, org.mockito.Mockito.times(3))
+                .scheduleBackfill(assetIdCaptor.capture(), ensureFromCaptor.capture())
+            // Body fromDate is 2020-01-01, well inside the 10y cap, so each asset
+            // is scheduled against the same forwarded targetFrom.
+            val expectedFrom = LocalDate.of(2020, 1, 1)
+            assertThat(assetIdCaptor.allValues).containsExactlyInAnyOrder("asset-1", "asset-2", "asset-3")
+            assertThat(ensureFromCaptor.allValues).containsExactly(expectedFrom, expectedFrom, expectedFrom)
         }
 
         @Test
@@ -636,6 +644,40 @@ internal class PriceControllerTests
             org.mockito.Mockito
                 .verify(marketDataService, org.mockito.Mockito.never())
                 .backFill(any<String>(), any())
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
+        fun is_PriceHistoryReturnsEmptyWhenBackfillFails() {
+            // Cache miss path: backFill throws, controller must catch and return the empty initial.
+            val from = LocalDate.of(2024, 1, 1)
+            val to = LocalDate.of(2024, 1, 3)
+            `when`(assetFinder.find(asset.id)).thenReturn(asset)
+            `when`(marketDataRepo.findPriceHistory(asset.id, from, to)).thenReturn(emptyList())
+            org.mockito.Mockito
+                .doThrow(RuntimeException("provider unavailable"))
+                .`when`(marketDataService)
+                .backFill(eq(asset.id), any())
+
+            val json =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .get("/prices/{assetId}/history", asset.id)
+                            .param("from", from.toString())
+                            .param("to", to.toString())
+                            .with(
+                                SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                            ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString
+            val response = objectMapper.readValue<PriceHistoryResponse>(json)
+            assertThat(response.prices).isEmpty()
         }
 
         @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -613,6 +613,40 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
+        fun is_EnsureHistoryTrimsAndDedupesAssetIds() {
+            // Caller may ship duplicates, padded, or blank entries (e.g. portfolio with same
+            // asset across currencies). The endpoint must only schedule unique non-blank IDs and
+            // report the cleaned count in `scheduled`.
+            val body =
+                """{"assetIds":["asset-1","  asset-1","asset-2"," ",""],"fromDate":"2020-01-01"}"""
+
+            val json =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .post("/prices/ensure-history")
+                            .with(
+                                SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                            ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .content(body)
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString
+
+            assertThat(json).contains("\"scheduled\":2")
+            val cleanCaptor = argumentCaptor<String>()
+            org.mockito.Mockito
+                .verify(priceBackfillCoordinator, org.mockito.Mockito.times(2))
+                .scheduleBackfill(cleanCaptor.capture(), any())
+            assertThat(cleanCaptor.allValues).containsExactlyInAnyOrder("asset-1", "asset-2")
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
         fun is_NoBackfillScheduledWhenCachedRangeCoversRequest() {
             // Earliest cached price is already before (or equal to) the requested
             // `from` plus the retry buffer — nothing to fill, no async schedule.

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -530,6 +530,81 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
+        fun is_PriceHistoryBackfilledWhenEarliestLaterThanFrom() {
+            // The DB only has prices from after a recent purchase, but the user
+            // requests a wider window. Earliest available is well inside the
+            // provider's 2y backfill window, so we should backfill to fill the
+            // gap before the purchase.
+            val today = LocalDate.now()
+            val from = today.minusMonths(12)
+            val to = today
+            val purchaseDate = today.minusMonths(8)
+            val initial = listOf(MarketData(asset, close = BigDecimal("10.00"), priceDate = purchaseDate))
+            val backfilled =
+                listOf(
+                    MarketData(asset, close = BigDecimal("5.00"), priceDate = from),
+                    MarketData(asset, close = BigDecimal("10.00"), priceDate = purchaseDate)
+                )
+            `when`(assetFinder.find(asset.id)).thenReturn(asset)
+            `when`(marketDataRepo.findPriceHistory(asset.id, from, to))
+                .thenReturn(initial)
+                .thenReturn(backfilled)
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/prices/{assetId}/history", asset.id)
+                        .param("from", from.toString())
+                        .param("to", to.toString())
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            org.mockito.Mockito
+                .verify(marketDataService)
+                .backFill(asset.id)
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
+        fun is_PriceHistoryNotBackfilledWhenEarliestBeyondProviderWindow() {
+            // Existing earliest already sits at the provider's 2y backfill floor.
+            // Another backfill cannot reach further back, so don't burn quota.
+            val today = LocalDate.now()
+            val from = today.minusYears(5)
+            val to = today
+            val earliestExisting = today.minusYears(2).minusDays(30)
+            val history = listOf(MarketData(asset, close = BigDecimal("10.00"), priceDate = earliestExisting))
+            `when`(assetFinder.find(asset.id)).thenReturn(asset)
+            `when`(marketDataRepo.findPriceHistory(asset.id, from, to)).thenReturn(history)
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/prices/{assetId}/history", asset.id)
+                        .param("from", from.toString())
+                        .param("to", to.toString())
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            org.mockito.Mockito
+                .verify(marketDataService, org.mockito.Mockito.never())
+                .backFill(asset.id)
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
         fun is_ValuationRequestHydratingAssets() {
             val json =
                 mockMvc

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.security.oauth2.jwt.JwtDecoder
@@ -74,6 +76,9 @@ internal class PriceControllerTests
 
         @MockitoSpyBean
         private lateinit var marketDataService: MarketDataService
+
+        @MockitoBean
+        private lateinit var priceBackfillCoordinator: PriceBackfillCoordinator
 
         @BeforeEach
         fun setUp() {
@@ -521,7 +526,7 @@ internal class PriceControllerTests
             assertThat(response.prices.first().close).isEqualByComparingTo(BigDecimal("21.00"))
             org.mockito.Mockito
                 .verify(marketDataService)
-                .backFill(asset.id)
+                .backFill(eq(asset.id), any())
         }
 
         @Test
@@ -530,25 +535,18 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
-        fun is_PriceHistoryBackfilledWhenEarliestLaterThanFrom() {
+        fun is_AsyncBackfillScheduledWhenEarliestLaterThanFrom() {
             // The DB only has prices from after a recent purchase, but the user
-            // requests a wider window. Earliest available is well inside the
-            // provider's 2y backfill window, so we should backfill to fill the
-            // gap before the purchase.
+            // requests a wider window. We return what we have immediately and
+            // schedule an async backfill so the next request gets the extended
+            // history without paying provider latency now.
             val today = LocalDate.now()
             val from = today.minusMonths(12)
             val to = today
             val purchaseDate = today.minusMonths(8)
             val initial = listOf(MarketData(asset, close = BigDecimal("10.00"), priceDate = purchaseDate))
-            val backfilled =
-                listOf(
-                    MarketData(asset, close = BigDecimal("5.00"), priceDate = from),
-                    MarketData(asset, close = BigDecimal("10.00"), priceDate = purchaseDate)
-                )
             `when`(assetFinder.find(asset.id)).thenReturn(asset)
-            `when`(marketDataRepo.findPriceHistory(asset.id, from, to))
-                .thenReturn(initial)
-                .thenReturn(backfilled)
+            `when`(marketDataRepo.findPriceHistory(asset.id, from, to)).thenReturn(initial)
 
             mockMvc
                 .perform(
@@ -562,8 +560,12 @@ internal class PriceControllerTests
                 ).andExpect(MockMvcResultMatchers.status().isOk)
 
             org.mockito.Mockito
-                .verify(marketDataService)
-                .backFill(asset.id)
+                .verify(priceBackfillCoordinator)
+                .scheduleBackfill(eq(asset.id), any())
+            // Synchronous backfill must NOT happen — we returned what we had.
+            org.mockito.Mockito
+                .verify(marketDataService, org.mockito.Mockito.never())
+                .backFill(eq(asset.id), any())
         }
 
         @Test
@@ -572,14 +574,17 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
-        fun is_PriceHistoryNotBackfilledWhenEarliestBeyondProviderWindow() {
-            // Existing earliest already sits at the provider's 2y backfill floor.
-            // Another backfill cannot reach further back, so don't burn quota.
+        fun is_NoBackfillScheduledWhenCachedRangeCoversRequest() {
+            // Earliest cached price is already before (or equal to) the requested
+            // `from` plus the retry buffer — nothing to fill, no async schedule.
             val today = LocalDate.now()
-            val from = today.minusYears(5)
+            val from = today.minusMonths(12)
             val to = today
-            val earliestExisting = today.minusYears(2).minusDays(30)
-            val history = listOf(MarketData(asset, close = BigDecimal("10.00"), priceDate = earliestExisting))
+            val history =
+                listOf(
+                    MarketData(asset, close = BigDecimal("9.00"), priceDate = from.minusDays(30)),
+                    MarketData(asset, close = BigDecimal("10.00"), priceDate = from.plusMonths(2))
+                )
             `when`(assetFinder.find(asset.id)).thenReturn(asset)
             `when`(marketDataRepo.findPriceHistory(asset.id, from, to)).thenReturn(history)
 
@@ -595,8 +600,11 @@ internal class PriceControllerTests
                 ).andExpect(MockMvcResultMatchers.status().isOk)
 
             org.mockito.Mockito
+                .verify(priceBackfillCoordinator, org.mockito.Mockito.never())
+                .scheduleBackfill(any(), any())
+            org.mockito.Mockito
                 .verify(marketDataService, org.mockito.Mockito.never())
-                .backFill(asset.id)
+                .backFill(any<String>(), any())
         }
 
         @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceControllerTests.kt
@@ -539,6 +539,42 @@ internal class PriceControllerTests
             username = "test-user",
             roles = [AuthConstants.USER]
         )
+        fun is_PriceHistoryBackfillFromDateCappedAtTenYears() {
+            // Caller asks for 15y of history. Controller must coerce the backfill
+            // start date to today-10y so a sloppy/malicious caller can't drive
+            // arbitrarily-deep provider calls.
+            val today = LocalDate.now()
+            val from = today.minusYears(15)
+            val to = today
+            `when`(assetFinder.find(asset.id)).thenReturn(asset)
+            `when`(marketDataRepo.findPriceHistory(asset.id, from, to))
+                .thenReturn(emptyList())
+                .thenReturn(emptyList())
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/prices/{assetId}/history", asset.id)
+                        .param("from", from.toString())
+                        .param("to", to.toString())
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            val cappedCaptor = argumentCaptor<LocalDate>()
+            org.mockito.Mockito
+                .verify(marketDataService)
+                .backFill(eq(asset.id), cappedCaptor.capture())
+            assertThat(cappedCaptor.firstValue).isEqualTo(today.minusYears(10))
+        }
+
+        @Test
+        @Tag("wiremock")
+        @WithMockUser(
+            username = "test-user",
+            roles = [AuthConstants.USER]
+        )
         fun is_AsyncBackfillScheduledWhenEarliestLaterThanFrom() {
             // The DB only has prices from after a recent purchase, but the user
             // requests a wider window. We return what we have immediately and

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
@@ -27,6 +27,14 @@ class CacheInvalidationConsumer(
                     CacheChangeType.PRICE, CacheChangeType.FX -> {
                         cacheService.invalidateOnDate(event.fromDate)
                     }
+                    // Deep price-history backfill — any portfolio holding the
+                    // asset may need to recompute from fromDate onwards. We
+                    // don't try to filter by portfolio here (svc-position
+                    // doesn't have the asset→portfolio map); a broad sweep
+                    // across all portfolios is correct and rare.
+                    CacheChangeType.PRICE_HISTORY -> {
+                        cacheService.invalidateFromDate(event.fromDate)
+                    }
                 }
             } catch (e: DataAccessException) {
                 log.error("Failed to process cache invalidation event: {}", e.message)

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
@@ -37,7 +37,7 @@ class CacheInvalidationConsumer(
                     }
                 }
             } catch (e: DataAccessException) {
-                log.error("Failed to process cache invalidation event: {}", e.message)
+                log.error("Failed to process cache invalidation event", e)
             }
         }
 

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/JpaPerformanceCacheService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/JpaPerformanceCacheService.kt
@@ -83,6 +83,12 @@ class JpaPerformanceCacheService(
     }
 
     @Transactional
+    override fun invalidateFromDate(fromDate: LocalDate) {
+        repository.deleteByValuationDateGreaterThanEqual(fromDate)
+        log.trace("Cache invalidate: from={}", fromDate)
+    }
+
+    @Transactional
     override fun invalidatePortfolio(portfolioId: String) {
         repository.deleteByPortfolioId(portfolioId)
         log.trace("Cache invalidate: portfolio={}", portfolioId)

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/NoOpPerformanceCacheService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/NoOpPerformanceCacheService.kt
@@ -32,6 +32,10 @@ class NoOpPerformanceCacheService : PerformanceCacheService {
         // No-op
     }
 
+    override fun invalidateFromDate(fromDate: LocalDate) {
+        // No-op
+    }
+
     override fun invalidatePortfolio(portfolioId: String) {
         // No-op
     }

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceCacheService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceCacheService.kt
@@ -31,6 +31,8 @@ interface PerformanceCacheService {
 
     fun invalidateOnDate(date: LocalDate)
 
+    fun invalidateFromDate(fromDate: LocalDate)
+
     fun invalidatePortfolio(portfolioId: String)
 
     fun isAvailable(): Boolean

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotRepository.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotRepository.kt
@@ -33,5 +33,9 @@ interface PerformanceSnapshotRepository : JpaRepository<PerformanceSnapshotEntit
     fun deleteByValuationDate(date: LocalDate)
 
     @Modifying
+    @Query("DELETE FROM PerformanceSnapshotEntity e WHERE e.valuationDate >= :fromDate")
+    fun deleteByValuationDateGreaterThanEqual(fromDate: LocalDate)
+
+    @Modifying
     fun deleteByPortfolioId(portfolioId: String)
 }

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceAsyncConfig.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceAsyncConfig.kt
@@ -1,0 +1,39 @@
+package com.beancounter.position.service
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+/**
+ * Dedicated executor for the fire-and-forget `ensureHistory` nudge in
+ * [PerformanceService]. Keeps the calculate() request path off the network
+ * round-trip — svc-data only schedules the backfill, but the HTTP call
+ * itself can still add tens of ms and should not block the response.
+ */
+@Configuration
+class PerformanceAsyncConfig {
+    @Bean("performanceNudgeExecutor")
+    fun performanceNudgeExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = CORE_POOL_SIZE
+        executor.maxPoolSize = MAX_POOL_SIZE
+        executor.queueCapacity = QUEUE_CAPACITY
+        executor.setThreadNamePrefix("perf-nudge-")
+        // Drop the oldest queued task if the queue saturates — the nudge is
+        // best-effort and svc-data will eventually pick up the new range on
+        // a later request anyway.
+        executor.setRejectedExecutionHandler(
+            java.util.concurrent.ThreadPoolExecutor
+                .DiscardOldestPolicy()
+        )
+        executor.initialize()
+        return executor
+    }
+
+    private companion object {
+        const val CORE_POOL_SIZE = 1
+        const val MAX_POOL_SIZE = 2
+        const val QUEUE_CAPACITY = 32
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -10,6 +10,7 @@ import com.beancounter.common.contracts.AggregatedPerformanceResponse
 import com.beancounter.common.contracts.BulkFxRequest
 import com.beancounter.common.contracts.BulkFxResponse
 import com.beancounter.common.contracts.BulkPriceRequest
+import com.beancounter.common.contracts.EnsureHistoryRequest
 import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.PerformanceData
 import com.beancounter.common.contracts.PerformanceDataPoint
@@ -108,6 +109,12 @@ class PerformanceService(
         val allAssets = collectAssets(transactions)
         val allPairs = collectFxPairs(transactions, portfolio)
 
+        // Fire-and-forget — nudge svc-data to backfill deep history for the
+        // assets we're about to value. This lets long-window growth / wealth
+        // charts converge to a complete series across requests without
+        // blocking the current calculation on a multi-year provider call.
+        ensureAssetHistory(allAssets, startDate, token)
+
         // Pre-fetch all prices and FX rates in exactly 2 bulk calls
         val priceCache = prefetchPrices(allAssets, valuationDates, token)
         val fxCache = prefetchFxRates(allPairs, startDate, endDate, token)
@@ -155,6 +162,34 @@ class PerformanceService(
                 assets = assets
             )
         return priceService.getBulkPrices(request, token).data
+    }
+
+    private fun ensureAssetHistory(
+        assets: List<PriceAsset>,
+        startDate: LocalDate,
+        token: String
+    ) {
+        if (assets.isEmpty()) return
+        val assetIds =
+            assets
+                .mapNotNull {
+                    it.resolvedAsset?.id ?: it.assetId.takeIf { id ->
+                        id.isNotEmpty()
+                    }
+                }.distinct()
+        if (assetIds.isEmpty()) return
+        try {
+            priceService.ensureHistory(
+                EnsureHistoryRequest(assetIds = assetIds, fromDate = startDate),
+                token
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            // Non-fatal — performance calc continues with whatever is in the DB.
+            log.warn("ensureHistory call failed (continuing): {}", e.message)
+        }
     }
 
     private fun prefetchFxRates(

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -33,11 +33,13 @@ import com.beancounter.position.cache.PerformanceCacheService
 import com.beancounter.position.irr.TwrCalculator
 import com.beancounter.position.irr.ValuationSnapshot
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.dao.DataAccessException
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.util.concurrent.Executor
 
 /**
  * Calculates portfolio performance using Time-Weighted Return (TWR).
@@ -62,6 +64,8 @@ class PerformanceService(
     private val dateUtils: DateUtils,
     private val tokenService: TokenService,
     private val cacheService: PerformanceCacheService,
+    @Qualifier("performanceNudgeExecutor")
+    private val nudgeExecutor: Executor = Executor(Runnable::run),
     private val cashUtils: CashUtils = CashUtils()
 ) {
     fun calculate(
@@ -178,17 +182,23 @@ class PerformanceService(
                     }
                 }.distinct()
         if (assetIds.isEmpty()) return
-        try {
-            priceService.ensureHistory(
-                EnsureHistoryRequest(assetIds = assetIds, fromDate = startDate),
-                token
-            )
-        } catch (
-            @Suppress("TooGenericExceptionCaught")
-            e: Exception
-        ) {
-            // Non-fatal — performance calc continues with whatever is in the DB.
-            log.warn("ensureHistory call failed (continuing): {}", e.message)
+        // Truly fire-and-forget: dispatch the HTTP call onto a dedicated executor so
+        // the request thread doesn't wait on the round-trip to svc-data. svc-data
+        // returns immediately (it only schedules the backfill), but even the bare
+        // RPC adds latency we don't want on every calculate().
+        nudgeExecutor.execute {
+            try {
+                priceService.ensureHistory(
+                    EnsureHistoryRequest(assetIds = assetIds, fromDate = startDate),
+                    token
+                )
+            } catch (
+                @Suppress("TooGenericExceptionCaught")
+                e: Exception
+            ) {
+                // Non-fatal — performance calc continues with whatever is in the DB.
+                log.warn("ensureHistory call failed (continuing)", e)
+            }
         }
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/CacheInvalidationConsumerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/CacheInvalidationConsumerTest.kt
@@ -59,4 +59,20 @@ class CacheInvalidationConsumerTest {
 
         verify(cacheService).invalidateOnDate(LocalDate.of(2024, 6, 15))
     }
+
+    @Test
+    fun `PRICE_HISTORY event invalidates snapshots from date`() {
+        val consumer = CacheInvalidationConsumer(cacheService)
+        val handler = consumer.performanceCacheInvalidation()
+        val event =
+            CacheInvalidationEvent(
+                changeType = CacheChangeType.PRICE_HISTORY,
+                assetId = "asset-1",
+                fromDate = LocalDate.of(2020, 1, 1)
+            )
+
+        handler.accept(event)
+
+        verify(cacheService).invalidateFromDate(LocalDate.of(2020, 1, 1))
+    }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/JpaPerformanceCacheServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/JpaPerformanceCacheServiceTest.kt
@@ -110,6 +110,30 @@ class JpaPerformanceCacheServiceTest {
     }
 
     @Test
+    fun `invalidateFromDate deletes all rows on-or-after the date across portfolios`() {
+        cacheService.storeSnapshots(
+            "pf-1",
+            listOf(
+                CachedSnapshot(date1, BigDecimal("100"), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO),
+                CachedSnapshot(date2, BigDecimal("110"), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO)
+            )
+        )
+        cacheService.storeSnapshots(
+            "pf-2",
+            listOf(
+                CachedSnapshot(date1, BigDecimal("200"), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO),
+                CachedSnapshot(date2, BigDecimal("220"), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO)
+            )
+        )
+
+        // Wipe everything from date2 onward in both portfolios; date1 must survive.
+        cacheService.invalidateFromDate(date2)
+
+        assertThat(cacheService.findSnapshots("pf-1", listOf(date1, date2))).hasSize(1)
+        assertThat(cacheService.findSnapshots("pf-2", listOf(date1, date2))).hasSize(1)
+    }
+
+    @Test
     fun `invalidatePortfolio deletes all dates for that portfolio`() {
         cacheService.storeSnapshots(
             portfolioId,

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/JpaPerformanceCacheServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/JpaPerformanceCacheServiceTest.kt
@@ -129,8 +129,12 @@ class JpaPerformanceCacheServiceTest {
         // Wipe everything from date2 onward in both portfolios; date1 must survive.
         cacheService.invalidateFromDate(date2)
 
-        assertThat(cacheService.findSnapshots("pf-1", listOf(date1, date2))).hasSize(1)
-        assertThat(cacheService.findSnapshots("pf-2", listOf(date1, date2))).hasSize(1)
+        val remainingPf1 = cacheService.findSnapshots("pf-1", listOf(date1, date2))
+        val remainingPf2 = cacheService.findSnapshots("pf-2", listOf(date1, date2))
+        assertThat(remainingPf1).hasSize(1)
+        assertThat(remainingPf1[0].valuationDate).isEqualTo(date1)
+        assertThat(remainingPf2).hasSize(1)
+        assertThat(remainingPf2[0].valuationDate).isEqualTo(date1)
     }
 
     @Test

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
@@ -6,6 +6,8 @@ import com.beancounter.client.services.PriceService
 import com.beancounter.client.services.TrnService
 import com.beancounter.common.contracts.BulkFxResponse
 import com.beancounter.common.contracts.BulkPriceResponse
+import com.beancounter.common.contracts.EnsureHistoryRequest
+import com.beancounter.common.contracts.EnsureHistoryResponse
 import com.beancounter.common.contracts.TrnResponse
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Currency
@@ -30,7 +32,10 @@ import org.mockito.Mock
 import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -384,5 +389,86 @@ class PerformanceServiceTest {
                 .growthOf1000
                 .toDouble()
         ).isCloseTo(1000.0, Offset.offset(0.01))
+    }
+
+    @Test
+    fun `ensureHistory is nudged with the collected asset ids on calculate`() {
+        val buyTrn =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = testAsset,
+                tradeDate = LocalDate.now().minusMonths(6),
+                quantity = BigDecimal("100"),
+                price = BigDecimal("150"),
+                tradeAmount = BigDecimal("15000"),
+                cashAmount = BigDecimal("-15000")
+            )
+
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse(listOf(buyTrn)))
+        whenever(accumulator.accumulate(any(), any()))
+            .thenAnswer { invocation ->
+                val positions = invocation.getArgument<com.beancounter.common.model.Positions>(1)
+                positions.getOrCreate(testAsset)
+            }
+        lenient()
+            .`when`(priceService.getBulkPrices(any(), any()))
+            .thenReturn(BulkPriceResponse(emptyMap()))
+        lenient()
+            .`when`(fxRateService.getBulkRates(any(), any()))
+            .thenReturn(BulkFxResponse(emptyMap()))
+        whenever(priceService.ensureHistory(any(), any()))
+            .thenReturn(EnsureHistoryResponse(scheduled = 1))
+
+        performanceService.calculate(portfolio, 12)
+
+        val captor = argumentCaptor<EnsureHistoryRequest>()
+        verify(priceService).ensureHistory(captor.capture(), any())
+        assertThat(captor.firstValue.assetIds).containsExactly(testAsset.id)
+        assertThat(captor.firstValue.fromDate).isNotNull()
+    }
+
+    @Test
+    fun `ensureHistory failure does not break calculate`() {
+        val buyTrn =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = testAsset,
+                tradeDate = LocalDate.now().minusMonths(6),
+                quantity = BigDecimal("100"),
+                price = BigDecimal("150"),
+                tradeAmount = BigDecimal("15000"),
+                cashAmount = BigDecimal("-15000")
+            )
+
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse(listOf(buyTrn)))
+        whenever(accumulator.accumulate(any(), any()))
+            .thenAnswer { invocation ->
+                val positions = invocation.getArgument<com.beancounter.common.model.Positions>(1)
+                positions.getOrCreate(testAsset)
+            }
+        lenient()
+            .`when`(priceService.getBulkPrices(any(), any()))
+            .thenReturn(BulkPriceResponse(emptyMap()))
+        lenient()
+            .`when`(fxRateService.getBulkRates(any(), any()))
+            .thenReturn(BulkFxResponse(emptyMap()))
+        whenever(priceService.ensureHistory(any(), any()))
+            .thenThrow(RuntimeException("svc-data unavailable"))
+
+        // Calculate must still succeed (fire-and-forget contract).
+        val result = performanceService.calculate(portfolio, 12)
+        assertThat(result.data.series).isNotEmpty
+    }
+
+    @Test
+    fun `ensureHistory skipped when no transactions`() {
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse())
+
+        performanceService.calculate(portfolio, 12)
+
+        verify(priceService, never()).ensureHistory(any(), any())
     }
 }


### PR DESCRIPTION
## Summary
- The chart could never show prices earlier than the date a position was opened, because the price-history endpoint only backfilled when the DB returned **zero** prices in the requested range. For any asset BC has been tracking since purchase, backfill never triggered.
- Now we also backfill when the earliest cached price is later than the requested `from` **and** the earliest still sits inside the provider's 2y backfill window (with a 7-day headroom buffer to stop repeated provider calls once history reaches the floor).
- Backfills stay idempotent via `PriceService.handle` (skips existing dates), so the cost is one extra provider call only when there's actually a gap to fill.

## Test plan
- [x] `./gradlew testSmart` — green
- [x] `./gradlew formatKotlin && ./gradlew lintKotlin` — clean
- [x] Two new regression tests (earliest-later-than-from triggers backfill; earliest at 2y floor does NOT)
- [x] semgrep clean
- [ ] After deploy: open DBS/PLD price chart 12m view on kauri and confirm price line now extends before the purchase marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async background price-history backfills with a dedicated executor/coordinator, a POST /prices/ensure-history endpoint, and a client method to request backfills for multiple assets.
  * Cache-invalidation events emitted after backfills so caches can invalidate snapshots from a given date.
  * Performance calculations now nudge history backfills non-blocking before pricing.

* **Bug Fixes**
  * Smarter backfill windows with caps and retry buffers, trimming/deduping asset lists, and suppression of duplicate/concurrent attempts.

* **Tests**
  * Added tests for scheduling, cooldown/in-flight suppression, cache events, trimming/deduping, and cached-range behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->