### PR TITLE
ci: force JS actions onto Node 24 ahead of Node 20 removal

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -16,6 +16,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: monowai/eclipse-temurin
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   docker:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,6 +17,12 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Cancel an in-flight review if a new commit lands on the same PR.
 concurrency:
   group: code-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,12 @@ on:
           - debug
           - trace
 
+env:
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at workflow scope to `build-base-image.yml`, `code-review.yml`, and `renovate.yml`
- GitHub is removing Node 20 from GHA runners; the env var forces JS-based actions still pinned to `runs-using: node20` onto the Node 24 shim
- Docker gating that bc-view applied separately is already correct here — `build-base-image.yml` is restricted to `branches: [main]` + `workflow_dispatch`

## Reference
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan
- [ ] PR build: `code-review` workflow runs without Node 20 deprecation warnings
- [ ] Manual `workflow_dispatch` on `build-base-image.yml`: completes through to manifest push
- [ ] Next scheduled `renovate.yml` run: no Node deprecation failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)