### PR TITLE
fix(svc-data): single window query for bulk prices (ALL chart timeout hotfix)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
@@ -77,6 +77,23 @@ interface MarketDataRepo : CrudRepository<MarketData, String> {
     ): LocalDate?
 
     /**
+     * Bulk window load used by getBulkMarketData to eliminate N+1 nearest-prior fallback
+     * queries. Returns every price row for the given assets between [from] and [to] inclusive
+     * in a single query, ordered ascending. Caller resolves exact-date hits + nearest-prior
+     * fallback (weekends/holidays) in memory.
+     */
+    @Query(
+        "SELECT md FROM MarketData md JOIN FETCH md.asset a " +
+            "WHERE a IN :assets AND md.priceDate BETWEEN :from AND :to " +
+            "ORDER BY md.priceDate ASC"
+    )
+    fun findByAssetInAndPriceDateBetween(
+        @Param("assets") assets: Collection<Asset>,
+        @Param("from") from: LocalDate,
+        @Param("to") to: LocalDate
+    ): List<MarketData>
+
+    /**
      * Find stored prices that represent corporate events (dividend or split).
      */
     @Query(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -340,6 +340,13 @@ class PriceService(
      * Get market data for multiple assets across multiple dates (DB-only, no provider calls).
      * For dates without exact matches (weekends/holidays), falls back to the nearest prior price.
      * Returns a map keyed by date string.
+     *
+     * Implementation note: a single window query loads every row for the requested assets
+     * between [min(dates) - FALLBACK_LOOKBACK_DAYS] and [max(dates)]. Exact + nearest-prior
+     * resolution then runs in memory. The prior implementation issued a per-(asset, date)
+     * `findTop1...` fallback query for every weekend/holiday slot, which timed out under
+     * the wealth-performance "ALL" chart load (assets × ~50 monthly dates → hundreds of DB
+     * roundtrips, > 30s read-timeout on bc-position → /api/prices/bulk).
      */
     @Transactional
     fun getBulkMarketData(
@@ -348,37 +355,44 @@ class PriceService(
     ): Map<String, List<MarketData>> {
         if (assets.isEmpty() || dates.isEmpty()) return emptyMap()
 
-        // Single query for all exact matches
-        val exactMatches = marketDataRepo.findByAssetInAndPriceDateIn(assets, dates)
-        val exactByDateAsset =
-            exactMatches.groupBy { it.priceDate }.mapValues { (_, mds) ->
-                mds.associateBy { it.asset.id }
-            }
+        val minDate = dates.min()
+        val maxDate = dates.max()
+        val window =
+            marketDataRepo.findByAssetInAndPriceDateBetween(
+                assets,
+                minDate.minusDays(FALLBACK_LOOKBACK_DAYS),
+                maxDate
+            )
+        // Per-asset chronological list — already ascending from the query's ORDER BY.
+        val byAsset = window.groupBy { it.asset.id }
 
         val result = mutableMapOf<String, List<MarketData>>()
         for (date in dates) {
-            val exactForDate = exactByDateAsset[date] ?: emptyMap()
             val mdList = mutableListOf<MarketData>()
-
             for (asset in assets) {
-                val exact = exactForDate[asset.id]
-                if (exact != null) {
-                    mdList.add(exact)
-                } else {
-                    // Fallback: nearest price on or before this date
-                    val nearest =
-                        marketDataRepo.findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(
-                            asset,
-                            date
-                        )
-                    if (nearest.isPresent) {
-                        mdList.add(nearest.get())
-                    }
-                }
+                val series = byAsset[asset.id] ?: continue
+                val resolved = nearestOnOrBefore(series, date)
+                if (resolved != null) mdList.add(resolved)
             }
             result[date.toString()] = mdList
         }
         return result
+    }
+
+    /**
+     * Find the latest entry with `priceDate <= target` in an ascending-sorted series.
+     * Linear scan from the end — series is typically short (the FALLBACK_LOOKBACK_DAYS
+     * window keeps it bounded) so a binary-search complication isn't worth it.
+     */
+    private fun nearestOnOrBefore(
+        seriesAsc: List<MarketData>,
+        target: LocalDate
+    ): MarketData? {
+        for (i in seriesAsc.indices.reversed()) {
+            val md = seriesAsc[i]
+            if (!md.priceDate.isAfter(target)) return md
+        }
+        return null
     }
 
     /**
@@ -530,5 +544,11 @@ class PriceService(
         // Alpha. 0.70 catches 2:1 splits (50% drop) with comfortable headroom
         // over any realistic organic single-day move.
         private val MISSING_SPLIT_DROP_THRESHOLD = BigDecimal("0.70")
+
+        // How far before the earliest requested date to extend the bulk window
+        // load. Covers long weekends + bank-holiday clusters so the in-memory
+        // nearest-prior fallback has something to resolve to. 10 days is plenty
+        // for any developed market.
+        private const val FALLBACK_LOOKBACK_DAYS = 10L
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
@@ -9,11 +9,19 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.util.Optional
 
+/**
+ * Bulk price retrieval is the hot path for wealth-performance prefetch. The implementation
+ * uses a single window query (`findByAssetInAndPriceDateBetween`) and resolves exact +
+ * nearest-prior fallback in memory. These tests cover that contract; the prior N+1
+ * `findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc` path was removed because
+ * it caused /api/prices/bulk to time out on the "ALL" wealth chart (incident 2026-05-18).
+ */
 class BulkPriceServiceTest {
     private lateinit var priceService: PriceService
     private lateinit var marketDataRepo: MarketDataRepo
@@ -43,7 +51,7 @@ class BulkPriceServiceTest {
         val md3 = MarketData(asset = AAPL, priceDate = date2, close = BigDecimal("155"))
         val md4 = MarketData(asset = MSFT, priceDate = date2, close = BigDecimal("410"))
 
-        `when`(marketDataRepo.findByAssetInAndPriceDateIn(assets, dates))
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
             .thenReturn(listOf(md1, md2, md3, md4))
 
         val result = priceService.getBulkMarketData(assets, dates)
@@ -54,19 +62,16 @@ class BulkPriceServiceTest {
     }
 
     @Test
-    fun `getBulkMarketData falls back to nearest price for missing dates`() {
+    fun `getBulkMarketData falls back to nearest prior price for weekend dates`() {
         val weekend = LocalDate.of(2024, 1, 13) // Saturday
+        val friday = LocalDate.of(2024, 1, 12)
         val assets = listOf(AAPL)
         val dates = listOf(weekend)
 
-        // No exact match for Saturday
-        `when`(marketDataRepo.findByAssetInAndPriceDateIn(assets, dates))
-            .thenReturn(emptyList())
-
-        // But Friday's price exists
-        val fridayMd = MarketData(asset = AAPL, priceDate = LocalDate.of(2024, 1, 12), close = BigDecimal("148"))
-        `when`(marketDataRepo.findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(AAPL, weekend))
-            .thenReturn(Optional.of(fridayMd))
+        // Window query returns Friday's row (within lookback); no Saturday row.
+        val fridayMd = MarketData(asset = AAPL, priceDate = friday, close = BigDecimal("148"))
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
+            .thenReturn(listOf(fridayMd))
 
         val result = priceService.getBulkMarketData(assets, dates)
 
@@ -77,36 +82,35 @@ class BulkPriceServiceTest {
 
     @Test
     fun `getBulkMarketData handles mix of exact and fallback prices`() {
-        val date1 = LocalDate.of(2024, 1, 15)
-        val date2 = LocalDate.of(2024, 1, 13) // weekend
+        val tradingDay = LocalDate.of(2024, 1, 15)
+        val weekend = LocalDate.of(2024, 1, 13)
+        val friday = LocalDate.of(2024, 1, 12)
         val assets = listOf(AAPL)
-        val dates = listOf(date1, date2)
+        val dates = listOf(tradingDay, weekend)
 
-        val exactMd = MarketData(asset = AAPL, priceDate = date1, close = BigDecimal("150"))
-        `when`(marketDataRepo.findByAssetInAndPriceDateIn(assets, dates))
-            .thenReturn(listOf(exactMd))
-
-        // Fallback for weekend date
-        val fallbackMd = MarketData(asset = AAPL, priceDate = LocalDate.of(2024, 1, 12), close = BigDecimal("148"))
-        `when`(marketDataRepo.findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(AAPL, date2))
-            .thenReturn(Optional.of(fallbackMd))
+        val exactMd = MarketData(asset = AAPL, priceDate = tradingDay, close = BigDecimal("150"))
+        val fallbackMd = MarketData(asset = AAPL, priceDate = friday, close = BigDecimal("148"))
+        // Window contains both rows; one resolves exact, the other resolves nearest-prior.
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
+            .thenReturn(listOf(fallbackMd, exactMd))
 
         val result = priceService.getBulkMarketData(assets, dates)
 
         assertThat(result).hasSize(2)
         assertThat(result["2024-01-15"]).hasSize(1)
+        assertThat(result["2024-01-15"]!![0].close).isEqualByComparingTo(BigDecimal("150"))
         assertThat(result["2024-01-13"]).hasSize(1)
+        assertThat(result["2024-01-13"]!![0].close).isEqualByComparingTo(BigDecimal("148"))
     }
 
     @Test
-    fun `getBulkMarketData returns empty list for date with no data at all`() {
+    fun `getBulkMarketData returns empty list for date with no data in window`() {
         val date = LocalDate.of(2024, 1, 1)
         val assets = listOf(AAPL)
 
-        `when`(marketDataRepo.findByAssetInAndPriceDateIn(assets, listOf(date)))
+        // Window query returns nothing — no exact and no prior available.
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
             .thenReturn(emptyList())
-        `when`(marketDataRepo.findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(AAPL, date))
-            .thenReturn(Optional.empty())
 
         val result = priceService.getBulkMarketData(assets, listOf(date))
 


### PR DESCRIPTION
## 🔴 Hotfix for ALL-period chart timeout

Follow-up to PR #866 (OOM fix). With OOM resolved, the next failure under "ALL" wealth-performance load was a **30s read timeout** on \`POST /api/prices/bulk\` from bc-position → bc-data:

\`\`\`
ResourceAccessException: I/O error on POST request for "http://bc-data/api/prices/bulk": Read timed out
  at PerformanceService.prefetchPrices:174
\`\`\`

## Root cause

\`PriceService.getBulkMarketData\` ran:
1. One \`findByAssetInAndPriceDateIn\` for exact matches
2. **One \`findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc\` query per missing (asset, date) slot** — every weekend / holiday triggered a fresh DB roundtrip

For a 5-asset × 50-monthly-date "ALL" request → hundreds of roundtrips inside a single bulk endpoint call → > 30s response time → client-side timeout.

## Fix

- Add \`MarketDataRepo.findByAssetInAndPriceDateBetween\` — single window query across all requested assets between \`[min(dates) - 10d, max(dates)]\`.
- Rewrite \`getBulkMarketData\` to load the window once, group by asset (already ASC-ordered from the query), and resolve exact + nearest-prior in memory.
- **One DB roundtrip per bulk request**, no per-slot fallback queries.

10-day lookback covers long weekends + bank-holiday clusters so the in-memory nearest-prior resolver always has something to land on.

## Files

- \`MarketDataRepo.kt\` — new \`findByAssetInAndPriceDateBetween\` window query
- \`PriceService.kt\` — \`getBulkMarketData\` rewrite + private \`nearestOnOrBefore\` helper, \`FALLBACK_LOOKBACK_DAYS = 10\` constant
- \`BulkPriceServiceTest.kt\` — tests rewritten against the new contract (5 cases: empty / exact / weekend fallback / mixed / no-data-in-window)

## Test plan
- [x] \`./gradlew testSmart formatKotlin lintKotlin\` — all green
- [x] Semgrep scan clean
- [ ] Smoke on kauri: ALL-period wealth chart returns within 5s (was timing out at 30s)
- [ ] Verify weekend / holiday valuationDates still get the prior trading day's price

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized bulk market data retrieval by consolidating multiple database queries into a single efficient query with in-memory resolution, reducing latency for historical price lookups across multiple assets and date ranges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->