### PR TITLE
ci: base-image buildx cache mode=min

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -63,7 +63,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:25-jre-alpine-sentry${{ steps.sentry.outputs.version }}-${{ steps.prep.outputs.platform_tag }}
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          # mode=min stores only final-stage layers — base image has a
+          # single FROM, so mode=max offered no reuse benefit but accrued
+          # GHA cache storage.
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=min
           provenance: false
 
   docker-manifest:


### PR DESCRIPTION
## Summary

Flip `cache-to: type=gha,mode=max` to `mode=min` for the base-image build. The image has a single `FROM` plus a couple of `RUN` steps; `mode=max` was storing intermediate-builder layers in GHA cache with no realistic reuse benefit, just accruing storage.

## Why

Companion to storage-reduction PRs in `bc-view`, `svc-retire`, `svc-rebalance`. See https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions — caches and artifacts share one hourly-accrued pool.

## Test plan

- [ ] Workflow runs end-to-end on next Dockerfile change (or manual `workflow_dispatch`).
- [ ] Multi-arch manifest publishes successfully for both `linux/amd64` and `linux/arm64`.
- [ ] `gh cache list --repo monowai/beancounter` shows smaller buildx cache after the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build caching configuration in the CI/CD pipeline for improved build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->