### PR TITLE
feat(svc-data): contributionFrequency on pension asset config

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/ContributionFrequency.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/ContributionFrequency.kt
@@ -1,0 +1,12 @@
+package com.beancounter.marketdata.assets
+
+/**
+ * Cadence of regular contributions to a pension/policy asset. Stored on the
+ * asset config so a Work Scenario contribution amount can be annualised
+ * (MONTHLY × 12, ANNUAL × 1) during retirement projection without each
+ * scenario picking its own frequency.
+ */
+enum class ContributionFrequency {
+    MONTHLY,
+    ANNUAL
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
@@ -83,6 +83,11 @@ data class PrivateAssetConfig(
     // Regular contribution amount (e.g., pension contributions, insurance premiums)
     @Column(name = "monthly_contribution", precision = 19, scale = 4)
     val monthlyContribution: BigDecimal? = null,
+    // Cadence of pension contributions captured against this asset; the
+    // Work Scenario stores the amount, this resolves how it annualises.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contribution_frequency", length = 10, nullable = false)
+    val contributionFrequency: ContributionFrequency = ContributionFrequency.MONTHLY,
     @Column(name = "is_pension")
     val isPension: Boolean = false,
     // Composite policy support

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigContracts.kt
@@ -36,6 +36,9 @@ data class PrivateAssetConfigRequest(
     val lumpSum: Boolean? = null,
     // Regular contribution amount (e.g., pension contributions, insurance premiums)
     val monthlyContribution: BigDecimal? = null,
+    // Cadence of the contribution amount on this asset (MONTHLY or ANNUAL).
+    // Defaults MONTHLY on first save so existing callers keep their semantics.
+    val contributionFrequency: ContributionFrequency? = null,
     val isPension: Boolean? = null,
     // Composite policy support
     val policyType: PolicyType? = null,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -186,6 +186,7 @@ class PrivateAssetConfigService(
             monthlyPayoutAmount = request.monthlyPayoutAmount ?: monthlyPayoutAmount,
             lumpSum = request.lumpSum ?: lumpSum,
             monthlyContribution = request.monthlyContribution ?: monthlyContribution,
+            contributionFrequency = request.contributionFrequency ?: contributionFrequency,
             isPension = request.isPension ?: isPension,
             policyType = request.policyType ?: policyType,
             lockedUntilDate = request.lockedUntilDate ?: lockedUntilDate
@@ -226,6 +227,7 @@ class PrivateAssetConfigService(
             monthlyPayoutAmount = request.monthlyPayoutAmount,
             lumpSum = request.lumpSum ?: false,
             monthlyContribution = request.monthlyContribution,
+            contributionFrequency = request.contributionFrequency ?: ContributionFrequency.MONTHLY,
             isPension = request.isPension ?: false,
             policyType = request.policyType,
             lockedUntilDate = request.lockedUntilDate,

--- a/svc-data/src/main/resources/db/migration/V22__add_contribution_frequency.sql
+++ b/svc-data/src/main/resources/db/migration/V22__add_contribution_frequency.sql
@@ -1,0 +1,6 @@
+-- Pension/policy contribution cadence. Existing rows default to MONTHLY so
+-- the column can be NOT NULL without backfill input. Work Scenario stores
+-- the contribution amount; this resolves how it is annualised by the
+-- retirement projection (MONTHLY × 12, ANNUAL × 1).
+ALTER TABLE private_asset_config
+    ADD COLUMN contribution_frequency VARCHAR(10) NOT NULL DEFAULT 'MONTHLY';

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
@@ -221,6 +221,68 @@ class PrivateAssetConfigServiceTest {
     }
 
     @Test
+    fun `saveConfig persists contributionFrequency ANNUAL`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                isPension = true,
+                monthlyContribution = BigDecimal("8000"),
+                contributionFrequency = ContributionFrequency.ANNUAL
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.empty())
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.contributionFrequency).isEqualTo(ContributionFrequency.ANNUAL)
+    }
+
+    @Test
+    fun `saveConfig defaults contributionFrequency to MONTHLY when omitted`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                isPension = true,
+                monthlyContribution = BigDecimal("500")
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.empty())
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.contributionFrequency).isEqualTo(ContributionFrequency.MONTHLY)
+    }
+
+    @Test
+    fun `saveConfig preserves existing contributionFrequency when request omits it`() {
+        val asset = createTestAsset()
+        val existing =
+            PrivateAssetConfig(
+                assetId = assetId,
+                contributionFrequency = ContributionFrequency.ANNUAL
+            )
+        val request =
+            PrivateAssetConfigRequest(
+                monthlyContribution = BigDecimal("8500")
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.of(existing))
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.contributionFrequency).isEqualTo(ContributionFrequency.ANNUAL)
+    }
+
+    @Test
     fun `saveConfig sets rental to zero for primary residence`() {
         val asset = createTestAsset()
         val request =


### PR DESCRIPTION
## Summary
Adds `ContributionFrequency` enum (`MONTHLY` | `ANNUAL`) to `PrivateAssetConfig`. The asset becomes the single source of truth for how a pension contribution amount annualises; the Work Scenario (next PR) will store the amount.

## Why
Step 1 of pension-contributions-in-working-plan feature. CPF contributions are typically annual (employer + employee top-ups); SuperFund / SRS / private pension contributions are typically monthly. Independence projection needs this hint to roll contributions forward year by year.

## Test plan
- [x] New unit tests: saveConfig persists ANNUAL, defaults MONTHLY on omit, preserves existing
- [x] Flyway V22 adds `contribution_frequency VARCHAR(10) NOT NULL DEFAULT 'MONTHLY'`
- [x] `./gradlew testSmart formatKotlin lintKotlin` green
- [ ] Manual: hit `POST /api/private-asset-config/<id>` with `"contributionFrequency": "ANNUAL"` and verify round-trip

## Followups
- svc-retire: `WorkScenarioPensionContribution` table + projection wiring
- bc-view: form field to set the frequency on the asset; per-asset amount on Work Scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now specify contribution frequency for private asset configurations, choosing between monthly or annual cadence. Monthly is set as the default.

* **Tests**
  * Added comprehensive test coverage for contribution frequency handling, including persistence of specified values, default behavior when omitted, and preservation of existing settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->