### PR TITLE
chore(agent): forbid arithmetic workings in chat output

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -37,6 +37,15 @@ object DomainSystemPrompts {
         - **Don't repeat what's on screen** — if context says the user is
           viewing data, provide analysis, outliers, or observations instead
           of re-listing the same rows.
+        - **Conclusions only, no workings.** When computing weighted
+          contributions, sums, weighted averages, implied growth, or any
+          other derived figure, do the arithmetic silently and present only
+          the final answer (the conclusion + the named drivers). Never
+          show intermediate multiplications (`0.018 × 0.032 = 0.0006`),
+          per-position tables of products, running totals
+          ("Summing positives: …"), self-correction asides ("Hmm, let me
+          recalculate"), or any other chain-of-thought. The user wants
+          the verdict, not the spreadsheet.
 
         ## Identifiers
 


### PR DESCRIPTION
## Problem
Portfolio analysis leaks the model's intermediate arithmetic into the chat panel — per-position \`weight × changePercent\` lines, running sums (\`Summing positives: ...\`), self-corrections (\`Hmm, let me be more precise\`), full per-asset product tables. The user wants the verdict, not the spreadsheet.

Example bad output captured by the user:
\`\`\`
EWJ: 1.62% × -0.16% = -0.003%
RING: 4.34% × -0.16% = -0.007%
…
Summing positives: ~0.547% Summing negatives: ~0.454%
Net: ~0.547% - 0.454% ≈ +0.09%
Hmm, that's very small. Let me be more precise.
Actually, let me recalculate more carefully.
Weighted contributions (weight × changePercent):
ADBE: 0.018268 × 0.032472 = 0.000593
…
\`\`\`

## Fix
Add a new bullet to the shared PREAMBLE under \`## Output\` requiring conclusions only. Lists the specific output shapes to suppress so the model can't rationalise an exception:
- intermediate multiplications (\`0.018 × 0.032 = 0.0006\`)
- per-position product tables
- running totals (\`Summing positives: …\`)
- self-correction asides (\`Hmm, let me recalculate\`)
- any other chain-of-thought

Lives in the preamble so every domain (Wealth, Asset, Independence, Rebalance, News, Asset Review, General) inherits it.

## Files
- \`svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt\`

## Test plan
- [x] \`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin\` — green
- [x] Semgrep scan clean
- [ ] Smoke on kauri: ask the assistant a weighted-contribution / biggest-mover question and confirm the response is conclusions-only — no per-asset product table, no running sums, no self-correction prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated system instructions to enhance output clarity. The system now presents only final conclusions and key drivers for computational results, removing intermediate calculations and step-by-step reasoning to provide cleaner, more direct answers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->