### PR TITLE
refactor(svc-data): drop manual hydrateAsset on save paths via @PostPersist/@PostUpdate

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetEntityListener.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetEntityListener.kt
@@ -3,14 +3,27 @@ package com.beancounter.marketdata.assets
 import com.beancounter.common.model.Asset
 import com.beancounter.marketdata.markets.MarketService
 import jakarta.persistence.PostLoad
+import jakarta.persistence.PostPersist
+import jakarta.persistence.PostUpdate
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.stereotype.Component
 
 /**
- * Populates the `@Transient` fields on [Asset] every time JPA loads one
- * (`@PostLoad`). Replaces the historical pattern of calling
- * `AssetFinder.hydrateAsset(...)` at every read site — Hibernate now wires
- * `market` and `assetCategory` for callers automatically.
+ * Populates the `@Transient` fields on [Asset] every time Hibernate hands one
+ * back to the application. Covers all three lifecycle hooks:
+ *
+ *  - `@PostLoad`    fires after a fresh load from the DB (find / query).
+ *  - `@PostPersist` fires after `em.persist()` — initial insert path.
+ *  - `@PostUpdate`  fires after a managed entity flushes a change — covers
+ *                   the `em.merge()` route Spring Data uses for `save()` on
+ *                   application-assigned ids (Asset.id is set at creation).
+ *
+ * Without `@PostPersist` / `@PostUpdate`, the entity returned by `save()`
+ * would carry null `market` / `assetCategory`, and the controller layer
+ * would serialise it straight to JSON — the EVENT-1F class of bug. With all
+ * three hooks the manual `AssetFinder.hydrateAsset` calls on save paths
+ * become unnecessary; the method survives only for in-process Asset
+ * construction (e.g. enricher output passed into save).
  *
  * Registered via `META-INF/orm.xml` so jar-common keeps no svc-data dependency.
  * Spring's `SpringBeanContainer` (default in Spring Boot 3) supplies the
@@ -26,6 +39,8 @@ class AssetEntityListener(
     private val assetCategoryConfigProvider: ObjectProvider<AssetCategoryConfig>
 ) {
     @PostLoad
+    @PostPersist
+    @PostUpdate
     fun hydrate(asset: Asset) {
         if (asset.marketCode.isNotBlank()) {
             asset.market = marketServiceProvider.getObject().getMarket(asset.marketCode)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
@@ -1,8 +1,8 @@
 package com.beancounter.marketdata.assets
 
 import com.beancounter.common.model.Asset
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 import java.util.Optional
 import java.util.stream.Stream
@@ -10,7 +10,7 @@ import java.util.stream.Stream
 /**
  * CRUD interface for Asset details.
  */
