### PR TITLE
fix(svc-data): restore V23, move CHECK constraints to V24 (Flyway checksum mismatch hotfix)

### DIFF
--- a/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
+++ b/svc-data/src/main/resources/db/migration/V23__add_user_profile_demographics.sql
@@ -2,19 +2,7 @@
 -- Source of truth still lives in svc-retire; svc-data holds a denormalised
 -- read copy so screens scoped to svc-data (Edit Asset, holdings views) can
 -- compute the user's age without a runtime dependency on svc-retire.
--- CHECK constraints are the simplest defence-in-depth against garbage
--- values (negative ages, month 13, life expectancy 999) poisoning the
--- age math downstream.
 ALTER TABLE user_preferences
     ADD COLUMN year_of_birth INT,
     ADD COLUMN month_of_birth INT,
-    ADD COLUMN life_expectancy INT,
-    -- Literal upper bound (not EXTRACT(YEAR FROM CURRENT_DATE)) keeps the
-    -- constraint portable across H2 (test) and Postgres (prod); a far-future
-    -- ceiling still catches anything physically plausible going wrong.
-    ADD CONSTRAINT chk_user_preferences_year_of_birth
-        CHECK (year_of_birth IS NULL OR year_of_birth BETWEEN 1900 AND 2150),
-    ADD CONSTRAINT chk_user_preferences_month_of_birth
-        CHECK (month_of_birth IS NULL OR month_of_birth BETWEEN 1 AND 12),
-    ADD CONSTRAINT chk_user_preferences_life_expectancy
-        CHECK (life_expectancy IS NULL OR life_expectancy BETWEEN 1 AND 130);
+    ADD COLUMN life_expectancy INT;

--- a/svc-data/src/main/resources/db/migration/V24__user_preferences_demographics_check_constraints.sql
+++ b/svc-data/src/main/resources/db/migration/V24__user_preferences_demographics_check_constraints.sql
@@ -1,0 +1,16 @@
+-- Defence-in-depth CHECK constraints for the demographics added in V23.
+-- Originally landed in V23 (PR #891) but that retroactively broke the
+-- checksum on already-deployed kauri — V23 was applied without CHECK,
+-- so the in-jar V23 must stay byte-for-byte identical. Splitting the
+-- constraints into V24 lets them deploy cleanly forward.
+--
+-- Literal upper bound on year_of_birth (not EXTRACT(YEAR FROM CURRENT_DATE))
+-- keeps the migration portable across H2 (test) and Postgres (prod); the
+-- far-future ceiling still catches anything physically plausible going wrong.
+ALTER TABLE user_preferences
+    ADD CONSTRAINT chk_user_preferences_year_of_birth
+        CHECK (year_of_birth IS NULL OR year_of_birth BETWEEN 1900 AND 2150),
+    ADD CONSTRAINT chk_user_preferences_month_of_birth
+        CHECK (month_of_birth IS NULL OR month_of_birth BETWEEN 1 AND 12),
+    ADD CONSTRAINT chk_user_preferences_life_expectancy
+        CHECK (life_expectancy IS NULL OR life_expectancy BETWEEN 1 AND 130);


### PR DESCRIPTION
## Summary
- PR #891 modified V23 in-place to add CHECK constraints. V23 had already been applied by bc-data:3283 on kauri (from PR #890), so Flyway computed a different checksum and refused to start, putting bc-data into CrashLoopBackOff.
- This PR restores V23 to byte-for-byte its original form (matches the applied checksum) and lifts the CHECK constraints into a new V24 migration that deploys forward cleanly.

## Symptom
```
FlywayValidateException: Validate failed: Migrations have failed validation
Migration checksum mismatch for migration version 23
-> Applied to database : -1639357931
-> Resolved locally    : -885733788
```

## Lesson
Never modify an applied Flyway migration in-place — always add a forward migration. Re-flagging in CLAUDE.md after this lands.

## Test plan
- [x] `./gradlew :svc-data:test --tests "*RegistrationControllerTest"` (V24 applies clean in H2 test mode)
- [ ] Post-merge: deploy bc-data with new image → kauri pod boots past Flyway → `actuator/health` 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized database validation configurations for user profile demographics to optimize deployment compatibility while maintaining data integrity checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->