### PR TITLE
feat(svc-agent): aggregated-positions tool for cross-portfolio AI review

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -100,6 +100,14 @@ object DomainSystemPrompts {
         - `listPortfolios` — every portfolio the user owns. Metadata +
           portfolio-level XIRR.
         - `getPortfolio(code)` — portfolio metadata + XIRR by user-facing code.
+        - `getAggregatedPositions(codes, asAt?)` — use this whenever the
+          page context carries `portfolioCodes` (plural). It returns a
+          SINGLE merged dataset across all the listed portfolios in the
+          same columnar shape as `getPositions`, but WITHOUT the `weight`
+          column. Treat the response as one combined portfolio: never
+          call `getPositions` per code and stitch the results, never
+          narrate per-portfolio breakdowns or which holding belongs to
+          which portfolio.
         - `getPositions(code, asAt?)` — positions in a compact columnar
           shape: `cols` lists field names once and each entry of `rows`
           is an array aligned to `cols` (rows[i][j] is cols[j] for the

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -131,7 +131,6 @@ object DomainSystemPrompts {
             Useful when explaining stale or dormant holdings.
           - `lastDividend` — ISO date of the most recent dividend
             (null if never paid one). Useful for income commentary.
-          - `closed` — true when quantity is zero.
           Show ratios as percentages when discussing performance. ROI,
           dividend yield, and trade currency are not exposed — never
           claim them.
@@ -164,13 +163,16 @@ object DomainSystemPrompts {
 
         ### Closed positions
 
-        Never mention, count, list, or comment on closed positions
-        (`closed = true`) — not even in passing, not even as a count or
-        footnote. Filter them out silently before any analysis.
+        Closed (zero-quantity) positions are filtered out before the tool
+        result reaches you — every row in `rows` represents an open
+        holding. Do not infer, list, count, or comment on closed
+        holdings; the absence of a holding from the response does NOT
+        mean it was sold.
 
         The only exception: the user has explicitly asked about closed,
-        sold, exited, or historical holdings. In that case, address those
-        positions directly.
+        sold, exited, or historical holdings. In that case, say plainly
+        that the positions tool returns only open holdings and that
+        closed history is not available in this view.
         """.trimIndent()
 
     /**

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/client/PositionClient.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/client/PositionClient.kt
@@ -49,4 +49,31 @@ class PositionClient(
             .retrieve()
             .body<PositionResponse>()
             ?: PositionResponse()
+
+    /**
+     * Aggregated positions across the listed portfolio codes (or every
+     * portfolio the user owns when [codes] is empty). svc-position merges
+     * positions for the same asset across all selected portfolios server-
+     * side, so the response shape matches a single-portfolio call.
+     */
+    fun getAggregatedPositions(
+        codes: List<String>,
+        asAt: String = "today",
+        includeValues: Boolean = true
+    ): PositionResponse {
+        val joined = codes.joinToString(",")
+        return restClient
+            .get()
+            .uri { builder ->
+                builder
+                    .path("/aggregated")
+                    .queryParam("asAt", asAt)
+                    .queryParam("value", includeValues)
+                    .also { if (joined.isNotEmpty()) it.queryParam("codes", joined) }
+                    .build()
+            }.header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+            .retrieve()
+            .body<PositionResponse>()
+            ?: PositionResponse()
+    }
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/PositionTools.kt
@@ -41,6 +41,29 @@ class PositionTools(
     ): ScrubbedPositionResponse =
         scrubber.scrub(positionClient.getPositionsById(portfolioId, asAt, includeValues = true))
 
+    @Tool(description = POSITIONS_AGGREGATED_DESC)
+    fun getAggregatedPositions(
+        @ToolParam(
+            description =
+                "Comma-separated list of portfolio codes to aggregate, e.g. 'TYLER,PSE'. " +
+                    "Empty string aggregates EVERY portfolio the user owns. " +
+                    "Use this whenever the page context exposes `portfolioCodes` (plural). " +
+                    "The response merges positions for the same asset across all listed " +
+                    "portfolios — treat it as a single combined dataset and do NOT narrate " +
+                    "per-portfolio breakdowns; the `weight` column is intentionally absent."
+        ) portfolioCodes: String,
+        @ToolParam(description = "Valuation date YYYY-MM-DD or 'today'") asAt: String = "today"
+    ): ScrubbedPositionResponse {
+        val codes =
+            portfolioCodes
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+        return scrubber.scrubAggregated(
+            positionClient.getAggregatedPositions(codes, asAt, includeValues = true)
+        )
+    }
+
     companion object {
         const val POSITIONS_DESC =
             "Get the positions for a portfolio identified by its code. " +
@@ -77,5 +100,13 @@ class PositionTools(
                 "the page context exposes `portfolioId` (managed/shared portfolios). " +
                 "The by-code tool 404s for shared portfolios because portfolio " +
                 "code is unique only within an owner."
+        const val POSITIONS_AGGREGATED_DESC =
+            "Get a SINGLE merged position dataset across the listed portfolios. " +
+                "Same columnar shape as getPositions BUT the `weight` column is " +
+                "absent — per-position portfolio weight has no single denominator " +
+                "once positions are aggregated. Use this tool whenever the page " +
+                "context carries `portfolioCodes` (plural); never loop getPositions " +
+                "per code and stitch the results yourself. The response represents " +
+                "ONE combined portfolio — do not narrate per-portfolio breakdowns."
     }
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/ScrubbedDtos.kt
@@ -73,6 +73,13 @@ data class ScrubbedPositionResponse(
                 "lastTrade",
                 "lastDividend"
             )
+
+        // Aggregated reviews drop `weight` — once positions are merged across
+        // portfolios the per-position weight has no single denominator, and
+        // the LLM was burning tokens narrating per-portfolio breakdowns.
+        // The remaining columns match COLS in order so prompts can describe
+        // the schema once and reference both views.
+        val COLS_AGGREGATED: List<String> = COLS.filterNot { it == "weight" }
     }
 }
 
@@ -92,7 +99,20 @@ class ResponseScrubber {
 
     fun scrub(response: PortfoliosResponse): List<ScrubbedPortfolio> = response.data.map(::scrub)
 
-    fun scrub(response: PositionResponse): ScrubbedPositionResponse {
+    fun scrub(response: PositionResponse): ScrubbedPositionResponse = scrubInternal(response, includeWeight = true)
+
+    /**
+     * Aggregated-portfolio variant. Drops the `weight` column from both
+     * `cols` and every row — see [ScrubbedPositionResponse.COLS_AGGREGATED]
+     * for the rationale.
+     */
+    fun scrubAggregated(response: PositionResponse): ScrubbedPositionResponse =
+        scrubInternal(response, includeWeight = false)
+
+    private fun scrubInternal(
+        response: PositionResponse,
+        includeWeight: Boolean
+    ): ScrubbedPositionResponse {
         val positions = response.data
         // Drop closed (zero-quantity) rows server-side so the LLM never sees
         // them. Earlier the system prompt asked the LLM to filter silently;
@@ -101,7 +121,7 @@ class ResponseScrubber {
         val openRows =
             positions.positions.values
                 .filter { it.quantityValues.getTotal().signum() != 0 }
-                .map(::scrubPositionRow)
+                .map { scrubPositionRow(it, includeWeight) }
         return ScrubbedPositionResponse(
             portfolioCode = positions.portfolio.code,
             portfolioName = positions.portfolio.name,
@@ -112,27 +132,46 @@ class ResponseScrubber {
                 positions.totals[Position.In.PORTFOLIO]
                     ?.irr
                     ?.toNullableDouble(),
+            cols =
+                if (includeWeight) {
+                    ScrubbedPositionResponse.COLS
+                } else {
+                    ScrubbedPositionResponse.COLS_AGGREGATED
+                },
             rows = openRows
         )
     }
 
-    private fun scrubPositionRow(position: Position): List<Any?> {
+    private fun scrubPositionRow(
+        position: Position,
+        includeWeight: Boolean = true
+    ): List<Any?> {
         val portfolioBucket = position.moneyValues[Position.In.PORTFOLIO]
         val price = portfolioBucket?.priceData
         val asset = position.asset
-        return listOf(
-            asset.code,
-            asset.name,
-            asset.market.code,
-            price?.close?.toNullableDouble(),
-            price?.changePercent?.toNullableDouble(),
-            portfolioBucket?.irr?.toNullableDouble(),
-            portfolioBucket?.weight?.toDouble() ?: 0.0,
-            asset.category,
-            position.dateValues.opened?.toString(),
-            position.dateValues.last?.toString(),
-            position.dateValues.lastDividend?.toString()
-        )
+        val base =
+            listOf(
+                asset.code,
+                asset.name,
+                asset.market.code,
+                price?.close?.toNullableDouble(),
+                price?.changePercent?.toNullableDouble(),
+                portfolioBucket?.irr?.toNullableDouble()
+            )
+        val weightCol: List<Any?> =
+            if (includeWeight) {
+                listOf(portfolioBucket?.weight?.toDouble() ?: 0.0)
+            } else {
+                emptyList()
+            }
+        val tail =
+            listOf(
+                asset.category,
+                position.dateValues.opened?.toString(),
+                position.dateValues.last?.toString(),
+                position.dateValues.lastDividend?.toString()
+            )
+        return base + weightCol + tail
     }
 }
 

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/PositionToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/PositionToolsTest.kt
@@ -1,0 +1,79 @@
+package com.beancounter.agent.tools
+
+import com.beancounter.agent.client.PositionClient
+import com.beancounter.common.contracts.PositionResponse
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Currency
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Position
+import com.beancounter.common.model.Positions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.math.BigDecimal
+
+/**
+ * Confirms [PositionTools] delegates correctly and exposes an aggregated
+ * variant that the LLM uses when reviewing holdings across many portfolios.
+ */
+class PositionToolsTest {
+    private val usd = Currency("USD")
+    private val nzd = Currency("NZD")
+    private val nasdaq = Market("NASDAQ", "NASDAQ", currencyId = "USD", currency = usd)
+    private val portfolio =
+        Portfolio(
+            id = "pf-1",
+            code = "AGG",
+            name = "Aggregated",
+            currency = nzd,
+            base = usd,
+            marketValue = BigDecimal("500000.00"),
+            irr = BigDecimal("0.11")
+        )
+    private val scrubber = ResponseScrubber()
+
+    private fun samplePositions(): Positions {
+        val asset = Asset(code = "AAPL", market = nasdaq, category = "Equity")
+        val position = Position(asset, portfolio)
+        position.quantityValues.purchased = BigDecimal("50")
+        val money = position.getMoneyValues(Position.In.PORTFOLIO)
+        money.weight = BigDecimal("0.125")
+        money.irr = BigDecimal("0.14")
+        return Positions(portfolio).apply {
+            add(position)
+            asAt = "2026-04-16"
+        }
+    }
+
+    @Test
+    fun `getAggregatedPositions delegates to client and scrubs without weight`() {
+        val client =
+            mock<PositionClient> {
+                on { getAggregatedPositions(listOf("A", "B"), "today") } doReturn
+                    PositionResponse(samplePositions())
+            }
+        val tools = PositionTools(client, scrubber)
+
+        val result = tools.getAggregatedPositions("A,B", "today")
+
+        assertThat(result.cols).doesNotContain("weight")
+        assertThat(result.rows).hasSize(1)
+        assertThat(result.cols).contains("assetCode", "xirr", "category")
+    }
+
+    @Test
+    fun `getAggregatedPositions tolerates spaces and empty entries in code list`() {
+        val client =
+            mock<PositionClient> {
+                on { getAggregatedPositions(listOf("A", "B"), "today") } doReturn
+                    PositionResponse(samplePositions())
+            }
+        val tools = PositionTools(client, scrubber)
+
+        val result = tools.getAggregatedPositions(" A , , B ", "today")
+
+        assertThat(result.rows).hasSize(1)
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
@@ -205,7 +205,13 @@ class ResponseScrubberTest {
         val row = scrubbed.rows.single()
         assertThat(row).hasSize(scrubbed.cols.size)
         val codeIdx = scrubbed.cols.indexOf("assetCode")
+        val xirrIdx = scrubbed.cols.indexOf("xirr")
+        val categoryIdx = scrubbed.cols.indexOf("category")
+        val priceIdx = scrubbed.cols.indexOf("priceClose")
         assertThat(row[codeIdx]).isEqualTo("AAPL")
+        assertThat(row[xirrIdx]).isEqualTo(0.14)
+        assertThat(row[categoryIdx]).isEqualTo("Equity")
+        assertThat(row[priceIdx]).isEqualTo(178.50)
     }
 
     @Test

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/ResponseScrubberTest.kt
@@ -163,6 +163,52 @@ class ResponseScrubberTest {
     }
 
     @Test
+    fun `scrubAggregated drops weight column from cols and rows`() {
+        // Aggregated reviews collapse N portfolios into a single dataset
+        // for the LLM. The per-position portfolio weight is meaningless
+        // once positions are aggregated across portfolios (each position
+        // can have a different denominator), and the LLM was observed
+        // wasting tokens narrating per-portfolio breakdowns. Drop weight
+        // server-side so the input matches a single-portfolio view.
+        val asset = Asset(code = "AAPL", market = nasdaq, category = "Equity")
+        val position = Position(asset, portfolio)
+        position.quantityValues.purchased = BigDecimal("50")
+        val money = position.getMoneyValues(Position.In.PORTFOLIO)
+        money.weight = BigDecimal("0.125")
+        money.irr = BigDecimal("0.14")
+        money.priceData =
+            PriceData(
+                priceDate = LocalDate.parse("2026-04-15"),
+                close = BigDecimal("178.50"),
+                changePercent = BigDecimal("0.012")
+            )
+
+        val positions = Positions(portfolio).apply { add(position) }
+        positions.asAt = "2026-04-16"
+
+        val scrubbed = scrubber.scrubAggregated(PositionResponse(positions))
+
+        assertThat(scrubbed.cols).doesNotContain("weight")
+        assertThat(scrubbed.cols)
+            .containsExactly(
+                "assetCode",
+                "assetName",
+                "market",
+                "priceClose",
+                "changePercent",
+                "xirr",
+                "category",
+                "opened",
+                "lastTrade",
+                "lastDividend"
+            )
+        val row = scrubbed.rows.single()
+        assertThat(row).hasSize(scrubbed.cols.size)
+        val codeIdx = scrubbed.cols.indexOf("assetCode")
+        assertThat(row[codeIdx]).isEqualTo("AAPL")
+    }
+
+    @Test
     fun `zero-quantity positions are filtered out before reaching the LLM`() {
         // Closed (zero-quantity) positions clutter analysis prompts and the
         // LLM has been observed surfacing them in commentary even when the


### PR DESCRIPTION
## Summary
- Adds `getAggregatedPositions(portfolioCodes, asAt)` to svc-agent's `PositionTools`. The aggregated-holdings page already sends `portfolioCodes: [...]` in the AI Review request context, but the LLM had no tool that merged them — it was either looping `getPositions` per code or narrating per-portfolio breakdowns.
- New `PositionClient.getAggregatedPositions(codes, asAt)` delegates to svc-position's existing `GET /aggregated?codes=…&asAt=…&value=true`.
- New `ResponseScrubber.scrubAggregated(response)` drops the `weight` column from both `cols` and rows (`COLS_AGGREGATED`). Per-position portfolio weight has no single denominator once positions span portfolios; the LLM was burning tokens on per-portfolio breakdowns the user explicitly asked to suppress.
- `DomainSystemPrompts.WEALTH` now directs the LLM to use the aggregated tool whenever the context exposes `portfolioCodes` (plural) and to treat the dataset as one combined portfolio.

## Test plan
- [x] `./gradlew :svc-agent:test` passes (new `PositionToolsTest`, extended `ResponseScrubberTest`)
- [x] `./gradlew :svc-agent:formatKotlin :svc-agent:lintKotlin` clean
- [x] Semgrep scan on touched Kotlin files — no findings
- [ ] Manual: open Aggregated Holdings on kauri, click AI Summary; confirm the LLM produces a single combined narrative (no per-portfolio breakdown commentary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View aggregated positions across multiple portfolios as a single merged dataset (consolidated holdings/analytics).
* **Behavior Changes / Bug Fixes**
  * Aggregated view omits the per-position "weight" column.
  * Positions view now filters out closed (zero-quantity) holdings; closed/sold history is not shown in this view and must be requested separately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->