### PR TITLE
fix(svc-position): performance lookup by id (managed portfolios)

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceController.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.contracts.AggregatedPerformanceRequest
 import com.beancounter.common.contracts.AggregatedPerformanceResponse
 import com.beancounter.common.contracts.PerformanceResponse
 import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.model.Portfolio
 import com.beancounter.position.cache.PerformanceCacheService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -43,6 +44,21 @@ class PerformanceController(
 ) {
     private val log = LoggerFactory.getLogger(PerformanceController::class.java)
 
+    /**
+     * Accept either a portfolio code or its id in the `code` path slot. The
+     * holdings page passes `portfolio.id` so that managed/shared portfolios
+     * resolve — `getPortfolioByCode` is owner-scoped (`findByCodeAndOwner`)
+     * and 404s when the caller is the manager rather than the owner.
+     * `getPortfolioById` goes through `find(id)` on svc-data which applies
+     * the `canView` access check, so both owner and shared-with-me cases
+     * succeed. By-id first; fall back to by-code so existing callers that
+     * still send codes continue to work.
+     */
+    private fun resolvePortfolio(idOrCode: String): Portfolio =
+        runCatching { portfolioServiceClient.getPortfolioById(idOrCode) }
+            .getOrNull()
+            ?: portfolioServiceClient.getPortfolioByCode(idOrCode)
+
     @GetMapping("/{code}/performance")
     @Operation(
         summary = "Get portfolio performance",
@@ -57,7 +73,7 @@ class PerformanceController(
         months: Int
     ): PerformanceResponse {
         log.debug("Performance request for portfolio={}, months={}", code, months)
-        val portfolio = portfolioServiceClient.getPortfolioByCode(code)
+        val portfolio = resolvePortfolio(code)
         return performanceService.calculate(portfolio, months)
     }
 
@@ -85,7 +101,7 @@ class PerformanceController(
             indexAssetId,
             months
         )
-        val portfolio = portfolioServiceClient.getPortfolioByCode(code)
+        val portfolio = resolvePortfolio(code)
         return benchmarkService.benchmark(portfolio, indexAssetId, months)
     }
 
@@ -104,7 +120,7 @@ class PerformanceController(
         val displayCurrency =
             staticService.getCurrency(request.displayCurrency)
                 ?: throw BusinessException("Unknown display currency ${request.displayCurrency}")
-        val portfolios = request.portfolioCodes.map { portfolioServiceClient.getPortfolioByCode(it) }
+        val portfolios = request.portfolioCodes.map { resolvePortfolio(it) }
         log.debug(
             "Aggregate performance: portfolios={}, months={}, displayCurrency={}",
             request.portfolioCodes,
@@ -121,7 +137,7 @@ class PerformanceController(
         @PathVariable
         code: String
     ): Map<String, String> {
-        val portfolio = portfolioServiceClient.getPortfolioByCode(code)
+        val portfolio = resolvePortfolio(code)
         performanceCacheService.invalidatePortfolio(portfolio.id)
         log.info("Performance cache reset for portfolio={}", code)
         return mapOf("status" to "ok", "portfolio" to code)

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceControllerTest.kt
@@ -250,4 +250,36 @@ class PerformanceControllerTest {
         assertThat(result["status"]).isEqualTo("ok")
         assertThat(result["portfolio"]).isEqualTo("TEST")
     }
+
+    @Test
+    fun `resolves managed portfolio by id when by-code lookup fails`() {
+        // Managed portfolios are owned by another SystemUser; the holdings
+        // page sends `portfolio.id` to the performance endpoint. svc-data's
+        // `findByCode(code, owner)` is owner-scoped and would 404, while
+        // `find(id)` applies `canView` and succeeds for shared portfolios.
+        val managedId = "managed-pf-uuid"
+        whenever(portfolioServiceClient.getPortfolioById(managedId)).thenReturn(portfolio)
+        val expectedResponse =
+            PerformanceResponse(
+                PerformanceData(
+                    currency = USD,
+                    series =
+                        listOf(
+                            PerformanceDataPoint(
+                                date = LocalDate.of(2024, 1, 1),
+                                growthOf1000 = BigDecimal("1000"),
+                                marketValue = BigDecimal("10000"),
+                                netContributions = BigDecimal("10000"),
+                                cumulativeReturn = BigDecimal.ZERO
+                            )
+                        )
+                )
+            )
+        whenever(performanceService.calculate(portfolio, 12)).thenReturn(expectedResponse)
+
+        val result = controller.getPerformance(managedId, 12)
+
+        assertThat(result.data.series).hasSize(1)
+        verify(performanceService).calculate(portfolio, 12)
+    }
 }


### PR DESCRIPTION
## Summary

Holdings page for managed/shared portfolio LIV: chart 404'd with `Portfolio not found: LIV`. The Performance endpoints (`/{code}/performance`, `.../benchmark`, `.../cache`) routed every call through `getPortfolioByCode` → svc-data `findByCodeAndOwner(code, currentUser)` which is owner-scoped. The holdings page itself worked because it routes managed portfolios via `?byId=1` to a by-id endpoint that goes through svc-data's `find(id)` + `canView`.

New `resolvePortfolio` helper tries `getPortfolioById` first (works for owner + manager) and falls back to `getPortfolioByCode` so existing owner-only callers continue to work. `runCatching` covers both production (RestClient throws on 4xx) and Mockito stubs that return null for unmocked Kotlin non-null types.

bc-view follow-up PR will pass `portfolio.id` to PerformanceChart so the by-id branch is always used.

## Test plan

- [x] `./gradlew testSmart formatKotlin lintKotlin` — green.
- [x] New test `resolves managed portfolio by id when by-code lookup fails` in PerformanceControllerTest.
- [x] Semgrep clean.
- [ ] Manual on kauri after deploy: navigate to /holdings for a managed portfolio (e.g. LIV from the manager account); chart must load with no 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced portfolio lookup mechanism to intelligently resolve portfolios using ID or code, providing more robust and flexible performance calculations across all related endpoints.

* **Tests**
  * Added test coverage to verify ID-based portfolio resolution functionality works as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->