### PR TITLE
fix(svc-data): admin-only gate on repair-splits

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -470,6 +470,9 @@ class PriceController(
     ): Map<String, Any> = portfolioPriceBackfillService.backfill(code)
 
     @PostMapping("/{assetId}/repair-splits")
+    @PreAuthorize(
+        "hasAnyAuthority('" + AuthConstants.SCOPE_ADMIN + "', '" + AuthConstants.SCOPE_SYSTEM + "')"
+    )
     @Operation(
         summary = "Stamp the split column on existing rows from provider events",
         description = """
@@ -477,7 +480,8 @@ class PriceController(
             to its configured provider) and stamps the `split` column on each ex-date MarketData row
             that still carries the default `1`. After repair, SplitAdjuster rebases historical OHLC
             via column-transition detection on every read path without re-querying the provider per
-            call. Idempotent.
+            call. Idempotent. Restricted to admin / system scope — write operation on shared
+            historical data.
         """
     )
     fun repairSplits(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceRepairControllerTest.kt
@@ -1,0 +1,77 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.marketdata.SpringMvcDbTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.Instant
+
+/**
+ * Integration tests for `POST /prices/{assetId}/repair-splits`.
+ *
+ * Writes provider-derived split factors back onto stored price rows, so the
+ * endpoint is gated to admin / system scope — a regular user-scope token
+ * (i.e. the JWT a bc-view session holds for a non-admin login) must not be
+ * able to invoke it.
+ */
+@SpringMvcDbTest
+internal class PriceRepairControllerTest
+    @Autowired
+    private constructor(
+        private val mockMvc: MockMvc,
+        private val mockAuthConfig: MockAuthConfig
+    ) {
+        @MockitoBean
+        private lateinit var jwtDecoder: JwtDecoder
+
+        @Test
+        fun `repair-splits is forbidden for a user-only scope token`() {
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/prices/asset-1/repair-splits")
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(userOnlyToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andExpect(MockMvcResultMatchers.status().isForbidden)
+        }
+
+        @Test
+        fun `repair-splits is allowed for the default mock token (carries admin scope)`() {
+            // mockAuthConfig.getUserToken() grants beancounter + user + admin
+            // by design (TokenUtils.getUserToken). Verify the @PreAuthorize on
+            // the controller accepts that token shape so admin-flow tests in
+            // bc-view's MockMvc layer keep working.
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/prices/asset-1/repair-splits")
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(mockAuthConfig.getUserToken())
+                        ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andExpect(
+                    // The gate passes the request through — downstream may 404 on a
+                    // non-existent asset, which is fine. We're only asserting the
+                    // @PreAuthorize check doesn't reject (not 401/403).
+                    MockMvcResultMatchers.status().`is`(404)
+                )
+        }
+
+        private fun userOnlyToken(): Jwt =
+            Jwt
+                .withTokenValue("user-only")
+                .header("alg", "none")
+                .subject("user-only")
+                .claim("scope", "${AuthConstants.APP_NAME} ${AuthConstants.USER}")
+                .expiresAt(Instant.now().plusSeconds(60))
+                .build()
+    }


### PR DESCRIPTION
## Summary
`POST /prices/{assetId}/repair-splits` writes split factors back onto stored price history — a privileged data-fix operation. Today the class-level `@PreAuthorize` on `PriceController` accepts USER or SYSTEM, so any authenticated bc-view session could invoke it.

## Change
Method-level `@PreAuthorize("hasAnyAuthority('SCOPE_ADMIN', 'SCOPE_SYSTEM')")` on the endpoint. UI gates client-side via `useIsAdmin`; this PR locks the server-side door too.

## Test plan
- [x] `PriceRepairControllerTest::repair-splits is forbidden for a user-only scope token` — explicit JWT with only `beancounter beancounter:user` scope → 403.
- [x] `PriceRepairControllerTest::repair-splits is allowed for the default mock token (carries admin scope)` — token from `mockAuthConfig.getUserToken()` (which grants admin) passes the gate (404 on the non-seeded asset id).
- [x] `./gradlew testSmart && formatKotlin && lintKotlin` BUILD SUCCESSFUL.
- [ ] Companion bc-view PR adds the admin-visible "Repair splits" button on the price chart popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Security
* The repair-splits endpoint is now restricted to admin and system users, preventing unauthorized access to critical operations.

## Tests
* Added authorization verification tests for the repair-splits endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->