### PR TITLE
feat(svc-data): anchor price backfill + skip when DB covers range

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
@@ -2,19 +2,40 @@ package com.beancounter.marketdata.providers
 
 import com.beancounter.common.model.Asset
 import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.MAX_BACKFILL_YEARS
 import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.defaultBackfillFrom
+import com.beancounter.marketdata.trn.TrnRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
 /**
  * Service for handling market data backfill operations.
+ *
+ * Two responsibilities sit here so every caller (controller, coordinator,
+ * scheduler) gets the same behaviour:
+ *
+ * 1. **Anchor** — widen `fromDate` to the earliest tradeDate the asset has
+ *    ever been held on, across every portfolio. This makes "ALL" wealth-
+ *    performance charts work even when a newer portfolio caused the first
+ *    backfill at a later anchor.
+ * 2. **Skip when covered** — if the DB already has price rows spanning
+ *    `[fromDate, today]`, do not call the external provider at all. EODHD
+ *    charges per call, not per row, so a redundant call is one wasted
+ *    quota unit per asset. Existing rows from any provider (incl. legacy
+ *    ALPHA) count as coverage; provider lineage is not preserved.
  */
 @Service
 class MarketDataBackfillService(
     private val providerUtils: ProviderUtils,
     private val priceService: PriceService,
-    private val assetFinder: AssetFinder
+    private val assetFinder: AssetFinder,
+    private val marketDataRepo: MarketDataRepo,
+    private val trnRepository: TrnRepository,
+    private val maxBackfillYears: Long = MAX_BACKFILL_YEARS
 ) {
+    private val log = LoggerFactory.getLogger(MarketDataBackfillService::class.java)
+
     fun backFill(
         assetId: String,
         fromDate: LocalDate = defaultBackfillFrom()
@@ -26,10 +47,55 @@ class MarketDataBackfillService(
         asset: Asset,
         fromDate: LocalDate = defaultBackfillFrom()
     ) {
+        val today = LocalDate.now()
+        val anchored = anchorFromDate(asset.id, fromDate, today)
+        if (isCovered(asset.id, anchored, today)) {
+            log.debug(
+                "Backfill skipped — DB already covers [{}, today] for asset {}",
+                anchored,
+                asset.id
+            )
+            return
+        }
         val byFactory = providerUtils.splitProviders(providerUtils.getInputs(listOf(asset)))
         for (marketDataProvider in byFactory.keys) {
-            priceService.handle(marketDataProvider.backFill(asset, fromDate))
+            priceService.handle(marketDataProvider.backFill(asset, anchored))
         }
+    }
+
+    /**
+     * Widen the caller's `fromDate` to the earliest SETTLED tradeDate for this
+     * asset across every portfolio, then floor at `today - maxBackfillYears`.
+     * If the asset has no recorded holdings (yet), keep the caller's date.
+     */
+    internal fun anchorFromDate(
+        assetId: String,
+        fromDate: LocalDate,
+        today: LocalDate = LocalDate.now()
+    ): LocalDate {
+        val earliestHeld = trnRepository.findEarliestTradeDateByAssetId(assetId)
+        val widened =
+            if (earliestHeld != null && earliestHeld.isBefore(fromDate)) earliestHeld else fromDate
+        val floor = today.minusYears(maxBackfillYears)
+        return if (widened.isBefore(floor)) floor else widened
+    }
+
+    /**
+     * True when the DB has price rows spanning `[fromDate, today - 1d]`. We allow
+     * a one-day tail because today's price is filled by the live-price path, not
+     * the historic backfill, so insisting on `dbMax == today` would re-fetch the
+     * whole range every evening for no benefit.
+     */
+    private fun isCovered(
+        assetId: String,
+        fromDate: LocalDate,
+        today: LocalDate
+    ): Boolean {
+        val dbMin = marketDataRepo.findEarliestPriceDateByAssetId(assetId) ?: return false
+        val dbMax = marketDataRepo.findLatestPriceDateByAssetId(assetId) ?: return false
+        val coversStart = !dbMin.isAfter(fromDate)
+        val coversEnd = !dbMax.isBefore(today.minusDays(1))
+        return coversStart && coversEnd
     }
 
     private fun getAsset(assetId: String): Asset = assetFinder.find(assetId)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
@@ -48,6 +48,12 @@ interface MarketDataPriceProvider {
         // pass an explicit `targetFrom` for deep-history charts.
         const val DEFAULT_BACKFILL_YEARS = 2L
 
+        // Hard floor for any backfill request. Matches the longest range
+        // the chart UI exposes and caps how far back providers will be
+        // asked to reach. MarketDataBackfillService enforces this floor
+        // after anchoring to earliest cross-portfolio tradeDate.
+        const val MAX_BACKFILL_YEARS = 10L
+
         fun defaultBackfillFrom(): LocalDate = LocalDate.now().minusYears(DEFAULT_BACKFILL_YEARS)
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
@@ -66,6 +66,16 @@ interface MarketDataRepo : CrudRepository<MarketData, String> {
         priceDate: LocalDate
     ): Long
 
+    @Query("SELECT MIN(md.priceDate) FROM MarketData md WHERE md.asset.id = :assetId")
+    fun findEarliestPriceDateByAssetId(
+        @Param("assetId") assetId: String
+    ): LocalDate?
+
+    @Query("SELECT MAX(md.priceDate) FROM MarketData md WHERE md.asset.id = :assetId")
+    fun findLatestPriceDateByAssetId(
+        @Param("assetId") assetId: String
+    ): LocalDate?
+
     /**
      * Find stored prices that represent corporate events (dividend or split).
      */

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -11,6 +11,7 @@ import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.DateUtils.Companion.TODAY
+import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.MAX_BACKFILL_YEARS
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -361,10 +362,6 @@ class PriceController(
     }
 
     private companion object {
-        // Hard cap on how far back we'll ever ask a provider to go. Matches the
-        // longest range the chart UI exposes.
-        const val MAX_BACKFILL_YEARS = 10L
-
         // Headroom buffer so we don't re-trigger backfills when the cached
         // earliest already sits right at the provider's reachable floor.
         const val BACKFILL_RETRY_BUFFER_DAYS = 7L

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -321,6 +321,20 @@ interface TrnRepository :
     fun findDistinctAssetIdsByPortfolioIds(portfolioIds: Collection<String>): Collection<String>
 
     /**
+     * Earliest SETTLED tradeDate for this asset across every portfolio that has ever held it.
+     * Anchors price backfill: if portfolio A imported trades since 2020 and portfolio B since 2010,
+     * backfill must reach 2010 for the wealth-performance "ALL" chart to be drawable.
+     */
+    @Query(
+        "select min(t.tradeDate) from Trn t " +
+            "where t.asset.id = :assetId " +
+            "and t.status = com.beancounter.common.model.TrnStatus.SETTLED"
+    )
+    fun findEarliestTradeDateByAssetId(
+        @Param("assetId") assetId: String
+    ): LocalDate?
+
+    /**
      * Group transaction count by [com.beancounter.common.model.TrnType].
      * Surfaced as the `beancounter.transaction.count.by_type` MultiGauge.
      */

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillServiceTest.kt
@@ -1,0 +1,144 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.contracts.PriceAsset
+import com.beancounter.common.contracts.PriceResponse
+import com.beancounter.common.model.Asset
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.trn.TrnRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+/**
+ * Tests anchor + skip behaviour. Provider lineage is not preserved — these tests assert
+ * the service treats any existing price as coverage, regardless of source.
+ *
+ * Service uses `LocalDate.now()` internally (matches `defaultBackfillFrom()` pattern), so
+ * tests build expected values relative to today rather than fixing a calendar date.
+ */
+class MarketDataBackfillServiceTest {
+    private lateinit var providerUtils: ProviderUtils
+    private lateinit var priceService: PriceService
+    private lateinit var assetFinder: AssetFinder
+    private lateinit var marketDataRepo: MarketDataRepo
+    private lateinit var trnRepository: TrnRepository
+    private lateinit var provider: MarketDataPriceProvider
+    private lateinit var service: MarketDataBackfillService
+
+    private val today: LocalDate get() = LocalDate.now()
+    private val asset = Asset(code = "AAPL", id = "aapl-id", market = NASDAQ)
+
+    @BeforeEach
+    fun setUp() {
+        providerUtils = mock()
+        priceService = mock()
+        assetFinder = mock()
+        marketDataRepo = mock()
+        trnRepository = mock()
+        provider = mock()
+
+        whenever(providerUtils.getInputs(eq(listOf(asset))))
+            .thenReturn(listOf(PriceAsset(asset)))
+        whenever(providerUtils.splitProviders(any()))
+            .thenReturn(mutableMapOf(provider to mutableListOf(asset)))
+        whenever(provider.backFill(any(), any())).thenReturn(PriceResponse(emptyList()))
+
+        service =
+            MarketDataBackfillService(
+                providerUtils,
+                priceService,
+                assetFinder,
+                marketDataRepo,
+                trnRepository,
+                maxBackfillYears = 10
+            )
+    }
+
+    @Test
+    fun `anchor widens fromDate when older holdings exist in another portfolio`() {
+        // Caller window starts 3y back; cross-portfolio earliest holding is 7y back — both inside 10y floor.
+        val requested = today.minusYears(3)
+        val earliestHeld = today.minusYears(7)
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(earliestHeld)
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(requested)
+        whenever(marketDataRepo.findLatestPriceDateByAssetId(asset.id)).thenReturn(today)
+
+        service.backFill(asset, requested)
+
+        val captor = argumentCaptor<LocalDate>()
+        verify(provider).backFill(eq(asset), captor.capture())
+        assertThat(captor.firstValue).isEqualTo(earliestHeld)
+    }
+
+    @Test
+    fun `anchor floors at maxBackfillYears so providers are not asked for 30 years`() {
+        // Holdings reach back 30y; floor pulls request to today - 10y.
+        val ancient = today.minusYears(30)
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(ancient)
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(null)
+
+        service.backFill(asset, today.minusYears(2))
+
+        val captor = argumentCaptor<LocalDate>()
+        verify(provider).backFill(eq(asset), captor.capture())
+        assertThat(captor.firstValue).isEqualTo(today.minusYears(10))
+    }
+
+    @Test
+    fun `anchor keeps caller fromDate when no holdings recorded`() {
+        val requested = today.minusYears(2)
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(null)
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(null)
+
+        service.backFill(asset, requested)
+
+        verify(provider).backFill(eq(asset), eq(requested))
+    }
+
+    @Test
+    fun `skip provider call when DB already covers requested range`() {
+        // DB has prices from 10y back to yesterday — full coverage of any reasonable request.
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(today.minusYears(10))
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(today.minusYears(10))
+        whenever(marketDataRepo.findLatestPriceDateByAssetId(asset.id)).thenReturn(today.minusDays(1))
+
+        service.backFill(asset, today.minusYears(5))
+
+        verify(provider, never()).backFill(any(), any())
+        verify(priceService, never()).handle(any())
+    }
+
+    @Test
+    fun `call provider when DB coverage starts later than anchored fromDate`() {
+        // Anchored to 8y back (cross-portfolio, inside 10y floor); DB only has 3y onwards → gap.
+        val earliestHeld = today.minusYears(8)
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(earliestHeld)
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(today.minusYears(3))
+        whenever(marketDataRepo.findLatestPriceDateByAssetId(asset.id)).thenReturn(today)
+
+        service.backFill(asset, today.minusYears(3))
+
+        verify(provider).backFill(eq(asset), eq(earliestHeld))
+    }
+
+    @Test
+    fun `call provider when DB has no rows yet`() {
+        val requested = today.minusYears(2)
+        whenever(trnRepository.findEarliestTradeDateByAssetId(asset.id)).thenReturn(null)
+        whenever(marketDataRepo.findEarliestPriceDateByAssetId(asset.id)).thenReturn(null)
+        whenever(marketDataRepo.findLatestPriceDateByAssetId(asset.id)).thenReturn(null)
+
+        service.backFill(asset, requested)
+
+        verify(provider).backFill(eq(asset), eq(requested))
+    }
+}


### PR DESCRIPTION
## Summary
- **Anchor**: `MarketDataBackfillService.backFill` now widens caller's `fromDate` to the earliest SETTLED `tradeDate` for the asset across **every portfolio**, then floors at `today - MAX_BACKFILL_YEARS` (10y). Fixes the "ALL" wealth-performance chart when portfolio A imported from 2020 and portfolio B from 2010 — first backfill now reaches 2010, not just 2020.
- **Skip when covered**: if the DB already has price rows spanning `[anchored, today - 1d]`, the external provider is not called. EODHD charges per call (not per row), so a redundant call is one wasted quota unit per asset. Any provider's row counts as coverage — legacy ALPHA prices remain valid post-switch to EODHD.
- **Single source for `MAX_BACKFILL_YEARS`** — collapsed duplicate constant in `PriceController` + `MarketDataBackfillService` into `MarketDataPriceProvider.Companion` so floors can't drift.

## Why
Two views of the same chart should hit the provider at most once. Today every `ensureHistory` nudge triggered an EODHD call regardless of whether the data was already cached, and the anchor was the request window — not the asset's true holding history — so the "ALL" chart kept paying for prices it could never display.

## Behaviour matrix

| Caller state | Before | After |
|---|---|---|
| New asset, never backfilled | 1 EODHD call (range) | 1 EODHD call (anchored to earliest tradeDate) |
| Asset cached for 5y window, user opens "ALL" (10y) | 1 EODHD call every time | 1 EODHD call once; later "ALL" views skip |
| Portfolio B holds since 2010, A since 2020, DB has 2020→today | Backfill only reaches 2020 | Backfill reaches 2010 |
| DB covers `[anchored, today-1d]` | 1 wasted EODHD call | 0 calls |
| ALPHA-sourced historic rows present | Still respected (no change) | Still respected (asserted by test) |

Steady-state cost after first fetch per asset ≈ 0 EODHD calls from this path.

## Files

- `MarketDataBackfillService.kt` — anchor + skip logic, single companion constant
- `MarketDataPriceProvider.kt` — `MAX_BACKFILL_YEARS = 10L` added to companion
- `PriceController.kt` — imports shared constant, drops local duplicate
- `MarketDataRepo.kt` — `findEarliestPriceDateByAssetId` / `findLatestPriceDateByAssetId`
- `TrnRepository.kt` — `findEarliestTradeDateByAssetId` (cross-portfolio MIN over SETTLED)
- `MarketDataBackfillServiceTest.kt` — 6 cases: anchor widens / floor caps / no-holdings passthrough / skip-when-covered / call-on-gap / call-when-empty

## Test plan
- [x] `./gradlew testSmart formatKotlin lintKotlin` — all green
- [x] Semgrep scan — clean on all touched files
- [ ] Smoke on kauri: open a 3M wealth-performance chart twice for the same portfolio → only one EODHD call in svc-data logs (or zero if already cached)
- [ ] Smoke: portfolio with trades pre-2020 → "ALL" chart shows data from earliest tradeDate, not capped at last cached anchor
- [ ] Verify EODHD rate-limiter metrics stay under 1000/min and 100k/day after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market data backfill now intelligently skips external provider calls when the database already contains sufficient price coverage for the requested period.
  * Backfill date ranges are anchored to actual portfolio trading activity, ensuring relevant historical data is fetched while maintaining a 10-year maximum look-back limit.

* **Tests**
  * Added comprehensive test coverage validating backfill behavior across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->