### PR TITLE
fix(svc-data): repair-splits endpoint + EventServiceFacade routing

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/RepairSplitsResponse.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/RepairSplitsResponse.kt
@@ -1,0 +1,16 @@
+package com.beancounter.common.contracts
+
+/**
+ * Outcome of `POST /prices/{assetId}/repair-splits`.
+ *
+ * The repair walks corporate-event splits for the asset and stamps the
+ * `split` column on each ex-date `MarketData` row that still carries the
+ * default `1`. Once stamped, `SplitAdjuster` can rebase historical OHLC
+ * via column-transition detection on every read path without per-call
+ * provider lookups.
+ */
+data class RepairSplitsResponse(
+    val stamped: Int = 0,
+    val alreadyStamped: Int = 0,
+    val missingRows: Int = 0
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
@@ -17,6 +17,18 @@ interface MarketDataRepo : CrudRepository<MarketData, String> {
         date: LocalDate?
     ): Optional<MarketData>
 
+    /**
+     * Every row for an asset on a given date, across all sources. The unique
+     * key on `MarketData` is `(source, asset_id, price_date)`, so a single
+     * (asset_id, price_date) tuple can have multiple rows when more than one
+     * provider supplies the asset. Splits / dividends apply to the asset
+     * regardless of provider, so the repair endpoint stamps every match.
+     */
+    fun findAllByAssetIdAndPriceDate(
+        assetId: String,
+        priceDate: LocalDate
+    ): List<MarketData>
+
     fun findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(
         asset: Asset,
         priceDate: LocalDate

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.contracts.OffMarketPriceRequest
 import com.beancounter.common.contracts.PriceHistoryResponse
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
+import com.beancounter.common.contracts.RepairSplitsResponse
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.DateUtils.Companion.TODAY
 import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.MAX_BACKFILL_YEARS
@@ -467,4 +468,23 @@ class PriceController(
         )
         @PathVariable code: String
     ): Map<String, Any> = portfolioPriceBackfillService.backfill(code)
+
+    @PostMapping("/{assetId}/repair-splits")
+    @Operation(
+        summary = "Stamp the split column on existing rows from provider events",
+        description = """
+            Walks corporate-event splits for the asset (via EventServiceFacade so each market routes
+            to its configured provider) and stamps the `split` column on each ex-date MarketData row
+            that still carries the default `1`. After repair, SplitAdjuster rebases historical OHLC
+            via column-transition detection on every read path without re-querying the provider per
+            call. Idempotent.
+        """
+    )
+    fun repairSplits(
+        @Parameter(
+            description = "Internal asset identifier",
+            example = "asset-123"
+        )
+        @PathVariable assetId: String
+    ): RepairSplitsResponse = priceService.repairSplits(assetId)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.providers
 import com.beancounter.common.contracts.PriceHistoryResponse
 import com.beancounter.common.contracts.PricePoint
 import com.beancounter.common.contracts.PriceResponse
+import com.beancounter.common.contracts.RepairSplitsResponse
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.MarketData
 import com.beancounter.common.model.MarketData.Companion.isDividend
@@ -35,10 +36,16 @@ class PriceService(
     private var eventProducer: EventProducer? = null
     private var cacheInvalidationProducer: CacheInvalidationProducer? = null
     private var alphaEventService: AlphaEventService? = null
+    private var eventServiceFacade: EventServiceFacade? = null
 
     @Autowired(required = false)
     fun setAlphaEventService(alphaEventService: AlphaEventService?) {
         this.alphaEventService = alphaEventService
+    }
+
+    @Autowired(required = false)
+    fun setEventServiceFacade(eventServiceFacade: EventServiceFacade?) {
+        this.eventServiceFacade = eventServiceFacade
     }
 
     @Autowired(required = false)
@@ -495,22 +502,21 @@ class PriceService(
         return marketData.close.compareTo(anomalyThreshold) < 0
     }
 
-    // Returns Alpha's known split factor for the asset on `date` when one
+    // Returns the provider's known split factor for the asset on `date` when one
     // exists, or null otherwise. Lets enrichWithPreviousClose recover from
     // providers that omit the split flag on the ex-date row (e.g. MarketStack
-    // on VUG 2026-04-21).
+    // on VUG 2026-04-21). Routes via [EventServiceFacade] so US assets covered
+    // by EODHD pick up splits Alpha misses (e.g. SCHG 4:1 on 2024-10-11).
     private fun knownSplitFor(
         asset: Asset,
         date: LocalDate
-    ): BigDecimal? {
-        val service = alphaEventService ?: return null
-        return try {
-            service
-                .getEvents(asset)
-                .data
-                .asSequence()
-                .filter(::isSplit)
-                .firstOrNull { it.priceDate == date }
+    ): BigDecimal? =
+        try {
+            providerEvents(asset)
+                ?.data
+                ?.asSequence()
+                ?.filter(::isSplit)
+                ?.firstOrNull { it.priceDate == date }
                 ?.split
                 ?.takeIf { it.compareTo(BigDecimal.ONE) != 0 && it.signum() > 0 }
         } catch (
@@ -525,7 +531,6 @@ class PriceService(
             )
             null
         }
-    }
 
     /**
      * Pulls known split events for the asset within the requested range.
@@ -541,17 +546,16 @@ class PriceService(
         asset: Asset,
         from: LocalDate,
         to: LocalDate
-    ): List<SplitAdjuster.SplitEvent> {
-        val service = alphaEventService ?: return emptyList()
-        return try {
-            service
-                .getEvents(asset)
-                .data
-                .asSequence()
-                .filter(::isSplit)
-                .filter { !it.priceDate.isBefore(from) && !it.priceDate.isAfter(to) }
-                .map { SplitAdjuster.SplitEvent(it.priceDate, it.split) }
-                .toList()
+    ): List<SplitAdjuster.SplitEvent> =
+        try {
+            providerEvents(asset)
+                ?.data
+                ?.asSequence()
+                ?.filter(::isSplit)
+                ?.filter { !it.priceDate.isBefore(from) && !it.priceDate.isAfter(to) }
+                ?.map { SplitAdjuster.SplitEvent(it.priceDate, it.split) }
+                ?.toList()
+                ?: emptyList()
         } catch (
             @Suppress("TooGenericExceptionCaught")
             e: Exception
@@ -563,6 +567,62 @@ class PriceService(
             )
             emptyList()
         }
+
+    // Source of corporate events for an asset. Prefer [EventServiceFacade] so
+    // each market routes to its configured provider (EODHD covers SCHG splits
+    // Alpha doesn't); fall back to [AlphaEventService] for unit tests that
+    // wire only the legacy collaborator.
+    private fun providerEvents(asset: Asset): PriceResponse? =
+        eventServiceFacade?.getEvents(asset.id)
+            ?: alphaEventService?.getEvents(asset)
+
+    /**
+     * Stamp the `split` column on each ex-date `MarketData` row from the
+     * provider's known split events. After repair, `SplitAdjuster` can rebase
+     * historical OHLC via column-transition detection on every read path
+     * without re-querying the provider on each call.
+     *
+     * Idempotent: rows already carrying the matching factor are left alone.
+     */
+    @Transactional
+    fun repairSplits(assetId: String): RepairSplitsResponse {
+        val asset = assetFinder.find(assetId)
+        val events =
+            providerEvents(asset)
+                ?.data
+                ?.filter(::isSplit)
+                ?.filter { it.split.compareTo(BigDecimal.ONE) != 0 && it.split.signum() > 0 }
+                ?: return RepairSplitsResponse()
+        var stamped = 0
+        var alreadyStamped = 0
+        var missingRows = 0
+        var earliest: LocalDate? = null
+        for (event in events) {
+            val existing = marketDataRepo.findByAssetIdAndPriceDate(asset.id, event.priceDate)
+            if (existing.isEmpty) {
+                missingRows++
+                continue
+            }
+            val row = existing.get()
+            if (row.split.compareTo(event.split) == 0) {
+                alreadyStamped++
+                continue
+            }
+            row.split = event.split
+            marketDataRepo.save(row)
+            stamped++
+            if (earliest == null || event.priceDate.isBefore(earliest)) {
+                earliest = event.priceDate
+            }
+        }
+        if (stamped > 0 && earliest != null) {
+            cacheInvalidationProducer?.sendPriceHistoryEvent(asset.id, earliest)
+        }
+        return RepairSplitsResponse(
+            stamped = stamped,
+            alreadyStamped = alreadyStamped,
+            missingRows = missingRows
+        )
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -598,20 +598,26 @@ class PriceService(
         var missingRows = 0
         var earliest: LocalDate? = null
         for (event in events) {
-            val existing = marketDataRepo.findByAssetIdAndPriceDate(asset.id, event.priceDate)
-            if (existing.isEmpty) {
+            // A split impacts the asset regardless of provider: stamp every
+            // row on the ex-date so multi-source coverage stays in sync (the
+            // unique key is (source, asset_id, price_date)).
+            val rows = marketDataRepo.findAllByAssetIdAndPriceDate(asset.id, event.priceDate)
+            if (rows.isEmpty()) {
                 missingRows++
                 continue
             }
-            val row = existing.get()
-            if (row.split.compareTo(event.split) == 0) {
-                alreadyStamped++
-                continue
+            var stampedThisEvent = false
+            for (row in rows) {
+                if (row.split.compareTo(event.split) == 0) {
+                    alreadyStamped++
+                    continue
+                }
+                row.split = event.split
+                marketDataRepo.save(row)
+                stamped++
+                stampedThisEvent = true
             }
-            row.split = event.split
-            marketDataRepo.save(row)
-            stamped++
-            if (earliest == null || event.priceDate.isBefore(earliest)) {
+            if (stampedThisEvent && (earliest == null || event.priceDate.isBefore(earliest))) {
                 earliest = event.priceDate
             }
         }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
@@ -1,0 +1,108 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.contracts.PriceResponse
+import com.beancounter.common.model.MarketData
+import com.beancounter.common.utils.CashUtils
+import com.beancounter.marketdata.Constants.Companion.AAPL
+import com.beancounter.marketdata.assets.AssetFinder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+/**
+ * Repair endpoint stamps the `split` column on existing `MarketData` rows so
+ * `SplitAdjuster` can rebase historical OHLC via column-transition detection
+ * on every read path. Without this, historical backfills from providers that
+ * don't carry split coefficients per row (Alpha `TIME_SERIES_DAILY`) leave
+ * the DB with `split = 1` across the board and charts span splits raw.
+ */
+class PriceRepairServiceTest {
+    private lateinit var priceService: PriceService
+    private lateinit var marketDataRepo: MarketDataRepo
+    private val assetFinder = mock(AssetFinder::class.java)
+    private val eventServiceFacade = mock(EventServiceFacade::class.java)
+
+    @BeforeEach
+    fun setUp() {
+        marketDataRepo = mock(MarketDataRepo::class.java)
+        priceService = PriceService(marketDataRepo, CashUtils(), assetFinder)
+        priceService.setEventServiceFacade(eventServiceFacade)
+        whenever(assetFinder.find(AAPL.id)).thenReturn(AAPL)
+    }
+
+    @Test
+    fun `repairSplits stamps split column on the ex-date row from provider events`() {
+        val exDate = LocalDate.of(2020, 8, 31)
+        val splitEvent =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal.ZERO).apply {
+                split = BigDecimal("4")
+            }
+        whenever(eventServiceFacade.getEvents(AAPL.id))
+            .thenReturn(PriceResponse(listOf(splitEvent)))
+
+        val existing =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("125.00"))
+        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(Optional.of(existing))
+
+        val response = priceService.repairSplits(AAPL.id)
+
+        assertThat(response.stamped).isEqualTo(1)
+        assertThat(response.alreadyStamped).isEqualTo(0)
+        assertThat(response.missingRows).isEqualTo(0)
+        val saved = ArgumentCaptor.forClass(MarketData::class.java)
+        verify(marketDataRepo).save(saved.capture())
+        assertThat(saved.value.split).isEqualByComparingTo(BigDecimal("4"))
+    }
+
+    @Test
+    fun `repairSplits leaves rows already stamped untouched`() {
+        val exDate = LocalDate.of(2020, 8, 31)
+        val splitEvent =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal.ZERO).apply {
+                split = BigDecimal("4")
+            }
+        whenever(eventServiceFacade.getEvents(AAPL.id))
+            .thenReturn(PriceResponse(listOf(splitEvent)))
+
+        val existing =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("125.00")).apply {
+                split = BigDecimal("4")
+            }
+        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(Optional.of(existing))
+
+        val response = priceService.repairSplits(AAPL.id)
+
+        assertThat(response.stamped).isEqualTo(0)
+        assertThat(response.alreadyStamped).isEqualTo(1)
+        verify(marketDataRepo, org.mockito.Mockito.never()).save(any<MarketData>())
+    }
+
+    @Test
+    fun `repairSplits reports missing rows when no MarketData exists on the ex-date`() {
+        val exDate = LocalDate.of(2020, 8, 31)
+        val splitEvent =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal.ZERO).apply {
+                split = BigDecimal("4")
+            }
+        whenever(eventServiceFacade.getEvents(AAPL.id))
+            .thenReturn(PriceResponse(listOf(splitEvent)))
+        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(Optional.empty())
+
+        val response = priceService.repairSplits(AAPL.id)
+
+        assertThat(response.stamped).isEqualTo(0)
+        assertThat(response.missingRows).isEqualTo(1)
+        verify(marketDataRepo, org.mockito.Mockito.never()).save(any<MarketData>())
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.util.Optional
 
 /**
  * Repair endpoint stamps the `split` column on existing `MarketData` rows so
@@ -50,8 +49,8 @@ class PriceRepairServiceTest {
 
         val existing =
             MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("125.00"))
-        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
-            .thenReturn(Optional.of(existing))
+        whenever(marketDataRepo.findAllByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(listOf(existing))
 
         val response = priceService.repairSplits(AAPL.id)
 
@@ -61,6 +60,34 @@ class PriceRepairServiceTest {
         val saved = ArgumentCaptor.forClass(MarketData::class.java)
         verify(marketDataRepo).save(saved.capture())
         assertThat(saved.value.split).isEqualByComparingTo(BigDecimal("4"))
+    }
+
+    @Test
+    fun `repairSplits stamps every provider's row on the same ex-date`() {
+        // A split affects the asset regardless of provider. With EODHD + ALPHA
+        // both holding rows for the ex-date, repair has to update both so the
+        // SplitAdjuster column-transition detector fires on whichever source
+        // wins resolution on a given read.
+        val exDate = LocalDate.of(2024, 10, 11)
+        val splitEvent =
+            MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal.ZERO).apply {
+                split = BigDecimal("4")
+            }
+        whenever(eventServiceFacade.getEvents(AAPL.id))
+            .thenReturn(PriceResponse(listOf(splitEvent)))
+
+        val alpha = MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("26.42"), source = "ALPHA")
+        val eodhd = MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("26.42"), source = "EODHD")
+        whenever(marketDataRepo.findAllByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(listOf(alpha, eodhd))
+
+        val response = priceService.repairSplits(AAPL.id)
+
+        assertThat(response.stamped).isEqualTo(2)
+        assertThat(alpha.split).isEqualByComparingTo(BigDecimal("4"))
+        assertThat(eodhd.split).isEqualByComparingTo(BigDecimal("4"))
+        verify(marketDataRepo).save(alpha)
+        verify(marketDataRepo).save(eodhd)
     }
 
     @Test
@@ -77,8 +104,8 @@ class PriceRepairServiceTest {
             MarketData(asset = AAPL, priceDate = exDate, close = BigDecimal("125.00")).apply {
                 split = BigDecimal("4")
             }
-        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
-            .thenReturn(Optional.of(existing))
+        whenever(marketDataRepo.findAllByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(listOf(existing))
 
         val response = priceService.repairSplits(AAPL.id)
 
@@ -96,8 +123,8 @@ class PriceRepairServiceTest {
             }
         whenever(eventServiceFacade.getEvents(AAPL.id))
             .thenReturn(PriceResponse(listOf(splitEvent)))
-        whenever(marketDataRepo.findByAssetIdAndPriceDate(AAPL.id, exDate))
-            .thenReturn(Optional.empty())
+        whenever(marketDataRepo.findAllByAssetIdAndPriceDate(AAPL.id, exDate))
+            .thenReturn(emptyList())
 
         val response = priceService.repairSplits(AAPL.id)
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairServiceTest.kt
@@ -84,6 +84,8 @@ class PriceRepairServiceTest {
         val response = priceService.repairSplits(AAPL.id)
 
         assertThat(response.stamped).isEqualTo(2)
+        assertThat(response.alreadyStamped).isEqualTo(0)
+        assertThat(response.missingRows).isEqualTo(0)
         assertThat(alpha.split).isEqualByComparingTo(BigDecimal("4"))
         assertThat(eodhd.split).isEqualByComparingTo(BigDecimal("4"))
         verify(marketDataRepo).save(alpha)
@@ -111,6 +113,7 @@ class PriceRepairServiceTest {
 
         assertThat(response.stamped).isEqualTo(0)
         assertThat(response.alreadyStamped).isEqualTo(1)
+        assertThat(response.missingRows).isEqualTo(0)
         verify(marketDataRepo, org.mockito.Mockito.never()).save(any<MarketData>())
     }
 
@@ -129,6 +132,7 @@ class PriceRepairServiceTest {
         val response = priceService.repairSplits(AAPL.id)
 
         assertThat(response.stamped).isEqualTo(0)
+        assertThat(response.alreadyStamped).isEqualTo(0)
         assertThat(response.missingRows).isEqualTo(1)
         verify(marketDataRepo, org.mockito.Mockito.never()).save(any<MarketData>())
     }


### PR DESCRIPTION
## Summary
Two problems surfaced after #876 deployed:

1. **`collectSplitEvents` / `knownSplitFor` bypassed `EventServiceFacade`** and went straight to `AlphaEventService`. For markets where the facade routes to EODHD (US), Alpha is missing splits EODHD has — SCHG 4:1 on 2024-10-11 was the visible case. Result: SplitAdjuster never saw the event, `/prices/bulk` and `/prices/{id}/history` returned raw pre-split closes.
2. **No way to persist the fix** — even with correct runtime routing, every read pays a provider lookup. Better to stamp the `split` column on the ex-date row so column-transition detection in SplitAdjuster handles it for free on every subsequent read.

## Changes
- New endpoint `POST /prices/{assetId}/repair-splits` — walks `EventServiceFacade.getEvents(assetId)`, stamps `split` factor on each ex-date `MarketData` row, fires `sendPriceHistoryEvent` so `svc-position` drops stale snapshots. Idempotent (`alreadyStamped` counter), reports `missingRows` when the ex-date sits outside the local price coverage.
- `collectSplitEvents` + `knownSplitFor` now prefer `EventServiceFacade` over the legacy `AlphaEventService`. Falls back to Alpha if only the legacy bean is wired (keeps existing unit tests green).

## Test plan
- [x] `PriceRepairServiceTest` — three cases: stamps fresh row, leaves already-stamped untouched, reports missing rows.
- [x] `BulkPriceServiceTest` from #876 unchanged + green.
- [x] `./gradlew testSmart && formatKotlin && lintKotlin` BUILD SUCCESSFUL.
- [ ] After merge: call `POST /prices/NI9sAMpaQzOBXknhfohZYQ/repair-splits` (SCHG) on kauri, verify `/prices/bulk` returns adjusted pre-split closes (~$26 not $105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repair-splits endpoint that detects and corrects missing or incorrect split adjustments across provider rows, returning counts for stamped, already-stamped, and missing rows; repairs trigger cache refreshes when changes occur and handle multiple provider rows per date.

* **Tests**
  * Added tests covering single/multiple-row repairs, already-correct detection, missing-data reporting, and persisted stamping behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->