### PR TITLE
fix(svc-position): use constant default for byId asAt param

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
@@ -48,7 +48,6 @@ import org.springframework.web.bind.annotation.RestController
 )
 class PositionController(
     private val portfolioServiceClient: PortfolioServiceClient,
-    private val dateUtils: DateUtils,
     private val allocationService: AllocationService,
     private val sectorExposureService: SectorExposureService,
     private val fxService: FxService,
@@ -125,7 +124,7 @@ class PositionController(
         @RequestParam(
             value = "asAt",
             required = false
-        ) asAt: String = dateUtils.offsetDateString(),
+        ) asAt: String = DateUtils.TODAY,
         @Parameter(
             description = "Whether to include market values in the response",
             example = "true"

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
@@ -41,9 +41,6 @@ class PositionControllerTest {
     private lateinit var portfolioServiceClient: PortfolioServiceClient
 
     @Mock
-    private lateinit var dateUtils: DateUtils
-
-    @Mock
     private lateinit var valuationService: Valuation
 
     @Mock
@@ -71,7 +68,6 @@ class PositionControllerTest {
         positionController =
             PositionController(
                 portfolioServiceClient,
-                dateUtils,
                 allocationService,
                 sectorExposureService,
                 fxService,


### PR DESCRIPTION
## Summary

- `PositionController.byId` declared the default as `asAt: String = dateUtils.offsetDateString()` — a method call. Spring's `@RequestParam(required = false)` binding passes `null` for an absent param instead of invoking the Kotlin default-value expression, and `DateUtils.offsetDateString(null)` then NPEs (Sentry `POSITION-3P`).
- Switch to `asAt: String = DateUtils.TODAY`, the const used by the five other endpoints in the same controller. Downstream parsing (`DateUtils.getFormattedDate`) already handles the literal `"today"` and returns `LocalDate.now()`.
- `dateUtils` field is no longer referenced — drop from the constructor.

## Why

Sentry `POSITION-3P` (Seer actionability: high). Single event so far, but the endpoint is part of the public valuation surface and the failure mode is data-shaped — any caller that omits `asAt` will hit it. The five sibling endpoints use the constant pattern and don't appear in Sentry, so the alignment also removes a footgun that someone else would otherwise repeat.

## Test plan

- [x] `./gradlew :svc-position:test --tests PositionControllerTest` — green (constructor signature change reflected; `dateUtils` mock removed)
- [x] `./gradlew testSmart` — green across mono-repo
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [ ] After deploy: hit `GET /api/id/{id}` with no `asAt` and confirm 200 + position payload (no Sentry `POSITION-3P` regression)

Fixes POSITION-3P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified dependency management in the position service by removing the injected `DateUtils` dependency.
  * Updated the `byId` endpoint's default date parameter to use a static constant instead of a utility method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->