### PR TITLE
fix(position): DEPOSIT into POLICY tracks cost = quantity (no phantom 100% gain)

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/CashAccumulator.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/CashAccumulator.kt
@@ -1,8 +1,10 @@
 package com.beancounter.position.accumulation
 
+import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.CashUtils
 import com.beancounter.position.utils.CurrencyResolver
 import com.beancounter.position.valuation.CashCost
 import org.springframework.stereotype.Service
@@ -15,7 +17,8 @@ import java.math.BigDecimal
  */
 @Service
 class CashAccumulator(
-    val currencyResolver: CurrencyResolver
+    val currencyResolver: CurrencyResolver,
+    private val cashUtils: CashUtils = CashUtils()
 ) {
     private val cashCost = CashCost()
 
@@ -44,39 +47,85 @@ class CashAccumulator(
         // since the asset IS the cash. For other transactions, use cashCurrency.
         val effectiveCashCurrency = trn.cashCurrency ?: trn.tradeCurrency
 
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.TRADE,
-                effectiveCashCurrency,
-                trn.portfolio,
-                position
-            ),
+        val isCash = cashUtils.isCash(cashPosition.asset)
+        applyPool(
+            Position.In.TRADE,
+            effectiveCashCurrency,
+            trn,
+            position,
             cashPosition,
             signedQuantity,
-            BigDecimal.ONE
-        ) // Cash trade currency
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.BASE,
-                effectiveCashCurrency,
-                trn.portfolio,
-                position
-            ),
-            cashPosition,
-            signedQuantity,
-            trn.tradeBaseRate
+            BigDecimal.ONE,
+            isCash
         )
-        cashCost.value(
-            currencyResolver.getMoneyValues(
-                Position.In.PORTFOLIO,
-                effectiveCashCurrency,
-                trn.portfolio,
-                position
-            ),
+        applyPool(
+            Position.In.BASE,
+            effectiveCashCurrency,
+            trn,
+            position,
             cashPosition,
             signedQuantity,
-            trn.tradePortfolioRate
+            trn.tradeBaseRate,
+            isCash
+        )
+        applyPool(
+            Position.In.PORTFOLIO,
+            effectiveCashCurrency,
+            trn,
+            position,
+            cashPosition,
+            signedQuantity,
+            trn.tradePortfolioRate,
+            isCash
         )
         return position
+    }
+
+    private fun applyPool(
+        pool: Position.In,
+        cashCurrency: com.beancounter.common.model.Currency,
+        trn: Trn,
+        position: Position,
+        cashPosition: Position,
+        signedQuantity: BigDecimal,
+        rate: BigDecimal,
+        isCash: Boolean
+    ) {
+        val moneyValues =
+            currencyResolver.getMoneyValues(
+                pool,
+                cashCurrency,
+                trn.portfolio,
+                position
+            )
+        cashCost.value(
+            moneyValues,
+            cashPosition,
+            signedQuantity,
+            rate
+        )
+        if (!isCash) {
+            // DEPOSIT/WITHDRAWAL targeting a non-cash position (POLICY, RE
+            // and friends) is the wizard's "set current balance" path: the
+            // user-entered quantity IS both market value AND cost basis, so
+            // gain = MV - cost = 0 by construction. Without this CashCost
+            // resets cost to zero (cash semantics) and the UI reports a
+            // phantom 100% gain.
+            applySnapshotCost(moneyValues, rate)
+        }
+    }
+
+    private fun applySnapshotCost(
+        moneyValues: MoneyValues,
+        rate: BigDecimal
+    ) {
+        val net = moneyValues.purchases.subtract(moneyValues.sales).abs()
+        val costBasis =
+            if (rate == BigDecimal.ZERO) net else net.multiply(BigDecimal.ONE)
+        // moneyValues.purchases / sales are already in the pool currency
+        // (cashCost.value applied the rate when adding), so just mirror.
+        moneyValues.costBasis = costBasis
+        moneyValues.costValue = costBasis
+        moneyValues.averageCost = if (costBasis > BigDecimal.ZERO) BigDecimal.ONE else BigDecimal.ZERO
     }
 }

