### PR TITLE
feat(svc-position): add portfolio breakdown to aggregated positions

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/model/PortfolioBreakdown.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/PortfolioBreakdown.kt
@@ -1,0 +1,17 @@
+package com.beancounter.common.model
+
+import java.math.BigDecimal
+
+/**
+ * Per-portfolio contribution to an aggregated [Position].
+ *
+ * Populated only on the aggregated holdings endpoint so the UI can show
+ * which underlying portfolios hold an asset and let the user navigate to
+ * a single portfolio.
+ */
+data class PortfolioBreakdown(
+    val portfolioId: String,
+    val portfolioCode: String,
+    val portfolioName: String,
+    val quantity: BigDecimal
+)

--- a/jar-common/src/main/kotlin/com/beancounter/common/model/Position.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/Position.kt
@@ -36,6 +36,14 @@ class Position(
     var subAccounts: MutableMap<String, java.math.BigDecimal> = mutableMapOf()
 
     /**
+     * Per-portfolio contribution for aggregated views.
+     * Empty for single-portfolio positions; populated only by the aggregated
+     * holdings endpoint so the UI can list the underlying portfolios holding
+     * this asset.
+     */
+    var portfolioBreakdown: List<PortfolioBreakdown> = emptyList()
+
+    /**
      * View currencies that cost is tracked in.
      */
     enum class In {

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.TrustedTrnQuery
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.PortfolioBreakdown
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
 import com.beancounter.common.model.setMarketValue
@@ -132,15 +133,17 @@ class ValuationService
             // Capture the security context to propagate to coroutines
             val securityContext = SecurityContextHolder.getContext()
 
-            // Concurrently fetch transactions for all portfolios
-            val allTransactions =
+            // Concurrently fetch transactions for all portfolios, retaining the
+            // portfolio each response belongs to so we can build a per-portfolio
+            // breakdown alongside the aggregated view.
+            val portfolioTransactions =
                 runBlocking(Dispatchers.IO) {
                     portfolios
                         .map { portfolio ->
                             async {
                                 SecurityContextHolder.setContext(securityContext)
                                 try {
-                                    trnService.query(portfolio, valuationDate)
+                                    portfolio to trnService.query(portfolio, valuationDate)
                                 } finally {
                                     SecurityContextHolder.clearContext()
                                 }
@@ -151,8 +154,8 @@ class ValuationService
             // Combine all transactions and sort by trade date
             // Sorting is required because the Accumulator validates date sequence
             val combinedTransactions =
-                allTransactions
-                    .flatMap { it.data.toTrns() }
+                portfolioTransactions
+                    .flatMap { it.second.data.toTrns() }
                     .sortedBy { it.tradeDate }
 
             if (combinedTransactions.isEmpty()) {
@@ -172,6 +175,11 @@ class ValuationService
                 )
             val positionResponse = positionService.build(contextPortfolio, positionRequest)
 
+            // Attach per-portfolio breakdown so the UI can list which portfolios
+            // hold each asset. Cost/quantity accumulation on the aggregated
+            // position itself is unchanged.
+            applyPortfolioBreakdown(positionResponse.data, portfolioTransactions)
+
             if (!valuationDate.equals(DateUtils.TODAY, ignoreCase = true)) {
                 positionResponse.data.asAt = valuationDate
             }
@@ -185,6 +193,46 @@ class ValuationService
                 )
             } else {
                 positionResponse
+            }
+        }
+
+        /**
+         * For each contributing portfolio, build its own positions and record the
+         * asset quantity it holds, then attach that list to the matching aggregated
+         * position. Portfolios with zero net quantity in an asset are skipped.
+         */
+        private fun applyPortfolioBreakdown(
+            aggregated: Positions,
+            portfolioTransactions: List<Pair<Portfolio, TrnResponse>>
+        ) {
+            if (!aggregated.hasPositions()) return
+
+            val breakdownByAsset = mutableMapOf<String, MutableList<PortfolioBreakdown>>()
+            portfolioTransactions.forEach { (portfolio, trnResponse) ->
+                val trns = trnResponse.data.toTrns()
+                if (trns.isEmpty()) return@forEach
+                val perPortfolio =
+                    positionService
+                        .build(portfolio, PositionRequest(portfolio.id, trns))
+                        .data
+                perPortfolio.positions.values.forEach { position ->
+                    val quantity = position.quantityValues.getTotal()
+                    if (quantity.signum() == 0) return@forEach
+                    breakdownByAsset
+                        .getOrPut(position.asset.id) { mutableListOf() }
+                        .add(
+                            PortfolioBreakdown(
+                                portfolioId = portfolio.id,
+                                portfolioCode = portfolio.code,
+                                portfolioName = portfolio.name,
+                                quantity = quantity
+                            )
+                        )
+                }
+            }
+
+            aggregated.positions.values.forEach { position ->
+                breakdownByAsset[position.asset.id]?.let { position.portfolioBreakdown = it.toList() }
             }
         }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -248,6 +248,97 @@ class ValuationServiceTest {
     }
 
     @Test
+    fun `getAggregatedPositions populates portfolioBreakdown per contributing portfolio`() {
+        // Given - two portfolios both holding the same asset
+        val portfolio2 = TestHelpers.createTestPortfolio("Portfolio2")
+        val portfolios = listOf(portfolio, portfolio2)
+
+        val asset = TestHelpers.createTestAsset("AAPL", "US")
+        val trn1 =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = portfolio,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("10"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 15)
+            )
+        val trn2 =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = portfolio2,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("5"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 16)
+            )
+
+        whenever(trnService.query(argThat { id == portfolio.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(trn1)))
+        whenever(trnService.query(argThat { id == portfolio2.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(trn2)))
+
+        val p1Positions =
+            Positions(portfolio).apply {
+                add(
+                    Position(asset, portfolio).apply {
+                        quantityValues.purchased = BigDecimal("10")
+                    }
+                )
+            }
+        val p2Positions =
+            Positions(portfolio2).apply {
+                add(
+                    Position(asset, portfolio2).apply {
+                        quantityValues.purchased = BigDecimal("5")
+                    }
+                )
+            }
+        val aggPositions =
+            Positions(portfolio).apply {
+                add(
+                    Position(asset, portfolio).apply {
+                        quantityValues.purchased = BigDecimal("15")
+                    }
+                )
+            }
+
+        whenever(
+            positionService.build(
+                argThat { id == portfolio.id },
+                argThat { trns.size == 1 }
+            )
+        ).thenReturn(PositionResponse(p1Positions))
+        whenever(
+            positionService.build(
+                argThat { id == portfolio2.id },
+                argThat { trns.size == 1 }
+            )
+        ).thenReturn(PositionResponse(p2Positions))
+        whenever(
+            positionService.build(
+                argThat { id == portfolio.id },
+                argThat { trns.size == 2 }
+            )
+        ).thenReturn(PositionResponse(aggPositions))
+
+        // When
+        val result = valuationService.getAggregatedPositions(portfolios, DateUtils.TODAY, value = false)
+
+        // Then
+        val agg =
+            result.data.positions.values
+                .first()
+        assertThat(agg.portfolioBreakdown).hasSize(2)
+        assertThat(agg.portfolioBreakdown.map { it.portfolioId })
+            .containsExactlyInAnyOrder(portfolio.id, portfolio2.id)
+        assertThat(agg.portfolioBreakdown.first { it.portfolioId == portfolio.id }.quantity)
+            .isEqualByComparingTo(BigDecimal("10"))
+        assertThat(agg.portfolioBreakdown.first { it.portfolioId == portfolio2.id }.quantity)
+            .isEqualByComparingTo(BigDecimal("5"))
+    }
+
+    @Test
     fun `getAggregatedPositions skips market value update for aggregated positions`() {
         // Given - aggregated positions that would normally trigger market value update
         val portfolio2 = TestHelpers.createTestPortfolio("Portfolio2")

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -339,6 +339,103 @@ class ValuationServiceTest {
     }
 
     @Test
+    fun `getAggregatedPositions excludes portfolio with net-zero quantity from breakdown`() {
+        // Given - P1 holds 10 AAPL; P2 bought 10 then sold 10 (net zero)
+        val portfolio2 = TestHelpers.createTestPortfolio("Portfolio2")
+        val portfolios = listOf(portfolio, portfolio2)
+
+        val asset = TestHelpers.createTestAsset("AAPL", "US")
+        val trnP1Buy =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = portfolio,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("10"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 15)
+            )
+        val trnP2Buy =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = portfolio2,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("10"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 16)
+            )
+        val trnP2Sell =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = portfolio2,
+                trnType = TrnType.SELL,
+                quantity = BigDecimal("10"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 17)
+            )
+
+        whenever(trnService.query(argThat { id == portfolio.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(trnP1Buy)))
+        whenever(trnService.query(argThat { id == portfolio2.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(trnP2Buy, trnP2Sell)))
+
+        val p1Positions =
+            Positions(portfolio).apply {
+                add(
+                    Position(asset, portfolio).apply {
+                        quantityValues.purchased = BigDecimal("10")
+                    }
+                )
+            }
+        val p2Positions =
+            Positions(portfolio2).apply {
+                add(
+                    Position(asset, portfolio2).apply {
+                        quantityValues.purchased = BigDecimal("10")
+                        quantityValues.sold = BigDecimal("-10")
+                    }
+                )
+            }
+        val aggPositions =
+            Positions(portfolio).apply {
+                add(
+                    Position(asset, portfolio).apply {
+                        quantityValues.purchased = BigDecimal("10")
+                    }
+                )
+            }
+
+        whenever(
+            positionService.build(
+                argThat { id == portfolio.id },
+                argThat { trns.size == 1 }
+            )
+        ).thenReturn(PositionResponse(p1Positions))
+        whenever(
+            positionService.build(
+                argThat { id == portfolio2.id },
+                argThat { trns.size == 2 }
+            )
+        ).thenReturn(PositionResponse(p2Positions))
+        whenever(
+            positionService.build(
+                argThat { id == portfolio.id },
+                argThat { trns.size == 3 }
+            )
+        ).thenReturn(PositionResponse(aggPositions))
+
+        // When
+        val result = valuationService.getAggregatedPositions(portfolios, DateUtils.TODAY, value = false)
+
+        // Then - only P1 appears in the breakdown
+        val agg =
+            result.data.positions.values
+                .first()
+        assertThat(agg.portfolioBreakdown).hasSize(1)
+        assertThat(agg.portfolioBreakdown.single().portfolioId).isEqualTo(portfolio.id)
+        assertThat(agg.portfolioBreakdown.single().quantity).isEqualByComparingTo(BigDecimal("10"))
+    }
+
+    @Test
     fun `getAggregatedPositions skips market value update for aggregated positions`() {
         // Given - aggregated positions that would normally trigger market value update
         val portfolio2 = TestHelpers.createTestPortfolio("Portfolio2")


### PR DESCRIPTION
## Summary
- Each `Position` returned by the aggregated holdings endpoint now carries `portfolioBreakdown: List<PortfolioBreakdown>` (`portfolioId`, `portfolioCode`, `portfolioName`, `quantity`)
- Single-portfolio responses leave the field empty
- `ValuationService` builds per-portfolio positions alongside the existing aggregated build and attaches the breakdown to each aggregated position
- Cost / quantity accumulation on the aggregated position itself is unchanged

Unblocks a bc-view aggregated-holdings UI where tapping a position's Quantity cell shows the underlying portfolios and links to single-portfolio views.

## Test plan
- [x] `./gradlew :svc-position:test :jar-common:test` — green
- [x] New test `ValuationServiceTest.getAggregatedPositions populates portfolioBreakdown per contributing portfolio` covers two portfolios holding the same asset
- [x] `./gradlew testSmart && formatKotlin && lintKotlin` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregated positions now include per-portfolio breakdowns showing portfolio id/code/name and net quantity for each contributing portfolio (zero-net contributors are excluded).
* **Tests**
  * Added tests verifying breakdowns are populated for multiple contributors and that portfolios with net-zero quantity are omitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->