### PR TITLE
chore(sentry): drop basic.ack + bc-perf-invalidate RabbitMQ noise from APM

### DIFF
--- a/svc-agent/src/main/resources/application.yml
+++ b/svc-agent/src/main/resources/application.yml
@@ -9,6 +9,10 @@ sentry:
   environment: local
   traces-sample-rate: 1
   debug: false
+  # Drop high-frequency RabbitMQ noise from APM (see svc-position application.yml).
+  ignored-transactions:
+    - "basic\\.ack"
+    - "bc-perf-invalidate-.*"
 
 
 marketdata:

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -38,6 +38,10 @@ sentry:
   environment: local
   traces-sample-rate: .2
   debug: false
+  # Drop high-frequency RabbitMQ noise from APM (see svc-position application.yml).
+  ignored-transactions:
+    - "basic\\.ack"
+    - "bc-perf-invalidate-.*"
 
 otel:
   traces:

--- a/svc-event/src/main/resources/application.yml
+++ b/svc-event/src/main/resources/application.yml
@@ -13,6 +13,10 @@ sentry:
   environment: local
   traces-sample-rate: 1
   debug: false
+  # Drop high-frequency RabbitMQ noise from APM (see svc-position application.yml).
+  ignored-transactions:
+    - "basic\\.ack"
+    - "bc-perf-invalidate-.*"
 
 springdoc:
   use-management-port: true

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -41,6 +41,14 @@ sentry:
   environment: local
   traces-sample-rate: 1
   debug: false
+  # Drop the high-frequency RabbitMQ noise from the Most Frequent
+  # Transactions report: AMQP basic.ack fires per consumer ack (8.9k/day),
+  # the bc-perf-invalidate-demo topic fires per portfolio mutation
+  # (8.4-8.5k/day). None tell us anything useful about request latency.
+  # Entries are FilterString regexes.
+  ignored-transactions:
+    - "basic\\.ack"
+    - "bc-perf-invalidate-.*"
 
 otel:
   traces:


### PR DESCRIPTION
## Summary
Sentry's Most Frequent Transactions report on kauri is dominated by AMQP plumbing rather than user-facing endpoints:

| Transaction | Count |
|---|---|
| basic.ack | 8.9k |
| bc-perf-invalidate-demo.bc-position process | 8.5k |
| bc-perf-invalidate-demo process | 8.4k |

None of these tell us anything about request latency — they crowd out the HTTP endpoints we actually want to triage.

Add `ignored-transactions` FilterString regexes to the shared `sentry:` block in all four services so they're dropped at the SDK before being sent.

```yaml
sentry:
  ignored-transactions:
    - "basic\.ack"
    - "bc-perf-invalidate-.*"
```

## Test plan
- [x] `./gradlew testSmart` green (config-only change, no behaviour code)
- [ ] After deploy: confirm Sentry APM no longer lists `basic.ack` or `bc-perf-invalidate-*` in Most Frequent Transactions
- [ ] Confirm HTTP endpoints surface where the noise used to be

## Followups
None.