### PR TITLE
chore(svc-data): CHECK constraints on user_preferences demographics

### DIFF
--- a/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
+++ b/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
@@ -2,7 +2,19 @@
 -- Source of truth still lives in svc-retire; svc-data holds a denormalised
 -- read copy so screens scoped to svc-data (Edit Asset, holdings views) can
 -- compute the user's age without a runtime dependency on svc-retire.
+-- CHECK constraints are the simplest defence-in-depth against garbage
+-- values (negative ages, month 13, life expectancy 999) poisoning the
+-- age math downstream.
 ALTER TABLE user_preferences
     ADD COLUMN year_of_birth INT,
     ADD COLUMN month_of_birth INT,
-    ADD COLUMN life_expectancy INT;
+    ADD COLUMN life_expectancy INT,
+    -- Literal upper bound (not EXTRACT(YEAR FROM CURRENT_DATE)) keeps the
+    -- constraint portable across H2 (test) and Postgres (prod); a far-future
+    -- ceiling still catches anything physically plausible going wrong.
+    ADD CONSTRAINT chk_user_preferences_year_of_birth
+        CHECK (year_of_birth IS NULL OR year_of_birth BETWEEN 1900 AND 2150),
+    ADD CONSTRAINT chk_user_preferences_month_of_birth
+        CHECK (month_of_birth IS NULL OR month_of_birth BETWEEN 1 AND 12),
+    ADD CONSTRAINT chk_user_preferences_life_expectancy
+        CHECK (life_expectancy IS NULL OR life_expectancy BETWEEN 1 AND 130);


### PR DESCRIPTION
## Summary
Follow-up to #890 addressing the CodeRabbit nit on V23's new demographic columns. Adds DB-level CHECK constraints so a typo or malformed payload can't poison age math downstream.

- \`year_of_birth\` IN [1900, 2150]
- \`month_of_birth\` IN [1, 12]
- \`life_expectancy\` IN [1, 130]

Literal upper bound on year (not \`EXTRACT(YEAR FROM CURRENT_DATE)::INT\`) keeps the migration portable between H2 test mode and Postgres prod.

The other CodeRabbit nit (use direct assignment so PATCH can clear) was declined — inconsistent with the rest of UserPreferences which treats null as "absent — keep existing". No UI flow currently clears these either.

## Test plan
- [x] \`./gradlew :svc-data:test\` green with the new constraints applied
- [ ] Manual after deploy: try posting yearOfBirth=99 — expect 4xx instead of corrupt row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles now support storing demographic information including birth year, birth month, and life expectancy details.
  * Added automatic validation to ensure demographic data entries remain within valid ranges, improving data quality and enabling more personalized user experiences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->