### PR TITLE
fix: TWR cache hit returns single anchor when window has no snapshots

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -79,7 +79,8 @@ class PerformanceService(
         val cached = tryLoadFromCache(portfolio.id)
         if (cached != null) {
             val earliestCached = cached.minOf { it.valuationDate }
-            if (!earliestCached.isAfter(startDate)) {
+            val hasInWindow = cached.any { !it.valuationDate.isBefore(startDate) }
+            if (!earliestCached.isAfter(startDate) && hasInWindow) {
                 val anchored = anchorToStartDate(cached, startDate)
                 log.debug(
                     "Cache HIT: portfolio={}, snapshots={} (filtered from {})",
@@ -89,10 +90,15 @@ class PerformanceService(
                 )
                 return buildResponseFromCache(portfolio, anchored)
             }
+            // `earliestCached <= startDate` alone is not enough: if every cached
+            // snapshot predates startDate, `anchorToStartDate` returns just the
+            // synthesised anchor (single-point series), producing 0% TWR and 0
+            // gain. Require at least one snapshot in `[startDate, endDate]`.
             log.debug(
-                "Cache PARTIAL: portfolio={}, cached from {} but requested from {}, recomputing",
+                "Cache PARTIAL: portfolio={}, earliest={}, latest={}, requested from {}, recomputing",
                 portfolio.code,
                 earliestCached,
+                cached.maxOf { it.valuationDate },
                 startDate
             )
         }

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
@@ -496,6 +496,69 @@ class PerformanceServiceCacheTest {
     }
 
     @Test
+    fun `cache hit with no in-window snapshots triggers recomputation`() {
+        // Regression: kauri 2026-05-17. Cache held only snapshots from BEFORE
+        // the requested window. Outer guard saw `earliestCached <= startDate`
+        // and HIT the cache; `anchorToStartDate` then returned a single
+        // synthesised anchor (onOrAfter was empty). Result: 1-point series,
+        // TWR = 0%, investmentGain = 0, even though portfolios had real
+        // activity in the window. Cache must MISS when nothing in
+        // `[startDate, endDate]`, regardless of how much pre-window history
+        // exists.
+        whenever(cacheService.isAvailable()).thenReturn(true)
+
+        val now = LocalDate.now()
+        val cachedSnapshots =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(24),
+                    marketValue = BigDecimal("9000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("9000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(18),
+                    marketValue = BigDecimal("10000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("9000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+        whenever(cacheService.findAllSnapshots(eq(portfolio.id)))
+            .thenReturn(cachedSnapshots)
+
+        val buyTrn =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = testAsset,
+                tradeDate = now.minusMonths(20),
+                quantity = BigDecimal("100"),
+                tradeAmount = BigDecimal("15000")
+            )
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse(listOf(buyTrn)))
+        whenever(accumulator.accumulate(any(), any()))
+            .thenAnswer { invocation ->
+                val positions = invocation.getArgument<com.beancounter.common.model.Positions>(1)
+                positions.getOrCreate(testAsset)
+            }
+        lenient()
+            .`when`(priceService.getBulkPrices(any(), any()))
+            .thenReturn(BulkPriceResponse(emptyMap()))
+        lenient()
+            .`when`(fxRateService.getBulkRates(any(), any()))
+            .thenReturn(BulkFxResponse(emptyMap()))
+
+        // Request 12 months — startDate = now - 12M. All cached snapshots are
+        // older than that. Must recompute, not return a single-anchor series.
+        performanceService.calculate(portfolio, 12)
+
+        verify(trnService).query(any<Portfolio>(), any())
+        verify(priceService).getBulkPrices(any(), any())
+    }
+
+    @Test
     fun `cache miss stores results`() {
         val buyDate = LocalDate.now().minusMonths(6)
         val buyTrn =


### PR DESCRIPTION
## Summary

- Wealth performance chart on kauri showed 0% TWR / 0 gain even though portfolios had real activity in the window.
- Root cause: `PerformanceService.calculate()` cache-hit guard only required `earliestCached ≤ startDate`. When every cached snapshot predated the requested window, `anchorToStartDate` synthesised a single anchor at `startDate` from the latest pre-window snapshot and returned no follow-on points. The 1-point series produced `growthOf1000 = 1000`, `cumulativeReturn = 0`, and `investmentGain = 0` after baselining.
- Fix: also require `cached.any { !it.valuationDate.isBefore(startDate) }` before taking the HIT branch. When the cache covers `startDate` but contains no in-window snapshots, fall through to full recomputation.

Observed on kauri 2026-05-17 across all 9 portfolios. `DELETE /{code}/performance/cache` followed by recompute restored the full series (e.g. USV: 1 pt → 22 pts, TWR 0% → +16.96%).

## Test plan

- [x] New regression test `cache hit with no in-window snapshots triggers recomputation` — RED → GREEN with the guard change.
- [x] All existing `PerformanceServiceCacheTest` cases still pass (cache hit, partial coverage, anchor synthesis, miss).
- [x] `./gradlew :svc-position:test` — green.
- [x] `./gradlew testSmart` — green.
- [x] `./gradlew :svc-position:formatKotlin :svc-position:lintKotlin` — clean.
- [ ] After merge / deploy: confirm wealth chart populates on kauri without manual cache reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance calculation accuracy by refining cache validation to require cached snapshots within the requested date window.
  * Enhanced debugging logs to display earliest and latest cached valuation dates alongside the requested time range.

* **Tests**
  * Added regression test to verify correct recalculation when cached data falls outside the requested date window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->