### PR TITLE
feat: mirror profile demographics (yearOfBirth/lifeExpectancy) to svc-data UserPreferences

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
@@ -19,5 +19,8 @@ data class UserPreferencesRequest(
     val showWeightedIrr: Boolean? = null,
     val enableTwr: Boolean? = null,
     val milestoneMode: MilestoneMode? = null,
-    val autoSettle: Boolean? = null
+    val autoSettle: Boolean? = null,
+    val yearOfBirth: Int? = null,
+    val monthOfBirth: Int? = null,
+    val lifeExpectancy: Int? = null
 )

--- a/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
@@ -41,5 +41,16 @@ data class UserPreferences(
     @Column(name = "milestone_mode")
     var milestoneMode: MilestoneMode = MilestoneMode.ACTIVE,
     @Column(name = "auto_settle")
-    var autoSettle: Boolean = true
+    var autoSettle: Boolean = true,
+    // Profile demographics — mirrored from svc-retire's UserIndependenceSettings
+    // so screens that live in the svc-data scope (Edit Asset, holdings views)
+    // can resolve the user's current age without a runtime dependency on
+    // svc-retire. svc-retire still owns the write of these fields; this is
+    // a denormalised read copy.
+    @Column(name = "year_of_birth")
+    var yearOfBirth: Int? = null,
+    @Column(name = "month_of_birth")
+    var monthOfBirth: Int? = null,
+    @Column(name = "life_expectancy")
+    var lifeExpectancy: Int? = null
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
@@ -51,6 +51,9 @@ class UserPreferencesService(
         request.enableTwr?.let { preferences.enableTwr = it }
         request.milestoneMode?.let { preferences.milestoneMode = it }
         request.autoSettle?.let { preferences.autoSettle = it }
+        request.yearOfBirth?.let { preferences.yearOfBirth = it }
+        request.monthOfBirth?.let { preferences.monthOfBirth = it }
+        request.lifeExpectancy?.let { preferences.lifeExpectancy = it }
         return userPreferencesRepository.save(preferences)
     }
 }

--- a/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
+++ b/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
@@ -1,0 +1,8 @@
+-- Profile demographics mirrored from svc-retire's UserIndependenceSettings.
+-- Source of truth still lives in svc-retire; svc-data holds a denormalised
+-- read copy so screens scoped to svc-data (Edit Asset, holdings views) can
+-- compute the user's age without a runtime dependency on svc-retire.
+ALTER TABLE user_preferences
+    ADD COLUMN year_of_birth INT,
+    ADD COLUMN month_of_birth INT,
+    ADD COLUMN life_expectancy INT;


### PR DESCRIPTION
## Summary
Asset screens (Edit Asset, holdings) live in the svc-data scope and need the user's current age to compute pension / lump-sum projections. Previously the only source of \`yearOfBirth\` was svc-retire's \`UserIndependenceSettings\`, which forced a runtime cross-service call — and any front-end bug that broke that call silently dropped age to null, killing pension projections and triggering the misleading "Create an Independence Plan" message even when one exists.

This PR makes svc-data the second source of truth (read copy; svc-retire still owns writes):

- **jar-common**: \`yearOfBirth\` / \`monthOfBirth\` / \`lifeExpectancy\` added to \`UserPreferences\` entity + \`UserPreferencesRequest\` contract.
- **svc-data**: Flyway V23 adds the columns; \`UserPreferencesService.update\` copies them through. The \`/me\` PATCH endpoint already accepts the request DTO, so the existing surface picks up the new fields automatically.
- **svc-retire** (companion PR): \`UserIndependenceSettingsController.updateSettings\` fires a best-effort PATCH \`/me\` to svc-data after persisting locally.

## Test plan
- [x] \`./gradlew testSmart formatKotlin lintKotlin\` green
- [ ] Manual on kauri after deploy: log in as Ruby, open Profile, save year of birth → confirm \`select year_of_birth, life_expectancy from user_preferences where owner_id = ...;\` is non-null on svc-data DB
- [ ] Manual: Edit Asset on a POLICY asset shows projection panel (no "Create an Independence Plan" message)

## Companion
- bc-view PR: switch EditAccountDialog to read profile from /api/me (svc-data) instead of /api/independence/settings (svc-retire) — removes the cross-service dependency for the asset screen
- svc-retire PR: mirror writes back to svc-data /me on settings update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now provide additional demographic information including year of birth, month of birth, and life expectancy as part of their user preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->