### PR TITLE
ci: bump actions/checkout to v5 (native Node 24)

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -16,6 +16,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: monowai/eclipse-temurin
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   docker:

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -34,7 +34,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract Sentry version from Dockerfile
         id: sentry
@@ -79,7 +79,7 @@ jobs:
     needs: docker
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract Sentry version from Dockerfile
         id: sentry

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Checkout PR head
         if: steps.gate.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full history so `git diff <base>...HEAD` works
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,6 +17,12 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Cancel an in-flight review if a new commit lands on the same PR.
 concurrency:
   group: code-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.14

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,12 @@ on:
           - debug
           - trace
 
+env:
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Follow-up to #880. Bumps `actions/checkout@v4` → `@v5` across all three workflows. v5 is the first major declaring `runs-using: node24`, so it no longer relies on the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` shim added in #880.

## Why not bump the other actions in the same pass?
The remaining third-party actions in these workflows still pin `node20` upstream:

- `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v6`
- `renovatebot/github-action@v43.0.14`
- `anthropics/claude-code-action@v1` (composite, depends on others)

Bumping any of those to their latest major brings behavioural changes beyond a Node runtime swap, so they're left for separate PRs (likely via Renovate) — the FORCE flag added in #880 stays as the shim for them.

## Test plan
- [ ] `code-review` workflow runs on this PR — confirm no failures
- [ ] Next scheduled `renovate.yml` run picks up the bump cleanly
- [ ] Next `build-base-image.yml` dispatch builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to force JavaScript actions to Node 24 compatibility mode
  * Updated checkout action version across automated workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->