### PR TITLE
feat(svc-data): PATCH /me accepts service token + sub/email

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/RegistrationController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/RegistrationController.kt
@@ -67,10 +67,30 @@ class RegistrationController internal constructor(
     }
 
     @PatchMapping("/me")
-    @PreAuthorize("hasAuthority('" + AuthConstants.SCOPE_USER + "')")
+    @PreAuthorize(
+        "hasAnyAuthority('" + AuthConstants.SCOPE_USER + "', '" + AuthConstants.SCOPE_SYSTEM + "')"
+    )
     fun updatePreferences(
-        @RequestBody request: UserPreferencesRequest
+        @RequestBody request: UserPreferencesRequest,
+        @RequestParam(required = false) sub: String?,
+        @RequestParam(required = false) email: String?
     ): RegistrationResponse {
+        if (tokenService.isServiceToken) {
+            // Service callers (e.g. svc-retire backfill) must identify the
+            // target SystemUser explicitly — same contract as getMe.
+            if (sub.isNullOrBlank() && email.isNullOrBlank()) {
+                throw BusinessException("Service callers must supply 'sub' or 'email'")
+            }
+            val target =
+                systemUserService.findByExternal(sub, email)
+                    ?: throw NotFoundException("No SystemUser for the supplied sub/email")
+            val preferences = userPreferencesService.update(target, request)
+            return RegistrationResponse(target, preferences)
+        }
+
+        if (!sub.isNullOrBlank() || !email.isNullOrBlank()) {
+            throw BusinessException("User callers must not supply 'sub' or 'email'")
+        }
         val user = systemUserService.getOrThrow()
         val preferences = userPreferencesService.update(user, request)
         return RegistrationResponse(user, preferences)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/RegistrationControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/RegistrationControllerTest.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.registration
 import com.beancounter.auth.MockAuthConfig
 import com.beancounter.common.contracts.RegistrationRequest
 import com.beancounter.common.contracts.RegistrationResponse
+import com.beancounter.common.contracts.UserPreferencesRequest
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.utils.BcJson.Companion.objectMapper
 import com.beancounter.marketdata.Constants
@@ -204,6 +205,98 @@ class RegistrationControllerTest {
                 ).andExpect(MockMvcResultMatchers.status().isBadRequest)
                 .andReturn()
         assertThat(performed.response.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
+    }
+
+    @Test
+    fun `M2M can patch a target user's preferences via sub`() {
+        val target =
+            SystemUser(
+                email = "m2m-patch-sub@testing.com",
+                auth0 = "auth0|m2m-patch-sub"
+            )
+        registerUser(mockMvc, mockAuthConfig.tokenUtils.getAuth0Token(target))
+
+        val m2m = mockAuthConfig.tokenUtils.getSystemToken(Constants.systemUser)
+        val body =
+            UserPreferencesRequest(
+                yearOfBirth = 1972,
+                monthOfBirth = 4,
+                lifeExpectancy = 92
+            )
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .patch("/me")
+                    .param("sub", "auth0|m2m-patch-sub")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(m2m))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(body))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+
+        val verify =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/me")
+                        .param("sub", "auth0|m2m-patch-sub")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(m2m))
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+        val response =
+            objectMapper.readValue(
+                verify.response.contentAsByteArray,
+                RegistrationResponse::class.java
+            )
+        assertThat(response.preferences?.yearOfBirth).isEqualTo(1972)
+        assertThat(response.preferences?.monthOfBirth).isEqualTo(4)
+        assertThat(response.preferences?.lifeExpectancy).isEqualTo(92)
+    }
+
+    @Test
+    fun `M2M patch without sub or email returns 400`() {
+        val m2m = mockAuthConfig.tokenUtils.getSystemToken(Constants.systemUser)
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .patch("/me")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(m2m))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(UserPreferencesRequest()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    @Test
+    fun `M2M patch returns 404 when sub has no SystemUser`() {
+        val m2m = mockAuthConfig.tokenUtils.getSystemToken(Constants.systemUser)
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .patch("/me")
+                    .param("sub", "auth0|never-registered-patch")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(m2m))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(UserPreferencesRequest(yearOfBirth = 1980)))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
+
+    @Test
+    fun `user-token patch with sub query param returns 400`() {
+        val token = mockAuthConfig.getUserToken(Constants.systemUser)
+        registerUser(mockMvc, token)
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .patch("/me")
+                    .param("sub", "auth0|someone-else")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(UserPreferencesRequest(yearOfBirth = 1980)))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isBadRequest)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Extends `PATCH /me` to mirror the existing `GET /me` M2M lookup pattern: service tokens (SCOPE_SYSTEM) must supply `sub` or `email` and update the target user's preferences; user tokens (SCOPE_USER) keep current behavior and must NOT pass `sub`/`email`.
- Unblocks svc-retire's startup demographics backfill (forthcoming PR in svc-retire) which mirrors `UserIndependenceSettings.yearOfBirth/monthOfBirth/lifeExpectancy` into `UserPreferences` for users whose Profile was saved before the per-request mirror existed (PR #890).

## Why
Ruby (and other early users) have their demographics in svc-retire's `UserIndependenceSettings` but not in svc-data's `UserPreferences`. The Edit Asset → Income & Planning panel reads `UserPreferences` only, so it falls back to the "Create an Independence Plan to see projected payout" message even though the plan exists. svc-retire needs a service-token entry point to backfill.

## Test plan
- [x] `M2M can patch a target user's preferences via sub` — round-trips via `GET /me` and asserts the demographics
- [x] `M2M patch without sub or email returns 400`
- [x] `M2M patch returns 404 when sub has no SystemUser`
- [x] `user-token patch with sub query param returns 400` — prevents user-token impersonation
- [x] Full `./gradlew testSmart && formatKotlin && lintKotlin` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for system-scope token authorization in preference updates, enabling machine-to-machine (M2M) services to update user preferences via external identifiers.

* **Tests**
  * Added test coverage for M2M preference update scenarios, including error validation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->