### PR TITLE
fix(svc-data): DATA-4G + agent position dates

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -42,10 +42,12 @@ object DomainSystemPrompts {
           other derived figure, do the arithmetic silently and present only
           the final answer (the conclusion + the named drivers). Never
           show intermediate multiplications (`0.018 × 0.032 = 0.0006`),
-          per-position tables of products, running totals
-          ("Summing positives: …"), self-correction asides ("Hmm, let me
-          recalculate"), or any other chain-of-thought. The user wants
-          the verdict, not the spreadsheet.
+          per-position tables of products (Holding | Weight | Change% |
+          Contribution), running totals ("Summing positives: …"),
+          self-correction asides ("Hmm, let me recalculate"), or any
+          other chain-of-thought. No "Weighted daily return calculation"
+          tables, no "Contribution" columns — the user wants the
+          verdict, not the spreadsheet.
 
         ## Identifiers
 
@@ -110,6 +112,17 @@ object DomainSystemPrompts {
             most accurate when positions are held over varying periods.
           - `weight` — portfolio weight (decimal; 0.125 = 12.5%).
           - `category` — asset class, useful for grouping.
+          - `opened` — ISO date the position opened. **Always check
+            this before commenting on returns.** A position opened in
+            the last few days will legitimately show near-zero XIRR /
+            change — say "recently opened (YYYY-MM-DD), insufficient
+            history to judge return" instead of flagging it as
+            underperformance. Mention age (days/weeks/months held)
+            when it materially affects the conclusion.
+          - `lastTrade` — ISO date of the most recent transaction.
+            Useful when explaining stale or dormant holdings.
+          - `lastDividend` — ISO date of the most recent dividend
+            (null if never paid one). Useful for income commentary.
           - `closed` — true when quantity is zero.
           Show ratios as percentages when discussing performance. ROI,
           dividend yield, and trade currency are not exposed — never

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
@@ -54,7 +54,15 @@ class PositionTools(
                 "`xirr` (annualised money-weighted return, decimal — 0.12 = 12% p.a.; " +
                 "the most accurate performance measure across holdings); " +
                 "`weight` (portfolio weight, decimal — 0.125 = 12.5%); " +
-                "`category` (asset class, useful for grouping). " +
+                "`category` (asset class, useful for grouping); " +
+                "`opened` (ISO date YYYY-MM-DD the position was opened — use this " +
+                "to age the holding before commenting on returns; a position " +
+                "opened in the last few days will legitimately show near-zero " +
+                "XIRR or change); " +
+                "`lastTrade` (ISO date of the most recent transaction — useful " +
+                "for detecting dormant holdings); " +
+                "`lastDividend` (ISO date of the most recent dividend, or null " +
+                "if the holding has never paid a dividend). " +
                 "Closed (zero-quantity) positions are filtered out before " +
                 "the response is built, so every row represents an open " +
                 "holding — there is no `closed` column to inspect. " +

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
@@ -43,6 +43,10 @@ data class ScrubbedPortfolio(
  *   xirr                           — annualised money-weighted return
  *   weight                         — portfolio weight (0.125 = 12.5%)
  *   category                       — asset class
+ *   opened                         — ISO date this position opened (YYYY-MM-DD,
+ *                                    cleared on close, reset on reopen)
+ *   lastTrade                      — ISO date of most recent transaction
+ *   lastDividend                   — ISO date of most recent dividend
  */
 data class ScrubbedPositionResponse(
     val portfolioCode: String,
@@ -64,7 +68,10 @@ data class ScrubbedPositionResponse(
                 "changePercent",
                 "xirr",
                 "weight",
-                "category"
+                "category",
+                "opened",
+                "lastTrade",
+                "lastDividend"
             )
     }
 }
@@ -121,7 +128,10 @@ class ResponseScrubber {
             price?.changePercent?.toNullableDouble(),
             portfolioBucket?.irr?.toNullableDouble(),
             portfolioBucket?.weight?.toDouble() ?: 0.0,
-            asset.category
+            asset.category,
+            position.dateValues.opened?.toString(),
+            position.dateValues.last?.toString(),
+            position.dateValues.lastDividend?.toString()
         )
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
@@ -16,7 +16,7 @@ import java.time.LocalDate
 
 /**
  * Verify [ResponseScrubber] emits the compact columnar position shape, strips
- * absolute monetary values, and exposes only the 9-column field set the LLM
+ * absolute monetary values, and exposes the documented column set the LLM
  * needs.
  */
 class ResponseScrubberTest {
@@ -47,7 +47,7 @@ class ResponseScrubberTest {
     }
 
     @Test
-    fun `position response is columnar with the 9 documented columns`() {
+    fun `position response is columnar with the documented columns`() {
         val asset =
             Asset(
                 code = "AAPL",
@@ -72,6 +72,9 @@ class ResponseScrubberTest {
                 changePercent = BigDecimal("0.012")
             )
         position.quantityValues.purchased = BigDecimal("50")
+        position.dateValues.opened = LocalDate.parse("2025-09-01")
+        position.dateValues.last = LocalDate.parse("2026-04-10")
+        position.dateValues.lastDividend = LocalDate.parse("2026-02-15")
 
         val positions = Positions(portfolio)
         positions.add(position)
@@ -101,7 +104,10 @@ class ResponseScrubberTest {
                 "changePercent",
                 "xirr",
                 "weight",
-                "category"
+                "category",
+                "opened",
+                "lastTrade",
+                "lastDividend"
             )
         assertThat(scrubbed.rows).hasSize(1)
         assertThat(scrubbed.rows.first())
@@ -113,8 +119,33 @@ class ResponseScrubberTest {
                 0.012,
                 0.14,
                 0.125,
-                "Equity"
+                "Equity",
+                "2025-09-01",
+                "2026-04-10",
+                "2026-02-15"
             )
+    }
+
+    @Test
+    fun `null key dates serialise as null in row`() {
+        // New / freshly-imported holdings may have opened set but no
+        // dividend yet — null must pass through, not crash.
+        val asset = Asset(code = "NEW", market = nasdaq, category = "Equity")
+        val position = Position(asset, portfolio)
+        position.quantityValues.purchased = BigDecimal("10")
+        position.dateValues.opened = LocalDate.parse("2026-05-17")
+        // last + lastDividend left null
+
+        val positions = Positions(portfolio).apply { add(position) }
+        val scrubbed = scrubber.scrub(PositionResponse(positions))
+
+        val openedIdx = scrubbed.cols.indexOf("opened")
+        val lastTradeIdx = scrubbed.cols.indexOf("lastTrade")
+        val lastDividendIdx = scrubbed.cols.indexOf("lastDividend")
+        val row = scrubbed.rows.single()
+        assertThat(row[openedIdx]).isEqualTo("2026-05-17")
+        assertThat(row[lastTradeIdx]).isNull()
+        assertThat(row[lastDividendIdx]).isNull()
     }
 
     @Test

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -123,27 +123,48 @@ class AssetService(
         }
 
     fun resolveAssets(priceRequest: PriceRequest): PriceRequest {
-        val assetIds = priceRequest.assets.map { it.assetId }
-        val assets = assetRepository.findAllById(assetIds)
-        val resolvedCount =
-            priceRequest.assets.count { priceAsset ->
-                assets.find { it.id == priceAsset.assetId } != null
-            }
-        if (resolvedCount < assetIds.size) {
-            log.warn(
-                "Resolved {} of {} assets from database",
-                resolvedCount,
-                assetIds.size
-            )
-        }
+        // Two-stage resolution: prefer bulk lookup by assetId (cheap, single
+        // round-trip), then fall back to market+code lookup for entries whose
+        // caller only supplied the ticker. The svc-agent `getCurrentPrice`
+        // tool, for example, sends `PriceAsset(market, code)` with no id
+        // (see DATA-4G: phantom Asset(id=code) propagated into the persistence
+        // path and crashed the async save).
+        val assetIds =
+            priceRequest.assets
+                .map { it.assetId }
+                .filter { it.isNotBlank() }
+        val byId = assetRepository.findAllById(assetIds).associateBy { it.id }
+
         val resolvedAssets =
             priceRequest.assets.map { priceAsset ->
-                val asset = assets.find { it.id == priceAsset.assetId }
+                if (priceAsset.resolvedAsset != null) return@map priceAsset
+                val byIdMatch = byId[priceAsset.assetId]
+                val asset =
+                    byIdMatch
+                        ?: if (priceAsset.market.isNotBlank() && priceAsset.code.isNotBlank()) {
+                            try {
+                                assetFinder.findLocally(
+                                    AssetInput(priceAsset.market, priceAsset.code)
+                                )
+                            } catch (_: Exception) {
+                                null
+                            }
+                        } else {
+                            null
+                        }
                 if (asset != null) {
                     priceAsset.resolvedAsset = assetFinder.hydrateAsset(asset)
                 }
                 priceAsset
             }
+        val resolvedCount = resolvedAssets.count { it.resolvedAsset != null }
+        if (resolvedCount < priceRequest.assets.size) {
+            log.warn(
+                "Resolved {} of {} assets from database",
+                resolvedCount,
+                priceRequest.assets.size
+            )
+        }
         return priceRequest.copy(assets = resolvedAssets)
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderUtils.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderUtils.kt
@@ -3,7 +3,7 @@ package com.beancounter.marketdata.providers
 import com.beancounter.common.contracts.PriceAsset
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Status
-import com.beancounter.marketdata.markets.MarketService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 /**
@@ -11,29 +11,34 @@ import org.springframework.stereotype.Service
  */
 @Service
 class ProviderUtils(
-    private val mdFactory: MdFactory,
-    private val marketService: MarketService
+    private val mdFactory: MdFactory
 ) {
+    private val log = LoggerFactory.getLogger(ProviderUtils::class.java)
+
+    /**
+     * Groups resolved assets by their data provider. Callers MUST pre-resolve
+     * `priceAsset.resolvedAsset` (see [com.beancounter.marketdata.assets.AssetService.resolveAssets]).
+     * Unresolved entries are skipped with a warning — the previous behaviour
+     * of fabricating `Asset(code, market)` produced a phantom row with
+     * `id = code` that crashed the async persistence path when no matching
+     * DB row existed (DATA-4G).
+     */
     fun splitProviders(priceAssets: Collection<PriceAsset>): Map<MarketDataPriceProvider, MutableCollection<Asset>> {
         val mdpAssetResults: MutableMap<MarketDataPriceProvider, MutableCollection<Asset>> =
             mutableMapOf()
         priceAssets.forEach { priceAsset ->
-            val market =
-                priceAsset.resolvedAsset?.market ?: marketService
-                    .getMarket(priceAsset.market)
-                    .also { market ->
-                        priceAsset.resolvedAsset =
-                            Asset(
-                                code = priceAsset.code,
-                                market = market
-                            )
-                    }
-            val marketDataProvider = mdFactory.getMarketDataProvider(market)
-
-            if (priceAsset.resolvedAsset!!.status == Status.Active) {
-                val mdpAssets = mdpAssetResults.getOrPut(marketDataProvider) { mutableListOf() }
-                mdpAssets.add(priceAsset.resolvedAsset!!)
+            val resolved = priceAsset.resolvedAsset
+            if (resolved == null) {
+                log.warn(
+                    "Skipping price lookup for unresolved asset: market={}, code={}",
+                    priceAsset.market,
+                    priceAsset.code
+                )
+                return@forEach
             }
+            if (resolved.status != Status.Active) return@forEach
+            val marketDataProvider = mdFactory.getMarketDataProvider(resolved.market)
+            mdpAssetResults.getOrPut(marketDataProvider) { mutableListOf() }.add(resolved)
         }
         return mdpAssetResults
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetsTest.kt
@@ -92,4 +92,52 @@ class AssetsTest {
 
         // val byProviders = ProviderUtils().splitProviders(priceRequest.assets)
     }
+
+    @Test
+    fun `resolveAssets falls back to market and code when assetId blank`() {
+        // DATA-4G regression: callers such as svc-agent's getCurrentPrice
+        // tool only know the market + ticker, never the internal assetId.
+        // Resolution must succeed via findLocally(market, code) so the
+        // pipeline does not fabricate a phantom Asset(id=code).
+        val msft = "MSFT"
+        assetService.handle(
+            AssetRequest(
+                mapOf(
+                    msft to
+                        AssetInput(
+                            NASDAQ.code,
+                            msft,
+                            name = "Microsoft Corp."
+                        )
+                )
+            )
+        )
+        val priceRequest =
+            PriceRequest(
+                assets = listOf(PriceAsset(market = NASDAQ.code, code = msft))
+            )
+
+        val result = assetService.resolveAssets(priceRequest)
+
+        assertThat(result.assets).hasSize(1)
+        assertThat(result.assets[0].resolvedAsset)
+            .isNotNull
+            .extracting("code", "market.code")
+            .containsExactly(msft, NASDAQ.code)
+    }
+
+    @Test
+    fun `resolveAssets leaves resolvedAsset null when asset unknown`() {
+        // Unknown ticker — no DB row, no phantom. resolvedAsset stays null
+        // so splitProviders drops the entry rather than crashing later.
+        val priceRequest =
+            PriceRequest(
+                assets = listOf(PriceAsset(market = NASDAQ.code, code = "NEVER_LISTED"))
+            )
+
+        val result = assetService.resolveAssets(priceRequest)
+
+        assertThat(result.assets).hasSize(1)
+        assertThat(result.assets[0].resolvedAsset).isNull()
+    }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderArgumentsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderArgumentsTest.kt
@@ -12,7 +12,6 @@ import com.beancounter.marketdata.Constants.Companion.AAPL
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.Constants.Companion.NYSE
-import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
 import com.beancounter.marketdata.providers.cash.CashProviderService
 import org.assertj.core.api.Assertions.assertThat
@@ -214,16 +213,9 @@ internal class DataProviderArgumentsTest {
     }
 
     private fun getProviderUtils(market: Market): ProviderUtils {
-        val marketService = Mockito.mock(MarketService::class.java)
-        Mockito
-            .`when`(marketService.getMarket(market.code))
-            .thenReturn(market)
         val mdFactory = Mockito.mock(MdFactory::class.java)
         Mockito.`when`(mdFactory.getMarketDataProvider(market)).thenReturn(CashProviderService())
-        return ProviderUtils(
-            mdFactory,
-            marketService
-        )
+        return ProviderUtils(mdFactory)
     }
 
     private class TestConfig(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/ProviderUtilsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/ProviderUtilsTest.kt
@@ -4,7 +4,6 @@ import com.beancounter.common.contracts.PriceAsset
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Status
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
-import com.beancounter.marketdata.markets.MarketService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -15,11 +14,7 @@ import org.mockito.Mockito
 class ProviderUtilsTest {
     @Test
     fun inactiveAssetsIgnored() {
-        val providerUtils =
-            ProviderUtils(
-                Mockito.mock(MdFactory::class.java),
-                Mockito.mock(MarketService::class.java)
-            )
+        val providerUtils = ProviderUtils(Mockito.mock(MdFactory::class.java))
         val activeAsset =
             Asset(
                 code = "FindMe",
@@ -40,5 +35,17 @@ class ProviderUtilsTest {
                 )
             )
         ).containsExactly(PriceAsset(activeAsset))
+    }
+
+    @Test
+    fun unresolvedPriceAssetsSkipped() {
+        // DATA-4G regression: PriceAsset(market, code) with no resolvedAsset
+        // must NOT be fabricated into a phantom Asset(id=code) — that crashed
+        // the async persistence path when no DB row existed. Such entries are
+        // dropped silently (with a warn) before reaching the provider.
+        val providerUtils = ProviderUtils(Mockito.mock(MdFactory::class.java))
+        val unresolved = PriceAsset(market = NASDAQ.code, code = "SPY")
+        val split = providerUtils.splitProviders(listOf(unresolved))
+        assertThat(split).isEmpty()
     }
 }


### PR DESCRIPTION
## Summary

Two related changes touching the agent → svc-data price path.

### 1. `fix(svc-data): resolve assets by market+code` (DATA-4G)

`svc-agent`'s `getCurrentPrice` tool sends `PriceAsset(market, code)` with no `assetId`. `AssetService.resolveAssets` only matched by id, leaving `resolvedAsset = null`; `ProviderUtils.splitProviders` then fabricated `Asset(code, market)`. `Asset.id` defaults to `code`, so a phantom row with `id="SPY"` entered the persistence path. The async `saveAll` inside `priceService.handle` then crashed with `JpaObjectRetrievalFailureException: Unable to find com.beancounter.common.model.Asset with id SPY`.

- `resolveAssets` falls back to `assetFinder.findLocally(market, code)` when `assetId` is blank or unmatched.
- `splitProviders` drops unresolved entries with a warn instead of fabricating phantoms (defence-in-depth). Unused `MarketService` ctor dep removed.

POST `/api/prices` for an unknown ticker now returns `200` with empty data (was `200` + async crash). `getCurrentPrice` surfaces its legitimate "No price data for market:code" instead.

### 2. `feat(agent): expose position open/last/dividend dates`

`ScrubbedPositionResponse` gains `opened`, `lastTrade`, `lastDividend` columns sourced from `position.dateValues`. The LLM uses `opened` to age the holding before commenting on returns — a position opened in the last few days will legitimately show near-zero XIRR / change. Prompt updated to instruct that behaviour. The no-workings rule also gains specific bans for the `Weighted daily return calculation` table and `Contribution` column the model kept emitting.

## Test plan

- [x] `./gradlew testSmart` — green (svc-data + svc-position).
- [x] `./gradlew formatKotlin lintKotlin` — green.
- [x] New tests: `ProviderUtilsTest.unresolvedPriceAssetsSkipped`, `AssetsTest.resolveAssets falls back to market and code when assetId blank`, `AssetsTest.resolveAssets leaves resolvedAsset null when asset unknown`, `ResponseScrubberTest` updated with new col order + null-date case.
- [x] Semgrep clean on all touched files.
- [ ] Manual on kauri after deploy: trigger AI `getCurrentPrice` for a ticker not yet held in DB; confirm no Sentry event in DATA project.

Closes DATA-4G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position data now includes additional date fields (opened, last trade, last dividend)
  * Enhanced asset resolution with fallback lookup using market and code when asset ID is unavailable

* **Bug Fixes**
  * Improved handling of missing or null date values in position data
  * Better handling of unresolved assets prevents placeholder fabrication

* **Refactor**
  * Simplified provider utilities for cleaner asset resolution logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->