### PR TITLE
fix(svc-data): apply SplitAdjuster to getBulkMarketData

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -364,7 +364,14 @@ class PriceService(
                 maxDate
             )
         // Per-asset chronological list — already ascending from the query's ORDER BY.
-        val byAsset = window.groupBy { it.asset.id }
+        // Rebase onto the latest post-split basis before resolution so wealth / TWR
+        // charts don't span split dates with raw pre-split closes (the DB stores raw
+        // closes for any provider that doesn't carry split coefficients on each row,
+        // e.g. Alpha TIME_SERIES_DAILY).
+        val byAsset =
+            window
+                .groupBy { it.asset.id }
+                .mapValues { (_, series) -> adjustSeriesForSplits(series) }
 
         val result = mutableMapOf<String, List<MarketData>>()
         for (date in dates) {
@@ -377,6 +384,48 @@ class PriceService(
             result[date.toString()] = mdList
         }
         return result
+    }
+
+    /**
+     * Apply [SplitAdjuster] to a chronological [MarketData] series and write the
+     * adjusted OHLC back into the returned rows. Mirrors what [getPriceHistory]
+     * does for the `/prices/{id}/history` endpoint so the bulk read path that
+     * feeds `svc-position` performance charts sees the same rebased basis.
+     */
+    private fun adjustSeriesForSplits(series: List<MarketData>): List<MarketData> {
+        if (series.size < 2) return series
+        val asset = series.first().asset
+        val from = series.first().priceDate
+        val to = series.last().priceDate
+        val splitEvents = collectSplitEvents(asset, from, to)
+        val adjusted = SplitAdjuster.adjust(series.map(PricePoint::from), splitEvents)
+        if (adjusted === series) return series
+        return series.zip(adjusted).map { (md, point) ->
+            if (point.close.compareTo(md.close) == 0 &&
+                point.open.compareTo(md.open) == 0 &&
+                point.high.compareTo(md.high) == 0 &&
+                point.low.compareTo(md.low) == 0
+            ) {
+                md
+            } else {
+                MarketData(
+                    asset = md.asset,
+                    priceDate = md.priceDate,
+                    open = point.open,
+                    close = point.close,
+                    source = md.source
+                ).also {
+                    it.high = point.high
+                    it.low = point.low
+                    it.previousClose = point.previousClose
+                    it.change = md.change
+                    it.changePercent = md.changePercent
+                    it.volume = md.volume
+                    it.split = point.split
+                    it.dividend = md.dividend
+                }
+            }
+        }
     }
 
     /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
@@ -104,6 +104,38 @@ class BulkPriceServiceTest {
     }
 
     @Test
+    fun `getBulkMarketData rebases pre-split closes via SplitAdjuster`() {
+        // Pre-split AAPL @ $500 should appear in the bulk response as the post-split
+        // basis ($125) once a known 4-for-1 ex-date sits later in the window. Without
+        // this, wealth/TWR charts span split dates with raw pre-split closes and show
+        // an N× drop on the ex-date that never recovers.
+        val preSplit = LocalDate.of(2020, 8, 28)
+        val exDate = LocalDate.of(2020, 8, 31)
+        val postSplit = LocalDate.of(2020, 9, 1)
+        val assets = listOf(AAPL)
+        val dates = listOf(preSplit, exDate, postSplit)
+
+        val pre = MarketData(asset = AAPL, priceDate = preSplit, close = BigDecimal("500.00"))
+        val ex =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("125.00")).apply {
+                split = BigDecimal("4")
+            }
+        val post = MarketData(asset = AAPL, priceDate = postSplit, close = BigDecimal("130.00"))
+
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
+            .thenReturn(listOf(pre, ex, post))
+
+        val result = priceService.getBulkMarketData(assets, dates)
+
+        assertThat(result["2020-08-28"]!![0].close)
+            .isEqualByComparingTo(BigDecimal("125.00"))
+        assertThat(result["2020-08-31"]!![0].close)
+            .isEqualByComparingTo(BigDecimal("125.00"))
+        assertThat(result["2020-09-01"]!![0].close)
+            .isEqualByComparingTo(BigDecimal("130.00"))
+    }
+
+    @Test
     fun `getBulkMarketData returns empty list for date with no data in window`() {
         val date = LocalDate.of(2024, 1, 1)
         val assets = listOf(AAPL)


### PR DESCRIPTION
## Summary
- `/prices/bulk` read path (used by `svc-position` performance / wealth / TWR charts) returned raw pre-split closes for any asset where the DB holds `split=1` across the board — i.e. anything backfilled via Alpha `TIME_SERIES_DAILY`, which doesn't carry split coefficients on each row.
- `/prices/{id}/history` already rebases via `SplitAdjuster`; the bulk path did not. Charts spanning a split date dropped N× on the ex-date and never recovered.
- Apply `SplitAdjuster` per-asset inside `getBulkMarketData`, sourcing split events from `AlphaEventService.getEvents` exactly like `getPriceHistory`.

## Visible case
SCHG 4:1 on 2024-10-11. Pre-split rows showed as $105 (raw) instead of ~$26 (adjusted) in performance charts.

## Test plan
- [x] New regression test: `BulkPriceServiceTest::getBulkMarketData rebases pre-split closes via SplitAdjuster` — Red on raw 500, Green after fix returns adjusted 125.
- [x] Existing bulk-price tests still pass.
- [x] `./gradlew testSmart && formatKotlin && lintKotlin` BUILD SUCCESSFUL.
- [ ] After merge: visual verify SCHG chart on kauri; restart `bc-position` to drop snapshot cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed historical price data handling to correctly apply stock split adjustments in bulk market data requests. Performance charts now display accurate, split-adjusted prices when viewing price history across stock split dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->