### PR TITLE
fix(svc-data): hydrate Asset on cached events to stop /events 500

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataRepo.kt
@@ -107,6 +107,13 @@ interface MarketDataRepo : CrudRepository<MarketData, String> {
 
     /**
      * Find stored prices that represent corporate events (dividend or split).
+     *
+     * Callers must hydrate `MarketData.asset` (set `Asset.market` from
+     * `marketCode` via [com.beancounter.marketdata.assets.AssetFinder.hydrateAsset])
+     * before returning to JSON, otherwise Jackson NPEs on the transient `market`
+     * field — see [com.beancounter.marketdata.providers.alpha.AlphaEventService] and
+     * [com.beancounter.marketdata.providers.eodhd.EodhdEventService] for the
+     * reference pattern.
      */
     @Query(
         "SELECT md FROM MarketData md WHERE md.asset.id = :assetId AND (md.dividend > 0 OR md.split <> 1)"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaEventService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaEventService.kt
@@ -44,7 +44,12 @@ class AlphaEventService(
         // Only fetch events for markets supported by Alpha Vantage
         if (!isMarketSupported(asset.market.code)) {
             log.debug("Market {} not supported by Alpha, checking stored prices for {}", asset.market.code, asset.code)
-            return PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
+            val events = marketDataRepo.findEventsByAssetId(asset.id)
+            // Reuse the caller's already-hydrated Asset — the entities returned by the
+            // repo carry an Asset where `market` is null (transient field), which would
+            // NPE during Jackson serialization on the events endpoint.
+            events.forEach { it.asset = asset }
+            return PriceResponse(events)
         }
         val json =
             alphaGateway.getAdjusted(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
@@ -37,7 +37,12 @@ class EodhdEventService(
     fun getEvents(asset: Asset): PriceResponse {
         if (!isMarketSupported(asset.market.code)) {
             log.debug("Market {} not supported by EODHD; falling back to repo for {}", asset.market.code, asset.code)
-            return PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
+            val events = marketDataRepo.findEventsByAssetId(asset.id)
+            // Reuse the caller's already-hydrated Asset — the entities returned by the
+            // repo carry an Asset where `market` is null (transient field), which would
+            // NPE during Jackson serialization on the events endpoint.
+            events.forEach { it.asset = asset }
+            return PriceResponse(events)
         }
         val symbol = eodhdConfig.getPriceCode(asset)
         val divs = eodhdProxy.getDividends(symbol, eodhdConfig.apiKey).map { toDividendRow(asset, it) }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaEventServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaEventServiceTest.kt
@@ -84,6 +84,32 @@ class AlphaEventServiceTest {
     }
 
     @Test
+    fun `repo-fallback events reuse the hydrated caller asset so market is never null`() {
+        // Reproduces the kauri 500 on /api/prices/{assetId}/events for NZX assets.
+        // Asset.market is @Transient, so MarketData rows returned by the repo
+        // arrive with `asset.market == null`. The service must re-attach the
+        // caller's hydrated Asset before returning, otherwise Jackson NPEs.
+        val nzxMarket = Market("NZX")
+        val hydratedAsset = Asset(id = "vct-id", code = "VCT", market = nzxMarket)
+
+        val orphanAsset = Asset(id = "vct-id", code = "VCT", market = Market("UNKNOWN"))
+        val event =
+            com.beancounter.common.model
+                .MarketData(asset = orphanAsset, priceDate = java.time.LocalDate.now())
+                .also { it.dividend = java.math.BigDecimal("0.5") }
+
+        `when`(alphaConfig.markets).thenReturn("US,NASDAQ,AMEX,NYSE,LON")
+        `when`(marketDataRepo.findEventsByAssetId(hydratedAsset.id)).thenReturn(listOf(event))
+
+        val result = alphaEventService.getEvents(hydratedAsset)
+
+        assertThat(result.data).hasSize(1)
+        val returned = result.data.first()
+        assertThat(returned.asset).isSameAs(hydratedAsset)
+        assertThat(returned.asset.market).isEqualTo(nzxMarket)
+    }
+
+    @Test
     fun `should return empty response when markets config is null`() {
         // Given: An asset with any market
         val market = Market("US")


### PR DESCRIPTION
## Summary
Repairs the `/api/prices/{assetId}/events` endpoint for assets whose market falls into the DB-cache fallback path (NZX, SGX, PRIVATE, etc.). Source of the EVENT-1F Sentry issue.

## Root cause
`Asset.market` is `@Transient`, so Hibernate hydrates `MarketData` rows returned by `findEventsByAssetId` with `asset.market == null`. Jackson then NPEs serialising the response. The NPE happens below Spring's error-handling filter, so bc-data emits a content-less 500 with no stack trace in its own logs — visible only downstream as the bc-event scheduled-job Sentry breadcrumb.

In production this surfaced as VCT/NZX 500s twelve times over the 2026-05-15 → 2026-05-22 window (no users impacted, but constant `EventSchedule.loadNewEvents` retry noise).

## Fix
Both `AlphaEventService` and `EodhdEventService` already receive a fully-hydrated `Asset` from `EventServiceFacade`. In the repo-fallback branch, attach that hydrated asset to each returned `MarketData` so the JSON response has a non-null market.

`MarketDataRepo.findEventsByAssetId` doc now spells out the hydration contract so the next event provider that adopts the same fallback gets it right.

## How we've been "getting" NZ events
There is no marketstack event service. NZX/SGX events live in `MarketData` rows written piggyback by the marketstack price refresh — the mstack EOD payload includes `dividend`/`split` columns alongside the daily close. The `/events` endpoint then reads those rows back. Until this fix the read side was broken, so bc-event saw no events for NZ assets even though the data was sitting in the table.

## Test plan
- [ ] CI green (testSmart + lintKotlin)
- [ ] New `AlphaEventServiceTest` case pins the contract: result rows reuse the caller's hydrated asset, market non-null
- [ ] Existing `EodhdEventServiceTest` / `EventServiceFacadeTest` / `AlphaEventServiceTest` cases unchanged
- [ ] Post-deploy: `curl -H "Authorization: Bearer …" http://kauri:30610/api/prices/D0MeoiAPRqiXvXPTI2jkIw/events` returns 200
- [ ] Mark EVENT-1F resolved in Sentry after next successful `EventSchedule.loadNewEvents` cycle

Fixes EVENT-1F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization errors that occurred during market data operations when using fallback data sources by ensuring assets are properly hydrated before returning results, preventing errors related to missing market information.

* **Documentation**
  * Added clarification on asset hydration requirements for market data results.

* **Tests**
  * Added test coverage for market data retrieval fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->