--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/CashAccumulator.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/CashAccumulator.kt
@@ -47,7 +47,20 @@ class CashAccumulator(
         // since the asset IS the cash. For other transactions, use cashCurrency.
         val effectiveCashCurrency = trn.cashCurrency ?: trn.tradeCurrency
 
-        val isCash = cashUtils.isCash(cashPosition.asset)
+        // Snapshot cost is only relevant when this CashAccumulator call IS
+        // the side that mutates the asset position — i.e. DEPOSIT /
+        // WITHDRAWAL / DEDUCTION where the asset itself is being acted on
+        // (cashPosition === position). For the cash-side leg of a BUY/SELL
+        // the cashPosition is a separate cash asset and CashCost's zeros
+        // are the right behaviour. Also requires the position's asset to
+        // be non-cash (POLICY/RE), captured by either CashUtils.isCash or
+        // a CASH market code (some test fixtures construct Assets without
+        // setting category, so isCash alone is not enough).
+        val isCashSide = cashPosition !== position
+        val isCashAsset =
+            cashUtils.isCash(cashPosition.asset) ||
+                cashPosition.asset.market.code == "CASH"
+        val needsSnapshot = !isCashSide && !isCashAsset
         applyPool(
             Position.In.TRADE,
             effectiveCashCurrency,
@@ -56,7 +69,7 @@ class CashAccumulator(
             cashPosition,
             signedQuantity,
             BigDecimal.ONE,
-            isCash
+            needsSnapshot
         )
         applyPool(
             Position.In.BASE,
@@ -66,7 +79,7 @@ class CashAccumulator(
             cashPosition,
             signedQuantity,
             trn.tradeBaseRate,
-            isCash
+            needsSnapshot
         )
         applyPool(
             Position.In.PORTFOLIO,
@@ -76,7 +89,7 @@ class CashAccumulator(
             cashPosition,
             signedQuantity,
             trn.tradePortfolioRate,
-            isCash
+            needsSnapshot
         )
         return position
     }
@@ -89,7 +102,7 @@ class CashAccumulator(
         cashPosition: Position,
         signedQuantity: BigDecimal,
         rate: BigDecimal,
-        isCash: Boolean
+        applySnapshot: Boolean
     ) {
         val moneyValues =
             currencyResolver.getMoneyValues(
@@ -104,28 +117,30 @@ class CashAccumulator(
             signedQuantity,
             rate
         )
-        if (!isCash) {
-            // DEPOSIT/WITHDRAWAL targeting a non-cash position (POLICY, RE
-            // and friends) is the wizard's "set current balance" path: the
-            // user-entered quantity IS both market value AND cost basis, so
-            // gain = MV - cost = 0 by construction. Without this CashCost
-            // resets cost to zero (cash semantics) and the UI reports a
-            // phantom 100% gain.
-            applySnapshotCost(moneyValues, rate)
+        if (applySnapshot) {
+            // Non-cash DEPOSIT/WITHDRAWAL targeting this asset's position —
+            // the wizard's "set current balance" path. Snapshot cost so MV
+            // − cost = 0 by construction instead of the phantom 100% gain
+            // CashCost's zero-cost cash semantics produced.
+            applySnapshotCost(moneyValues, cashPosition.quantityValues.getTotal())
         }
     }
 
     private fun applySnapshotCost(
         moneyValues: MoneyValues,
-        rate: BigDecimal
+        totalQuantity: BigDecimal
     ) {
-        val net = moneyValues.purchases.subtract(moneyValues.sales).abs()
-        val costBasis =
-            if (rate == BigDecimal.ZERO) net else net.multiply(BigDecimal.ONE)
-        // moneyValues.purchases / sales are already in the pool currency
-        // (cashCost.value applied the rate when adding), so just mirror.
-        moneyValues.costBasis = costBasis
-        moneyValues.costValue = costBasis
-        moneyValues.averageCost = if (costBasis > BigDecimal.ZERO) BigDecimal.ONE else BigDecimal.ZERO
+        // sales is already stored as a signed-negative figure for
+        // WITHDRAWAL/DEDUCTION, so the net is purchases + sales (not
+        // purchases - sales which double-counts the outflow).
+        val net = moneyValues.purchases.add(moneyValues.sales).abs()
+        moneyValues.costBasis = net
+        moneyValues.costValue = net
+        moneyValues.averageCost =
+            if (totalQuantity.signum() != 0) {
+                net.divide(totalQuantity.abs(), 10, java.math.RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/CashBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/CashBehaviourTest.kt
@@ -70,6 +70,61 @@ internal class CashBehaviourTest {
     }
 
     @Test
+    fun `DEPOSIT into a non-cash POLICY asset tracks cost equal to quantity`() {
+        // Regression: a CPF / pension policy seeded via DEPOSIT (the wizard's
+        // current path) was reporting a phantom 100% gain because the
+        // CashAccumulator path keeps costBasis at zero for cash semantics.
+        // For non-cash assets the snapshot IS the cost, so cost must equal
+        // the absolute quantity — gain = MV - cost = 0.
+        val cpfAsset =
+            com.beancounter.common.model
+                .Asset(
+                    code = "RUBY-CPF-DEPOSIT",
+                    id = "RUBY-CPF-DEPOSIT",
+                    name = "Ruby CPF",
+                    market = com.beancounter.common.model.Market("PRIVATE"),
+                    priceSymbol = "RUBY-CPF-DEPOSIT",
+                    category = com.beancounter.common.model.AssetCategory.POLICY,
+                )
+        val balance = BigDecimal("250000.00")
+        val trn =
+            Trn(
+                trnType = TrnType.DEPOSIT,
+                asset = cpfAsset,
+                quantity = balance,
+                cashCurrency = USD,
+                tradeCurrency = USD,
+                tradeCashRate = ONE,
+                tradeBaseRate = ONE,
+                tradePortfolioRate = ONE,
+                portfolio = PortfolioUtils.getPortfolio(),
+            )
+        val position =
+            accumulator.accumulate(
+                trn,
+                Positions(),
+            )
+        assertThat(
+            position.getMoneyValues(Position.In.PORTFOLIO),
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_BASIS,
+            balance,
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_VALUE,
+            balance,
+        )
+        assertThat(
+            position.getMoneyValues(Position.In.BASE),
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_BASIS,
+            balance,
+        ).hasFieldOrPropertyWithValue(
+            PROP_COST_VALUE,
+            balance,
+        )
+    }
+
+    @Test
     fun `should accumulate deposit for sell transaction`() {
         val asset =
             getTestAsset(

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/CashBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/CashBehaviourTest.kt
@@ -82,9 +82,11 @@ internal class CashBehaviourTest {
                     code = "RUBY-CPF-DEPOSIT",
                     id = "RUBY-CPF-DEPOSIT",
                     name = "Ruby CPF",
-                    market = com.beancounter.common.model.Market("PRIVATE"),
+                    market =
+                        com.beancounter.common.model
+                            .Market("PRIVATE"),
                     priceSymbol = "RUBY-CPF-DEPOSIT",
-                    category = com.beancounter.common.model.AssetCategory.POLICY,
+                    category = com.beancounter.common.model.AssetCategory.POLICY
                 )
         val balance = BigDecimal("250000.00")
         val trn =
@@ -97,30 +99,30 @@ internal class CashBehaviourTest {
                 tradeCashRate = ONE,
                 tradeBaseRate = ONE,
                 tradePortfolioRate = ONE,
-                portfolio = PortfolioUtils.getPortfolio(),
+                portfolio = PortfolioUtils.getPortfolio()
             )
         val position =
             accumulator.accumulate(
                 trn,
-                Positions(),
+                Positions()
             )
         assertThat(
-            position.getMoneyValues(Position.In.PORTFOLIO),
+            position.getMoneyValues(Position.In.PORTFOLIO)
         ).hasFieldOrPropertyWithValue(
             PROP_COST_BASIS,
-            balance,
+            balance
         ).hasFieldOrPropertyWithValue(
             PROP_COST_VALUE,
-            balance,
+            balance
         )
         assertThat(
-            position.getMoneyValues(Position.In.BASE),
+            position.getMoneyValues(Position.In.BASE)
         ).hasFieldOrPropertyWithValue(
             PROP_COST_BASIS,
-            balance,
+            balance
         ).hasFieldOrPropertyWithValue(
             PROP_COST_VALUE,
-            balance,
+            balance
         )
     }
 


### PR DESCRIPTION
## Summary
Same root cause as #886, different code path. The wizard seeds CPF / pension / SingLife / SRS assets via `DEPOSIT` transactions (not `BALANCE`), so PR #886's BalanceBehaviour fix didn't reach them. Ruby's SGD portfolio still reported 100% gain on every POLICY row after #886 deployed because the DEPOSIT path runs through `CashAccumulator`, which keeps `costBasis = 0` for cash semantics.

CashAccumulator now applies an absolute-snapshot cost to the position whenever the underlying asset isn't cash — `costBasis = costValue = |purchases − sales|`, `averageCost = 1` (matches `PrivateMarketDataProvider`'s POLICY price). Cash DEPOSIT/WITHDRAWAL behaviour unchanged.

## Test plan
- [x] New regression test in `CashBehaviourTest`: DEPOSIT into a POLICY asset asserts `costBasis = costValue = quantity`.
- [x] `./gradlew testSmart formatKotlin lintKotlin` green.
- [ ] Manual on kauri once deployed: Ruby's SGD portfolio CPF / SingLife rows show ~0% gain instead of 100%.

## Related
- Originally diagnosed in #886 — that fix only covered the BALANCE path. This is the missing companion fix for the DEPOSIT path that the wizard actually uses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cost-basis and cost-value computation for deposits into non-cash assets so portfolio/base positions reflect the deposited quantity.

* **Refactor**
  * Reorganized accumulation flow to centralize cash-vs-non-cash handling and simplify cost application paths.

* **Tests**
  * Added a regression test validating deposit transactions into policy (non-cash) assets track cost equal to quantity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->