### PR TITLE
perf: enable Spring response gzip on bc-data, bc-position, bc-event

### DIFF
--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -3,6 +3,10 @@ server:
   servlet:
     context-path: '/api'
   shutdown: graceful
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain,text/css,application/javascript
+    min-response-size: 1024
 schedule:
   enabled: false
 

--- a/svc-event/src/main/resources/application.yml
+++ b/svc-event/src/main/resources/application.yml
@@ -3,6 +3,10 @@ server:
   servlet:
     context-path: '/api'
   shutdown: graceful
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain,text/css,application/javascript
+    min-response-size: 1024
 
 sentry:
   enabled: false

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -2,6 +2,10 @@ server:
   port: 9500
   servlet:
     context-path: '/api'
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain,text/css,application/javascript
+    min-response-size: 1024
 
 # Portfolio valuation scheduling (disabled by default for local dev)
 # In production (kauri), runs every 10 mins from 5-7 AM SGT after US market close


### PR DESCRIPTION
## Summary

- Adds `server.compression.enabled=true` (standard JSON/XML/text mime list, 1 KB min threshold) to the three Spring services.
- Embedded Tomcat now gzip-encodes JSON responses when the client sends `Accept-Encoding: gzip`.
- No DTO change, no caller migration. Win is purely on the wire.

## Why

Baseline measurement against portfolio `MOK-7K9AQSynO6bJVo4NEg` (`USV`) on 2026-05-17:

| Endpoint | Bytes (uncompressed) |
|---|---:|
| `/api/USV` (holdings) | 182,597 |
| `/api/aggregated` (holdings) | 310,753 |
| `/api/trns/portfolio/MOK-…` | 2,548,030 |

Sending `Accept-Encoding: gzip` returned identical byte counts — compression was off. Expected reduction ~70% across every JSON response.

Side-finding from the same measurement: holdings already de-dupes assets (`Map<String,Position>` keyed by `assetId` → dup factor 1.0). Trns duplicates the asset block ~13× and the portfolio ~970× across 970 records — DTO normalization work is going there next, but is out of scope for this PR.

## Test plan

- [x] \`./gradlew testSmart && ./gradlew formatKotlin && ./gradlew lintKotlin\` green locally.
- [ ] After bc-deploy rolls the new images, re-run baseline curls with \`Accept-Encoding: gzip\` and confirm \`Content-Encoding: gzip\` plus reduced \`size_download\`.
- [ ] Verify bc-view still parses responses (HTTP client decompresses transparently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled HTTP response compression across services, configured for JSON, XML, HTML, text, CSS, and JavaScript content types with a 1 KB minimum response size threshold.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->