### PR TITLE
fix(svc-data): SplitAdjuster skips providers that ship adjusted close

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/PriceHistoryResponse.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/PriceHistoryResponse.kt
@@ -40,7 +40,13 @@ data class PricePoint(
     /** Split ratio applied on this date (1 = no split). Enables split-adjusted charts. */
     val split: BigDecimal = BigDecimal.ONE,
     /** Dividend amount per share paid on this date (0 = none). */
-    val dividend: BigDecimal = BigDecimal.ZERO
+    val dividend: BigDecimal = BigDecimal.ZERO,
+    /**
+     * Provider identifier that supplied the row (matches [MarketData.source]).
+     * Carried through so [SplitAdjuster] can skip dividing rows whose
+     * provider already persists adjusted close (e.g. EODHD post-#875).
+     */
+    val source: String = ""
 ) {
     companion object {
         fun from(md: MarketData): PricePoint =
@@ -55,7 +61,8 @@ data class PricePoint(
                 changePercent = md.changePercent,
                 volume = md.volume,
                 split = md.split,
-                dividend = md.dividend
+                dividend = md.dividend,
+                source = md.source
             )
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
@@ -41,6 +41,19 @@ interface MarketDataPriceProvider {
     // Return true if an external API calls is required
     fun isApiSupported(): Boolean
 
+    /**
+     * `true` when this provider persists rows whose `close` is already
+     * split- and dividend-adjusted (e.g. EODHD via `adjusted_close`,
+     * Alpha `TIME_SERIES_DAILY_ADJUSTED`). Drives [SplitAdjuster] to
+     * skip dividing rows from this source so the read path doesn't
+     * double-adjust on top of provider-side adjustment.
+     *
+     * Default is `false`: most legacy providers (Alpha `TIME_SERIES_DAILY`,
+     * MarketStack raw close, Morningstar, Cash, Private) ship raw closes
+     * and need read-time rebasement.
+     */
+    fun shipsAdjustedClose(): Boolean = false
+
     companion object {
         // Default window when no caller-supplied `fromDate`. Matches the
         // shortest provider plan (EODHD historical / MarketStack base tier

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -37,6 +37,7 @@ class PriceService(
     private var cacheInvalidationProducer: CacheInvalidationProducer? = null
     private var alphaEventService: AlphaEventService? = null
     private var eventServiceFacade: EventServiceFacade? = null
+    private var adjustedSources: Set<String> = emptySet()
 
     @Autowired(required = false)
     fun setAlphaEventService(alphaEventService: AlphaEventService?) {
@@ -46,6 +47,23 @@ class PriceService(
     @Autowired(required = false)
     fun setEventServiceFacade(eventServiceFacade: EventServiceFacade?) {
         this.eventServiceFacade = eventServiceFacade
+    }
+
+    /**
+     * Discover which provider IDs persist already-adjusted close prices.
+     * Built once at startup from every [MarketDataPriceProvider] bean and
+     * handed to [SplitAdjuster] to suppress double-adjustment.
+     */
+    @Autowired(required = false)
+    fun setPriceProviders(providers: List<MarketDataPriceProvider>) {
+        adjustedSources =
+            providers
+                .filter { it.shipsAdjustedClose() }
+                .map { it.getId() }
+                .toSet()
+        if (adjustedSources.isNotEmpty()) {
+            log.info("SplitAdjuster will skip already-adjusted sources: {}", adjustedSources)
+        }
     }
 
     @Autowired(required = false)
@@ -405,7 +423,7 @@ class PriceService(
         val from = series.first().priceDate
         val to = series.last().priceDate
         val splitEvents = collectSplitEvents(asset, from, to)
-        val adjusted = SplitAdjuster.adjust(series.map(PricePoint::from), splitEvents)
+        val adjusted = SplitAdjuster.adjust(series.map(PricePoint::from), splitEvents, adjustedSources)
         if (adjusted === series) return series
         return series.zip(adjusted).map { (md, point) ->
             if (point.close.compareTo(md.close) == 0 &&
@@ -483,7 +501,7 @@ class PriceService(
         val splitEvents = collectSplitEvents(asset, from, to)
         return PriceHistoryResponse(
             asset = asset,
-            prices = SplitAdjuster.adjust(rawPrices, splitEvents)
+            prices = SplitAdjuster.adjust(rawPrices, splitEvents, adjustedSources)
         )
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -39,7 +39,8 @@ object SplitAdjuster {
 
     fun adjust(
         prices: List<PricePoint>,
-        events: List<SplitEvent> = emptyList()
+        events: List<SplitEvent> = emptyList(),
+        adjustedSources: Set<String> = emptySet()
     ): List<PricePoint> {
         if (prices.isEmpty()) return prices
 
@@ -65,10 +66,16 @@ object SplitAdjuster {
         val sortedEvents = merged.entries.sortedBy { it.key }
 
         return prices.map { p ->
+            // Providers that persist `adjusted_close` (e.g. EODHD post-#875)
+            // ship rows already on the post-split basis. Dividing again would
+            // double-adjust. Skip the factor application for those sources.
+            val alreadyAdjusted = adjustedSources.contains(p.source)
             var factor = BigDecimal.ONE
-            for ((date, eventFactor) in sortedEvents) {
-                if (date.isAfter(p.priceDate)) {
-                    factor = factor.multiply(eventFactor)
+            if (!alreadyAdjusted) {
+                for ((date, eventFactor) in sortedEvents) {
+                    if (date.isAfter(p.priceDate)) {
+                        factor = factor.multiply(eventFactor)
+                    }
                 }
             }
             val canonicalSplit = merged[p.priceDate] ?: BigDecimal.ONE
@@ -78,9 +85,15 @@ object SplitAdjuster {
             // (svc-data's enrichWithPreviousClose) already rebase it. We
             // distinguish by magnitude: if it sits at roughly the raw
             // pre-split level (≥ half of close × canonicalSplit) treat it as
-            // raw, otherwise leave it alone.
+            // raw, otherwise leave it alone. Adjusted-close providers ship
+            // previousClose on the adjusted basis already, so skip the heuristic
+            // entirely for those rows.
             val previousCloseFactor =
-                resolvePreviousCloseFactor(p, factor, canonicalSplit)
+                if (alreadyAdjusted) {
+                    BigDecimal.ONE
+                } else {
+                    resolvePreviousCloseFactor(p, factor, canonicalSplit)
+                }
             if (factor.compareTo(BigDecimal.ONE) == 0 &&
                 previousCloseFactor.compareTo(BigDecimal.ONE) == 0 &&
                 canonicalSplit == p.split

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/SplitAdjuster.kt
@@ -66,18 +66,20 @@ object SplitAdjuster {
         val sortedEvents = merged.entries.sortedBy { it.key }
 
         return prices.map { p ->
-            // Providers that persist `adjusted_close` (e.g. EODHD post-#875)
-            // ship rows already on the post-split basis. Dividing again would
-            // double-adjust. Skip the factor application for those sources.
-            val alreadyAdjusted = adjustedSources.contains(p.source)
             var factor = BigDecimal.ONE
-            if (!alreadyAdjusted) {
-                for ((date, eventFactor) in sortedEvents) {
-                    if (date.isAfter(p.priceDate)) {
-                        factor = factor.multiply(eventFactor)
-                    }
+            for ((date, eventFactor) in sortedEvents) {
+                if (date.isAfter(p.priceDate)) {
+                    factor = factor.multiply(eventFactor)
                 }
             }
+            // `shipsAdjustedClose()` providers (e.g. EODHD post-#875) persist
+            // `MarketData.close = adjusted_close` but leave `open/high/low` on
+            // the raw basis (the EODHD response carries no adjusted variants
+            // of those fields). Skip the factor only for `close` so the
+            // adjusted figure isn't divided again; keep dividing `open/high/
+            // low/previousClose` so the row lands fully on one basis.
+            val closeIsAdjusted = adjustedSources.contains(p.source)
+            val closeFactor = if (closeIsAdjusted) BigDecimal.ONE else factor
             val canonicalSplit = merged[p.priceDate] ?: BigDecimal.ONE
             // previousClose on the ex-date row lives on the previous trading
             // day. Some upstream paths leave it raw pre-split (so it needs
@@ -85,23 +87,18 @@ object SplitAdjuster {
             // (svc-data's enrichWithPreviousClose) already rebase it. We
             // distinguish by magnitude: if it sits at roughly the raw
             // pre-split level (≥ half of close × canonicalSplit) treat it as
-            // raw, otherwise leave it alone. Adjusted-close providers ship
-            // previousClose on the adjusted basis already, so skip the heuristic
-            // entirely for those rows.
+            // raw, otherwise leave it alone.
             val previousCloseFactor =
-                if (alreadyAdjusted) {
-                    BigDecimal.ONE
-                } else {
-                    resolvePreviousCloseFactor(p, factor, canonicalSplit)
-                }
+                resolvePreviousCloseFactor(p, factor, canonicalSplit)
             if (factor.compareTo(BigDecimal.ONE) == 0 &&
+                closeFactor.compareTo(BigDecimal.ONE) == 0 &&
                 previousCloseFactor.compareTo(BigDecimal.ONE) == 0 &&
                 canonicalSplit == p.split
             ) {
                 p
             } else {
                 p.copy(
-                    close = divideIfPositive(p.close, factor),
+                    close = divideIfPositive(p.close, closeFactor),
                     open = divideIfPositive(p.open, factor),
                     high = divideIfPositive(p.high, factor),
                     low = divideIfPositive(p.low, factor),

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -96,6 +96,11 @@ class EodhdPriceService(
 
     override fun isApiSupported(): Boolean = true
 
+    // EODHD `/api/eod` ships `adjusted_close` per row; `EodhdAdapter` persists
+    // that value as `MarketData.close` (see PR #875). SplitAdjuster must skip
+    // dividing EODHD rows so corporate_event splits don't double-adjust them.
+    override fun shipsAdjustedClose(): Boolean = true
+
     companion object {
         const val ID = "EODHD"
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -32,12 +32,14 @@ class SplitAdjusterTest {
         date: LocalDate,
         close: Double,
         split: Double = 1.0,
-        previousClose: Double = 0.0
+        previousClose: Double = 0.0,
+        source: String = ""
     ) = PricePoint(
         priceDate = date,
         close = bd(close),
         previousClose = bd(previousClose),
-        split = bd(split)
+        split = bd(split),
+        source = source
     )
 
     @Test
@@ -223,6 +225,31 @@ class SplitAdjusterTest {
 
         assertThat(adjusted[0].previousClose)
             .isEqualByComparingTo(BigDecimal.valueOf(rebasedPreviousClose))
+    }
+
+    @Test
+    fun `skips dividing rows whose source already ships adjusted close`() {
+        // Regression guard: EODHD (post-#875) persists `adjusted_close` so its
+        // rows are already on the post-split basis. A corporate_event split
+        // would double-adjust them. ALPHA rows on the same window are raw and
+        // must still be divided.
+        val prices =
+            listOf(
+                point(date20260403, 100.0, source = "EODHD"),
+                point(date20260403, 5000.0, source = "ALPHA"),
+                point(date20260407, 205.0, source = "ALPHA")
+            )
+        val events = listOf(SplitAdjuster.SplitEvent(date20260406, BigDecimal("25")))
+
+        val adjusted =
+            SplitAdjuster.adjust(prices, events, adjustedSources = setOf("EODHD"))
+
+        // EODHD already-adjusted row: untouched.
+        assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("100"))
+        // ALPHA raw row pre-split: divided by 25.
+        assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("200"))
+        // ALPHA row on/after split: no events later, no divide.
+        assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("205"))
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/SplitAdjusterTest.kt
@@ -33,10 +33,16 @@ class SplitAdjusterTest {
         close: Double,
         split: Double = 1.0,
         previousClose: Double = 0.0,
-        source: String = ""
+        source: String = "",
+        open: Double = 0.0,
+        high: Double = 0.0,
+        low: Double = 0.0
     ) = PricePoint(
         priceDate = date,
         close = bd(close),
+        open = bd(open),
+        high = bd(high),
+        low = bd(low),
         previousClose = bd(previousClose),
         split = bd(split),
         source = source
@@ -228,26 +234,46 @@ class SplitAdjusterTest {
     }
 
     @Test
-    fun `skips dividing rows whose source already ships adjusted close`() {
-        // Regression guard: EODHD (post-#875) persists `adjusted_close` so its
-        // rows are already on the post-split basis. A corporate_event split
-        // would double-adjust them. ALPHA rows on the same window are raw and
-        // must still be divided.
+    fun `adjusted-source skip applies to close only - OHL still divided`() {
+        // EODHD (post-#875) persists `adjusted_close` as MarketData.close but
+        // leaves open/high/low on the raw basis — the response has no
+        // adjusted_* variants for OHL. Skipping the factor only on close
+        // keeps the row on a single basis after rebasement; an over-broad
+        // skip would leave a mixed-basis row (adjusted close + raw OHL).
         val prices =
             listOf(
-                point(date20260403, 100.0, source = "EODHD"),
-                point(date20260403, 5000.0, source = "ALPHA"),
-                point(date20260407, 205.0, source = "ALPHA")
+                point(
+                    date20260403,
+                    close = 100.0,
+                    source = "EODHD",
+                    open = 400.0,
+                    high = 420.0,
+                    low = 380.0
+                ),
+                point(
+                    date20260403,
+                    close = 5000.0,
+                    source = "ALPHA",
+                    open = 4900.0,
+                    high = 5100.0,
+                    low = 4800.0
+                ),
+                point(date20260407, close = 205.0, source = "ALPHA")
             )
         val events = listOf(SplitAdjuster.SplitEvent(date20260406, BigDecimal("25")))
 
         val adjusted =
             SplitAdjuster.adjust(prices, events, adjustedSources = setOf("EODHD"))
 
-        // EODHD already-adjusted row: untouched.
+        // EODHD: close untouched (already adjusted) ...
         assertThat(adjusted[0].close).isEqualByComparingTo(BigDecimal("100"))
-        // ALPHA raw row pre-split: divided by 25.
+        // ... but raw OHL still divided so the row lands on a single basis.
+        assertThat(adjusted[0].open).isEqualByComparingTo(BigDecimal("16"))
+        assertThat(adjusted[0].high).isEqualByComparingTo(BigDecimal("16.8"))
+        assertThat(adjusted[0].low).isEqualByComparingTo(BigDecimal("15.2"))
+        // ALPHA raw row pre-split: all fields divided by 25.
         assertThat(adjusted[1].close).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(adjusted[1].open).isEqualByComparingTo(BigDecimal("196"))
         // ALPHA row on/after split: no events later, no divide.
         assertThat(adjusted[2].close).isEqualByComparingTo(BigDecimal("205"))
     }


### PR DESCRIPTION
## Summary
Addresses the latent double-adjust risk surfaced after PRs #875–#877:
- EODHD now persists `adjusted_close` as `MarketData.close`.
- If `corporate_event` also carries the split (or `collectSplitEvents` returns it), `SplitAdjuster` divided EODHD rows on read despite them already sitting on the post-split basis. Today's data is safe (EODHD only owns post-rollout dates), but a future re-import of historic dates via EODHD would double-adjust.

## Approach
Provider-declarative routing instead of source-string checks scattered through `SplitAdjuster`:

- `MarketDataPriceProvider.shipsAdjustedClose(): Boolean` (default `false`). `EodhdPriceService` overrides to `true`.
- `PricePoint` carries `source` (populated from `MarketData.source`).
- `SplitAdjuster.adjust(prices, events, adjustedSources)` skips dividing rows whose source is in the set. Column-transition stamp on `split` still runs.
- `PriceService` builds `adjustedSources` from every injected `MarketDataPriceProvider` at startup and threads it through `getPriceHistory` + bulk path.

## Test plan
- [x] New `SplitAdjusterTest::skips dividing rows whose source already ships adjusted close` — EODHD adjusted + ALPHA raw mixed in one series with an external event; only ALPHA divides.
- [x] Existing `SplitAdjusterTest`, `BulkPriceServiceTest`, `PriceRepairServiceTest` all green.
- [x] `./gradlew testSmart && formatKotlin && lintKotlin` BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price data now records a provider/source identifier and market-data providers can declare when they supply already-adjusted close prices.
  * Adjustment logic now respects those declarations at service startup to avoid re-adjusting closes.

* **Bug Fixes**
  * Prevents double-adjusting of close prices for sources that ship adjusted closes while still adjusting other fields.

* **Tests**
  * Added regression test covering mixed adjusted and unadjusted sources during split adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->