-interface AssetRepository : CrudRepository<Asset, String> {
+interface AssetRepository : JpaRepository<Asset, String> {
     @Query(
         "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
             "WHERE a.marketCode = :marketCode"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -92,11 +92,12 @@ class AssetService(
             )
         if (marketService.canPersist(market)) {
             return try {
-                // save() calls em.merge() because Asset.id is application-assigned;
-                // merge returns a NEW managed instance with transient `market` /
-                // `assetCategory` cleared. AssetEntityListener.@PostLoad does not fire
-                // on merge, so we hydrate explicitly here.
-                assetFinder.hydrateAsset(assetRepository.save(eAsset))
+                // saveAndFlush forces an immediate flush so AssetEntityListener
+                // (@PostPersist / @PostUpdate) fires inline and rehydrates the
+                // managed instance's `@Transient` fields. Plain save() defers the
+                // flush to transaction commit, so callers inside @Transactional
+                // boundaries would see a null `market`.
+                assetRepository.saveAndFlush(eAsset)
             } catch (_: DataIntegrityViolationException) {
                 // Race condition: another request created this asset concurrently
                 // Use new transaction as current one is marked for rollback
@@ -187,8 +188,8 @@ class AssetService(
                         assetInput = assetInput
                     )
             try {
-                // See findOrCreate for save() → merge() rationale.
-                assetFinder.hydrateAsset(assetRepository.save(asset))
+                // saveAndFlush — see findOrCreate above for rationale.
+                assetRepository.saveAndFlush(asset)
             } catch (_: DataIntegrityViolationException) {
                 // Race condition: another request created this asset concurrently
                 // Use new transaction as current one is marked for rollback
@@ -215,9 +216,9 @@ class AssetService(
             assetRepository.findById(assetId).orElseThrow {
                 NotFoundException("Asset not found: $assetId")
             }
-        // findById is @PostLoad-hydrated; copy preserves transient fields. save()
-        // goes through merge() so we hydrate the returned managed instance.
-        return assetFinder.hydrateAsset(assetRepository.save(asset.copy(status = status)))
+        // saveAndFlush so AssetEntityListener (@PostUpdate) fires inline and
+        // hydrates the managed instance before we hand it back to the caller.
+        return assetRepository.saveAndFlush(asset.copy(status = status))
     }
 
     companion object {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/OwnedAssetService.kt
@@ -129,9 +129,9 @@ class OwnedAssetService(
         }
         // Update expected return rate for retirement projections
         assetInput.expectedReturnRate?.let { asset.expectedReturnRate = it }
-        // save() goes through em.merge() — returned managed instance loses transient
-        // fields. AssetEntityListener.@PostLoad does not fire on merge, so re-hydrate.
-        return assetFinder.hydrateAsset(assetRepository.save(asset))
+        // saveAndFlush — AssetEntityListener (@PostUpdate) needs an immediate
+        // flush to rehydrate transient fields on the managed instance.
+        return assetRepository.saveAndFlush(asset)
     }
 
     /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetEntityListenerIntegrationTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetEntityListenerIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.beancounter.marketdata.assets
 
 import com.beancounter.common.contracts.AssetRequest
 import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.Status
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.SpringMvcDbTest
 import org.assertj.core.api.Assertions.assertThat
@@ -54,5 +55,37 @@ class AssetEntityListenerIntegrationTest {
         assertThat(reloaded.market.code).isEqualTo(NASDAQ.code)
         assertThat(reloaded.market.currency).isNotNull
         assertThat(reloaded.assetCategory).isNotNull
+    }
+
+    @Test
+    fun `Asset returned from save has market hydrated by @PostPersist or @PostUpdate listener`() {
+        // Spring Data save() routes through em.merge() for application-assigned
+        // ids; the returned managed instance has its `@Transient` fields cleared.
+        // @PostPersist (initial insert) and @PostUpdate (subsequent updates)
+        // re-populate them so callers do not need to call hydrateAsset manually.
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "SAVED" to
+                                AssetInput(
+                                    market = NASDAQ.code,
+                                    code = "SAVED",
+                                    name = "Saved Hydrated"
+                                )
+                        )
+                    )
+                ).data.values
+                .first()
+
+        // Status change forces an @PostUpdate path via assetService.updateStatus,
+        // which calls assetRepository.save on the modified copy.
+        val updated = assetService.updateStatus(asset.id, Status.Inactive)
+
+        assertThat(updated.status).isEqualTo(Status.Inactive)
+        assertThat(updated.market.code).isEqualTo(NASDAQ.code)
+        assertThat(updated.market.currency).isNotNull
+        assertThat(updated.assetCategory).isNotNull
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetEntityListenerIntegrationTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetEntityListenerIntegrationTest.kt
@@ -79,6 +79,11 @@ class AssetEntityListenerIntegrationTest {
                 ).data.values
                 .first()
 
+        // The initial save returns the @PostPersist-hydrated managed instance.
+        assertThat(asset.market.code).isEqualTo(NASDAQ.code)
+        assertThat(asset.market.currency).isNotNull
+        assertThat(asset.assetCategory).isNotNull
+
         // Status change forces an @PostUpdate path via assetService.updateStatus,
         // which calls assetRepository.save on the modified copy.
         val updated = assetService.updateStatus(asset.id, Status.Inactive)


### PR DESCRIPTION
## Summary
Finishes the AssetEntityListener story started in #883. Eliminates the last 4 manual `hydrateAsset` calls on save paths by adding `@PostPersist` and `@PostUpdate` callbacks to the listener.

Closes the EVENT-1F bug class end-to-end: no save path can hand back an Asset with null transient `market` / `assetCategory`, and no caller has to remember to hydrate.

## Scope correction (vs. earlier "PR-B" sketch)
The original PR-B plan called for a full AssetEntity / Asset split. Audit found the cost: 20 `@Entity` classes in `jar-common` doubling as DTOs across 5 services, ~100+ files touched. ROI is low now that `@PostLoad` already neutralised the bug class — opted for this surgical follow-up instead.

## Subtlety the integration tests surfaced

`@PostPersist` and `@PostUpdate` fire at **flush**, not at `save()`. Inside a `@Transactional` boundary, `save()` defers flush to commit, so the returned managed instance still carried `null market` until the transaction ended (`AssetStatusTest` blew up on `Asset.copy(status=...)` because `market` is non-nullable). Fix: the four save sites now call `saveAndFlush` so the listener fires inline. `AssetRepository` is promoted from `CrudRepository` to `JpaRepository` to expose the method.

## Files changed
- `AssetEntityListener.kt` — `@PostPersist` + `@PostUpdate` added alongside `@PostLoad`. Docstring spells out which lifecycle covers what.
- `AssetRepository.kt` — `JpaRepository<Asset, String>`.
- `AssetService.findOrCreate` / private `create` / `updateStatus`: `save → saveAndFlush`, manual hydrate wrappers gone.
- `OwnedAssetService.updateOwnedAsset`: same.
- `AssetEntityListenerIntegrationTest`: new test pinning the contract that a save-path-returned Asset has `market` + `assetCategory` populated.

## `hydrateAsset` status
Dead in production code. Kept on `AssetFinder` for tests + any future in-process Asset construction outside JPA. Pruning is a separate cleanup once unit-test mocks are migrated.

## Verification
- `./gradlew testSmart` passes
- `./gradlew formatKotlin lintKotlin` clean
- `AssetEntityListenerIntegrationTest` covers both `@PostLoad` and `@PostPersist`/`@PostUpdate` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset data (market, currency, category, status) is now consistently populated immediately after creation and after status updates, ensuring managed instances returned from persistence operations are fully hydrated.

* **Tests**
  * Added an integration test that verifies assets are hydrated after save and update paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->