### PR TITLE
fix: pension zero-gain + share viewer can read asset config

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -2,6 +2,9 @@ package com.beancounter.marketdata.assets
 
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.model.ShareStatus
+import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
 import jakarta.transaction.Transactional
@@ -22,7 +25,8 @@ class PrivateAssetConfigService(
     private val configRepository: PrivateAssetConfigRepository,
     private val assetRepository: AssetRepository,
     private val systemUserService: SystemUserService,
-    private val trnRepository: TrnRepository
+    private val trnRepository: TrnRepository,
+    private val portfolioShareRepository: PortfolioShareRepository
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -57,9 +61,13 @@ class PrivateAssetConfigService(
     /**
      * Get config for a specific asset.
      * Returns null if no config exists.
+     *
+     * Read access is allowed for either the asset owner OR a viewer of any
+     * portfolio that holds transactions for the asset (active share). Writes
+     * remain owner-only via [verifyAssetOwnership].
      */
     fun getConfig(assetId: String): PrivateAssetConfigResponse? {
-        verifyAssetOwnership(assetId)
+        verifyAssetReadAccess(assetId)
         val config = configRepository.findById(assetId).orElse(null) ?: return null
         return PrivateAssetConfigResponse(config)
     }
@@ -346,5 +354,45 @@ class PrivateAssetConfigService(
         if (asset.systemUser?.id != user.id) {
             throw BusinessException("Asset not owned by current user")
         }
+    }
+
+    /**
+     * Read-only counterpart to [verifyAssetOwnership]. Allows the asset
+     * owner OR any user with an ACTIVE portfolio share covering a portfolio
+     * that holds transactions for this asset. Write paths must still call
+     * [verifyAssetOwnership].
+     */
+    private fun verifyAssetReadAccess(assetId: String) {
+        val user =
+            systemUserService.getActiveUser()
+                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
+
+        val asset =
+            assetRepository.findById(assetId).orElseThrow {
+                NotFoundException("Asset not found: $assetId")
+            }
+
+        if (asset.systemUser?.id == user.id) return
+        if (hasSharedPortfolioReadAccess(assetId, user)) return
+        throw BusinessException("Asset not accessible to current user")
+    }
+
+    private fun hasSharedPortfolioReadAccess(
+        assetId: String,
+        user: SystemUser
+    ): Boolean {
+        val sharedPortfolioIds =
+            portfolioShareRepository
+                .findBySharedWithAndStatus(
+                    user,
+                    ShareStatus.ACTIVE
+                ).mapNotNull { it.portfolio?.id }
+                .toSet()
+        if (sharedPortfolioIds.isEmpty()) return false
+        val assetIdsInSharedPortfolios =
+            trnRepository
+                .findDistinctAssetIdsByPortfolioIds(sharedPortfolioIds)
+                .toSet()
+        return assetId in assetIdsInSharedPortfolios
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
@@ -12,12 +12,12 @@ import com.beancounter.common.model.SystemUser
 import com.beancounter.marketdata.portfolio.PortfolioShareRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
-import org.mockito.kotlin.eq
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
@@ -4,9 +4,15 @@ import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.PortfolioShare
+import com.beancounter.common.model.ShareAccessLevel
+import com.beancounter.common.model.ShareStatus
 import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
+import org.mockito.kotlin.eq
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -24,6 +30,7 @@ class PrivateAssetConfigServiceTest {
     private lateinit var assetRepository: AssetRepository
     private lateinit var systemUserService: SystemUserService
     private lateinit var trnRepository: TrnRepository
+    private lateinit var portfolioShareRepository: PortfolioShareRepository
     private lateinit var configService: PrivateAssetConfigService
 
     private val userId = "user-123"
@@ -37,12 +44,14 @@ class PrivateAssetConfigServiceTest {
         assetRepository = mock()
         systemUserService = mock()
         trnRepository = mock()
+        portfolioShareRepository = mock()
         configService =
             PrivateAssetConfigService(
                 configRepository,
                 assetRepository,
                 systemUserService,
-                trnRepository
+                trnRepository,
+                portfolioShareRepository
             )
     }
 
@@ -366,6 +375,78 @@ class PrivateAssetConfigServiceTest {
 
         // $300 + $400 + $200 + $100 + $50 = $1050
         assertThat(totalExpenses).isEqualByComparingTo(BigDecimal("1050"))
+    }
+
+    @Test
+    fun `getConfig allows viewer of a shared portfolio that holds the asset`() {
+        // Regression: Edit Asset opened blank when adviser/share viewer
+        // opened a CPF/policy asset from a portfolio shared with them,
+        // because ownership-only verifyAssetOwnership threw on the GET.
+        val owner = SystemUser(id = "owner-789", email = "ruby@test.com")
+        val viewer = user
+        val asset = createTestAsset(ownerId = owner.id)
+        val sharedPortfolio =
+            Portfolio(
+                id = "pf-1",
+                code = "RUBY-SGD",
+                owner = owner,
+                currency = privateMarket.currency,
+                base = privateMarket.currency
+            )
+        val savedConfig =
+            PrivateAssetConfig(
+                assetId = assetId,
+                monthlyRentalIncome = BigDecimal("0"),
+                rentalCurrency = "SGD"
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(viewer)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(
+            portfolioShareRepository.findBySharedWithAndStatus(
+                eq(viewer),
+                eq(ShareStatus.ACTIVE),
+                any()
+            )
+        ).thenReturn(
+            listOf(
+                PortfolioShare(
+                    portfolio = sharedPortfolio,
+                    sharedWith = viewer,
+                    accessLevel = ShareAccessLevel.VIEW,
+                    status = ShareStatus.ACTIVE,
+                    createdBy = owner
+                )
+            )
+        )
+        whenever(trnRepository.findDistinctAssetIdsByPortfolioIds(setOf("pf-1")))
+            .thenReturn(listOf(assetId))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.of(savedConfig))
+
+        val response = configService.getConfig(assetId)
+
+        assertThat(response).isNotNull
+        assertThat(response!!.data.assetId).isEqualTo(assetId)
+    }
+
+    @Test
+    fun `getConfig throws when caller is neither owner nor active share viewer`() {
+        val owner = SystemUser(id = "owner-789", email = "ruby@test.com")
+        val viewer = user
+        val asset = createTestAsset(ownerId = owner.id)
+
+        whenever(systemUserService.getActiveUser()).thenReturn(viewer)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(
+            portfolioShareRepository.findBySharedWithAndStatus(
+                eq(viewer),
+                eq(ShareStatus.ACTIVE),
+                any()
+            )
+        ).thenReturn(emptyList())
+
+        assertThatThrownBy { configService.getConfig(assetId) }
+            .isInstanceOf(BusinessException::class.java)
     }
 
     @Test

--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
@@ -1,9 +1,12 @@
 package com.beancounter.position.accumulation
 
+import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.CashUtils
+import com.beancounter.common.utils.MathUtils
 import com.beancounter.position.utils.CurrencyResolver
 import com.beancounter.position.valuation.CashCost
 import org.springframework.stereotype.Service
@@ -15,7 +18,8 @@ import java.math.BigDecimal
  */
 @Service
 class BalanceBehaviour(
-    val currencyResolver: CurrencyResolver
+    val currencyResolver: CurrencyResolver,
+    private val cashUtils: CashUtils = CashUtils()
 ) : AccumulationStrategy {
     private val cashCost = CashCost()
     override val supportedType: TrnType
@@ -27,39 +31,74 @@ class BalanceBehaviour(
         position: Position
     ): Position {
         position.quantityValues.purchased = trn.tradeAmount
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.BASE,
-                trn.tradeCurrency,
-                trn.portfolio,
-                position
-            ),
+        val isCash = cashUtils.isCash(position.asset)
+        applyMoneyValues(
+            Position.In.BASE,
+            trn,
             position,
-            trn.tradeAmount,
-            trn.tradeBaseRate
+            trn.tradeBaseRate,
+            isCash
         )
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.PORTFOLIO,
-                trn.tradeCurrency,
-                trn.portfolio,
-                position
-            ),
+        applyMoneyValues(
+            Position.In.PORTFOLIO,
+            trn,
             position,
-            trn.tradeAmount,
-            trn.tradePortfolioRate
+            trn.tradePortfolioRate,
+            isCash
         )
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.TRADE,
-                trn.tradeCurrency,
-                trn.portfolio,
-                position
-            ),
+        applyMoneyValues(
+            Position.In.TRADE,
+            trn,
             position,
-            trn.tradeAmount,
-            BigDecimal.ZERO
-        ) // Trade to Cash Settlement ?
+            BigDecimal.ZERO,
+            isCash
+        )
         return position
+    }
+
+    private fun applyMoneyValues(
+        pool: Position.In,
+        trn: Trn,
+        position: Position,
+        rate: BigDecimal,
+        isCash: Boolean
+    ) {
+        val moneyValues =
+            currencyResolver.getMoneyValues(
+                pool,
+                trn.tradeCurrency,
+                trn.portfolio,
+                position
+            )
+        cashCost.value(
+            moneyValues,
+            position,
+            trn.tradeAmount,
+            rate
+        )
+        if (!isCash) {
+            setSnapshotCost(
+                moneyValues,
+                trn.tradeAmount,
+                rate
+            )
+        }
+    }
+
+    /**
+     * Non-cash BALANCE = snapshot of accumulated contributions. Cost basis
+     * tracks the snapshot amount so MV - cost = 0 by construction; this
+     * stops pension/CPF positions reporting a phantom 100% gain (the prior
+     * code reused CashCost which keeps cost at zero for cash semantics).
+     */
+    private fun setSnapshotCost(
+        moneyValues: MoneyValues,
+        tradeAmount: BigDecimal,
+        rate: BigDecimal
+    ) {
+        val amount = MathUtils.multiply(tradeAmount, rate) ?: return
+        moneyValues.costBasis = amount.abs()
+        moneyValues.costValue = amount.abs()
+        moneyValues.averageCost = BigDecimal.ONE
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -1,5 +1,8 @@
 package com.beancounter.position.accumulation
 
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Market
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
@@ -11,6 +14,7 @@ import com.beancounter.position.Constants.Companion.PROP_COST_BASIS
 import com.beancounter.position.Constants.Companion.PROP_COST_VALUE
 import com.beancounter.position.Constants.Companion.PROP_CURRENCY
 import com.beancounter.position.Constants.Companion.PROP_SALES
+import com.beancounter.position.Constants.Companion.SGD
 import com.beancounter.position.Constants.Companion.USD
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -79,6 +83,69 @@ class BalanceBehaviourTest {
         ).hasFieldOrPropertyWithValue(
             PROP_SALES,
             BigDecimal.ZERO
+        )
+    }
+
+    @Test
+    fun `policy Balance tracks cost equal to tradeAmount so gain is zero`() {
+        // Regression: pension/CPF positions loaded via a single BALANCE
+        // transaction reported a 100% gain because CashCost reset cost
+        // to zero. For non-cash assets, a BALANCE snapshot is both the
+        // contribution-to-date and the current value, so cost must equal
+        // tradeAmount (gain = MV - cost = 0).
+        val portfolio =
+            Portfolio(
+                Constants.TEST,
+                currency = SGD,
+                base = SGD
+            )
+        val cpfAsset =
+            Asset(
+                code = "RUBY-CPF",
+                id = "RUBY-CPF",
+                name = "Ruby CPF",
+                market = Market("PRIVATE"),
+                priceSymbol = "RUBY-CPF",
+                category = AssetCategory.POLICY
+            )
+        val balance = BigDecimal("250000.00")
+        val trn =
+            Trn(
+                trnType = TrnType.BALANCE,
+                asset = cpfAsset,
+                quantity = balance,
+                tradeAmount = balance,
+                cashCurrency = SGD,
+                tradeCurrency = SGD,
+                tradeCashRate = BigDecimal.ONE,
+                tradeBaseRate = BigDecimal.ONE,
+                tradePortfolioRate = BigDecimal.ONE,
+                portfolio = portfolio
+            )
+        val positions = Positions(portfolio)
+        val position =
+            accumulator.accumulate(
+                trn,
+                positions
+            )
+
+        assertThat(
+            position.getMoneyValues(Position.In.PORTFOLIO)
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_BASIS,
+            balance
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_VALUE,
+            balance
+        )
+        assertThat(
+            position.getMoneyValues(Position.In.BASE)
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_BASIS,
+            balance
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_VALUE,
+            balance
         )
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -30,6 +30,10 @@ class BalanceBehaviourTest {
     @Autowired
     private lateinit var accumulator: Accumulator
 
+    companion object {
+        private const val RUBY_CPF = "RUBY-CPF"
+    }
+
     @Test
     fun `cash Balance with no FX`() {
         val portfolio =
@@ -101,11 +105,11 @@ class BalanceBehaviourTest {
             )
         val cpfAsset =
             Asset(
-                code = "RUBY-CPF",
-                id = "RUBY-CPF",
+                code = RUBY_CPF,
+                id = RUBY_CPF,
                 name = "Ruby CPF",
                 market = Market("PRIVATE"),
-                priceSymbol = "RUBY-CPF",
+                priceSymbol = RUBY_CPF,
                 category = AssetCategory.POLICY
             )
         val balance = BigDecimal("250000.00")


### PR DESCRIPTION
## Summary
Two related fixes surfaced while reviewing a shared SGD portfolio.

### Bug A — phantom 100% gain on pension/CPF positions
`BalanceBehaviour` delegated to `CashCost` (which keeps cost at zero for cash semantics), so a BALANCE snapshot on a non-cash asset (POLICY/CPF) left `costBasis = 0`. Combined with `PrivateMarketDataProvider` pricing POLICY at 1.00, this produced `unrealisedGain = marketValue` — rendered as a 100% gain in the UI.

Fix: non-cash BALANCE sets `costBasis = costValue = tradeAmount`. Cash BALANCEs unchanged.

### Bug B — Edit Asset blank for share viewers
`PrivateAssetConfigService.getConfig` called the owner-only `verifyAssetOwnership`. An adviser viewing a client's shared portfolio could not load the CPF/policy config the Edit Asset dialog depends on.

Fix: read path uses new `verifyAssetReadAccess` which also permits ACTIVE `PortfolioShare` holders whose share covers a portfolio holding transactions for the asset. Writes still require ownership.

## Test plan
- [x] New unit tests in `BalanceBehaviourTest` (policy BALANCE → cost=trade=MV → gain=0)
- [x] New unit tests in `PrivateAssetConfigServiceTest` (shared viewer allowed; non-viewer denied)
- [x] `./gradlew testSmart formatKotlin lintKotlin` green
- [ ] Manual: open shared SGD portfolio, view pension position (expect ~0% gain), click Edit Asset (expect loaded values)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset configuration read access expanded—users with active shared portfolio access can now view asset configs (beyond owner-only)

* **Improvements**
  * Refined balance handling so non-cash/policy balances record snapshot cost fields, improving cost-basis and gain accuracy

* **Tests**
  * Added regression tests covering shared-portfolio read access and balance cost behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->