### PR TITLE
feat(jar-common): InterestAccrual + DayCountConvention

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/accrual/DayCountConvention.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/accrual/DayCountConvention.kt
@@ -1,0 +1,46 @@
+package com.beancounter.common.accrual
+
+/**
+ * Day-count conventions used by [InterestAccrual] to translate calendar
+ * intervals into year-fractions for compound-interest calculations.
+ *
+ * The current projection engine accumulates whole-year ticks (CPF sub-accounts
+ * + lump-sum FV-of-annuity), so the choice of convention only matters for
+ * partial-period accruals. We surface the convention now so the public
+ * projection contract is honest about which rule produced the figures and
+ * so future fractional-period work (mid-year contributions, daily
+ * compounding) can switch the calculator without changing the call sites.
+ *
+ * Default for every BC projection is [ACT_365_FIXED] — the simplest fixed
+ * 365-day year, which matches Singapore CPF's published rates and most
+ * retail-savings-product literature.
+ */
+enum class DayCountConvention {
+    /**
+     * Actual days / 365. Fixed denominator regardless of leap years.
+     * Most common retail-finance convention; matches CPF's stated rates
+     * and what most insurance policy projections quote.
+     */
+    ACT_365_FIXED,
+
+    /**
+     * Actual days / 360. Common in money-market and short-dated USD
+     * instruments. Produces a slightly higher year-fraction than ACT/365
+     * for the same period (~1.4% larger).
+     */
+    ACT_360,
+
+    /**
+     * Actual days / actual days in year (365 or 366). Bond-market
+     * convention; precise but expensive to compute. The projection engine
+     * does not require this yet.
+     */
+    ACT_ACT,
+
+    /**
+     * 30 days per month, 360 days per year. Legacy US corporate bond
+     * convention; included for completeness — not used by any BC
+     * projection today.
+     */
+    THIRTY_360
+}

--- a/jar-common/src/main/kotlin/com/beancounter/common/accrual/InterestAccrual.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/accrual/InterestAccrual.kt
@@ -117,12 +117,12 @@ class InterestAccrual {
         var cursor = start
         while (cursor.year < end.year) {
             val yearEnd = LocalDate.of(cursor.year + 1, 1, 1)
-            val daysInYear = if (cursor.isLeapYear) 366 else 365
+            val daysInYear = daysInYearOf(cursor)
             val days = ChronoUnit.DAYS.between(cursor, yearEnd)
             total = total.add(BigDecimal(days).divide(BigDecimal(daysInYear), SCALE, RoundingMode.HALF_UP))
             cursor = yearEnd
         }
-        val daysInFinalYear = if (cursor.isLeapYear) 366 else 365
+        val daysInFinalYear = daysInYearOf(cursor)
         val tailDays = ChronoUnit.DAYS.between(cursor, end)
         total =
             total.add(BigDecimal(tailDays).divide(BigDecimal(daysInFinalYear), SCALE, RoundingMode.HALF_UP))
@@ -139,10 +139,15 @@ class InterestAccrual {
         return BigDecimal(days).divide(BigDecimal(360), SCALE, RoundingMode.HALF_UP)
     }
 
-    private val LocalDate.isLeapYear: Boolean get() =
-        java.time.Year
-            .of(year)
-            .isLeap
+    private fun daysInYearOf(date: LocalDate): Int =
+        if (java.time.Year
+                .of(date.year)
+                .isLeap
+        ) {
+            366
+        } else {
+            365
+        }
 
     companion object {
         private val MC = MathContext.DECIMAL128

--- a/jar-common/src/main/kotlin/com/beancounter/common/accrual/InterestAccrual.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/accrual/InterestAccrual.kt
@@ -1,0 +1,151 @@
+package com.beancounter.common.accrual
+
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * Single source of truth for compound-interest and annuity math used by
+ * every BC retirement projection. Encapsulates the arithmetic so that
+ * (a) no caller reimplements `(1 + r)^n`, and (b) the day-count
+ * convention is an explicit parameter, not a hidden assumption.
+ *
+ * The default convention is [DayCountConvention.ACT_365_FIXED] — the
+ * existing whole-year projection ticks were implicitly ACT/365 anyway,
+ * so callers that don't care can stay convention-free. Surface it on
+ * response DTOs (e.g. `LumpSumProjectionResponse.dayCountConvention`)
+ * so the frontend can show the user which rule produced the numbers.
+ */
+@Component
+class InterestAccrual {
+    /**
+     * Compound a principal at `annualRate` for `years` whole years.
+     * Convention is honoured for fractional-year extensions in the
+     * future; with an integer year count the result is identical
+     * across all four supported conventions.
+     */
+    fun compound(
+        principal: BigDecimal,
+        annualRate: BigDecimal,
+        years: Int,
+        convention: DayCountConvention = DayCountConvention.ACT_365_FIXED
+    ): BigDecimal {
+        require(years >= 0) { "years must be non-negative, got $years" }
+        if (years == 0 || principal == BigDecimal.ZERO || annualRate == BigDecimal.ZERO) {
+            return principal
+        }
+        // Whole-year compounding is convention-agnostic — `convention`
+        // is captured here so future partial-year work can branch on it.
+        @Suppress("UNUSED_VARIABLE")
+        val unused = convention
+        return principal.multiply(BigDecimal.ONE.add(annualRate).pow(years, MC), MC)
+    }
+
+    /**
+     * Compound the principal by one year-step at `annualRate`. Hot path
+     * used by year-by-year projection loops (CPF sub-accounts) — kept
+     * separate from [compound] so the loop doesn't pay `pow` overhead
+     * per iteration.
+     */
+    fun compoundOneYear(
+        principal: BigDecimal,
+        annualRate: BigDecimal
+    ): BigDecimal = principal.multiply(BigDecimal.ONE.add(annualRate), MC)
+
+    /**
+     * Future value of a monthly annuity (level payments at period end),
+     * compounded at `annualRate`. Returns 0 when monthly payment or
+     * months is non-positive. When `annualRate` is zero, returns the
+     * undiscounted sum of contributions.
+     *
+     * FV = PMT × ((1 + r/12)^n - 1) / (r/12)
+     */
+    fun futureValueOfAnnuityMonthly(
+        monthlyPayment: BigDecimal,
+        annualRate: BigDecimal,
+        totalMonths: Int,
+        convention: DayCountConvention = DayCountConvention.ACT_365_FIXED
+    ): BigDecimal {
+        require(totalMonths >= 0) { "totalMonths must be non-negative, got $totalMonths" }
+        if (monthlyPayment <= BigDecimal.ZERO || totalMonths == 0) {
+            return BigDecimal.ZERO
+        }
+        if (annualRate <= BigDecimal.ZERO) {
+            return monthlyPayment.multiply(BigDecimal(totalMonths))
+        }
+        @Suppress("UNUSED_VARIABLE")
+        val unused = convention
+        val monthlyRate = annualRate.divide(BigDecimal(12), SCALE, RoundingMode.HALF_UP)
+        val growthFactor = BigDecimal.ONE.add(monthlyRate).pow(totalMonths)
+        val numerator = growthFactor.subtract(BigDecimal.ONE)
+        return monthlyPayment.multiply(numerator).divide(monthlyRate, 2, RoundingMode.HALF_UP)
+    }
+
+    /**
+     * Year-fraction between `start` and `end` under `convention`.
+     * Reserved for fractional-period work (mid-year contributions,
+     * dated cashflows) — current callers only need whole years and
+     * stick to [compound] / [compoundOneYear].
+     */
+    fun yearFraction(
+        start: LocalDate,
+        end: LocalDate,
+        convention: DayCountConvention = DayCountConvention.ACT_365_FIXED
+    ): BigDecimal {
+        val days = ChronoUnit.DAYS.between(start, end)
+        require(days >= 0) { "end must be on/after start" }
+        val daysBd = BigDecimal(days)
+        return when (convention) {
+            DayCountConvention.ACT_365_FIXED -> daysBd.divide(BigDecimal(365), SCALE, RoundingMode.HALF_UP)
+            DayCountConvention.ACT_360 -> daysBd.divide(BigDecimal(360), SCALE, RoundingMode.HALF_UP)
+            DayCountConvention.ACT_ACT -> actActYearFraction(start, end)
+            DayCountConvention.THIRTY_360 -> thirty360YearFraction(start, end)
+        }
+    }
+
+    private fun actActYearFraction(
+        start: LocalDate,
+        end: LocalDate
+    ): BigDecimal {
+        // Simplified ACT/ACT (ISDA): split the interval at year boundaries,
+        // accumulate days / days-in-each-year. Good enough for projection
+        // displays; full bond-market ACT/ACT is more nuanced.
+        var total = BigDecimal.ZERO
+        var cursor = start
+        while (cursor.year < end.year) {
+            val yearEnd = LocalDate.of(cursor.year + 1, 1, 1)
+            val daysInYear = if (cursor.isLeapYear) 366 else 365
+            val days = ChronoUnit.DAYS.between(cursor, yearEnd)
+            total = total.add(BigDecimal(days).divide(BigDecimal(daysInYear), SCALE, RoundingMode.HALF_UP))
+            cursor = yearEnd
+        }
+        val daysInFinalYear = if (cursor.isLeapYear) 366 else 365
+        val tailDays = ChronoUnit.DAYS.between(cursor, end)
+        total =
+            total.add(BigDecimal(tailDays).divide(BigDecimal(daysInFinalYear), SCALE, RoundingMode.HALF_UP))
+        return total
+    }
+
+    private fun thirty360YearFraction(
+        start: LocalDate,
+        end: LocalDate
+    ): BigDecimal {
+        val d1 = minOf(start.dayOfMonth, 30)
+        val d2 = if (d1 == 30) minOf(end.dayOfMonth, 30) else end.dayOfMonth
+        val days = 360L * (end.year - start.year) + 30L * (end.monthValue - start.monthValue) + (d2 - d1)
+        return BigDecimal(days).divide(BigDecimal(360), SCALE, RoundingMode.HALF_UP)
+    }
+
+    private val LocalDate.isLeapYear: Boolean get() =
+        java.time.Year
+            .of(year)
+            .isLeap
+
+    companion object {
+        private val MC = MathContext.DECIMAL128
+        private const val SCALE = 10
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
@@ -1,0 +1,110 @@
+package com.beancounter.common.accrual
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+class InterestAccrualTest {
+    private val accrual = InterestAccrual()
+
+    @Test
+    fun `compound at zero years returns principal unchanged`() {
+        val result = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 0)
+        assertThat(result).isEqualByComparingTo(BigDecimal(1000))
+    }
+
+    @Test
+    fun `compound applies annual rate over whole years`() {
+        // 1000 @ 4% for 10 years = 1000 * 1.04^10 ≈ 1480.244
+        val result = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 10)
+        assertThat(result.setScale(2, RoundingMode.HALF_UP))
+            .isEqualByComparingTo(BigDecimal("1480.24"))
+    }
+
+    @Test
+    fun `compoundOneYear matches single compound step`() {
+        val oneStep = accrual.compoundOneYear(BigDecimal(1000), BigDecimal("0.04"))
+        val viaCompound = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 1)
+        assertThat(oneStep.setScale(4, RoundingMode.HALF_UP))
+            .isEqualByComparingTo(viaCompound.setScale(4, RoundingMode.HALF_UP))
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly applies FV-of-annuity formula`() {
+        // PMT=100, r=0.06/yr, n=12 months → FV = 100 * ((1.005)^12 - 1) / 0.005 ≈ 1233.56
+        val result =
+            accrual.futureValueOfAnnuityMonthly(
+                monthlyPayment = BigDecimal(100),
+                annualRate = BigDecimal("0.06"),
+                totalMonths = 12
+            )
+        assertThat(result).isEqualByComparingTo(BigDecimal("1233.56"))
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly with zero rate returns plain sum of contributions`() {
+        val result =
+            accrual.futureValueOfAnnuityMonthly(
+                monthlyPayment = BigDecimal(100),
+                annualRate = BigDecimal.ZERO,
+                totalMonths = 24
+            )
+        assertThat(result).isEqualByComparingTo(BigDecimal(2400))
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly with zero months returns zero`() {
+        val result =
+            accrual.futureValueOfAnnuityMonthly(
+                monthlyPayment = BigDecimal(100),
+                annualRate = BigDecimal("0.05"),
+                totalMonths = 0
+            )
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `negative years rejected`() {
+        assertThrows<IllegalArgumentException> {
+            accrual.compound(BigDecimal(1000), BigDecimal("0.04"), -1)
+        }
+    }
+
+    @Test
+    fun `ACT_365_FIXED year-fraction over one calendar year is exactly 1`() {
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+                DayCountConvention.ACT_365_FIXED
+            )
+        // 365 days / 365 = 1.0
+        assertThat(yf).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `ACT_360 year-fraction over 365 days is greater than 1`() {
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+                DayCountConvention.ACT_360
+            )
+        // 365 / 360 ≈ 1.0139
+        assertThat(yf).isGreaterThan(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `THIRTY_360 year-fraction over exact calendar year is 1`() {
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+                DayCountConvention.THIRTY_360
+            )
+        assertThat(yf).isEqualByComparingTo(BigDecimal.ONE)
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
@@ -302,6 +302,46 @@ class InterestAccrualTest {
     }
 
     @Test
+    fun `ACT_ACT year-fraction inside a leap year is divided by 366`() {
+        // Same calendar year, leap: tailDays > 0 AND cursor.isLeapYear == true.
+        // Drives the final-year leap branch in actActYearFraction (line 125).
+        // Q1 2024 has 91 days (Jan 31 + Feb 29 + Mar 31). 91 / 366 ≈ 0.2486.
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 4, 1),
+                DayCountConvention.ACT_ACT
+            )
+        assertThat(yf.toDouble()).isCloseTo(
+            91.0 / 366.0,
+            org.assertj.core.data.Offset
+                .offset(0.0001)
+        )
+    }
+
+    @Test
+    fun `ACT_ACT year-fraction spanning three years exercises both isLeapYear branches`() {
+        // 2023 (non-leap, partial), 2024 (leap, full), 2025 (non-leap, partial).
+        // Forces the while-loop to iterate twice and the final-year branch
+        // to fire — exercises cursor.isLeapYear on both leap and non-leap.
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2025, 7, 1),
+                DayCountConvention.ACT_ACT
+            )
+        // 2023-07-01 → 2024-01-01 = 184 / 365 ≈ 0.5041
+        // 2024-01-01 → 2025-01-01 = 366 / 366 = 1.0
+        // 2025-01-01 → 2025-07-01 = 181 / 365 ≈ 0.4959
+        // total ≈ 2.0000
+        assertThat(yf.toDouble()).isCloseTo(
+            2.0,
+            org.assertj.core.data.Offset
+                .offset(0.001)
+        )
+    }
+
+    @Test
     fun `THIRTY_360 year-fraction caps both endpoints at day 30`() {
         // start day 31 → d1 caps to 30; end day 31 → d2 caps to 30 (because d1==30 triggers cap).
         // 2025-01-31 → 2025-12-31 under 30/360:

--- a/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/accrual/InterestAccrualTest.kt
@@ -107,4 +107,228 @@ class InterestAccrualTest {
             )
         assertThat(yf).isEqualByComparingTo(BigDecimal.ONE)
     }
+
+    @Test
+    fun `THIRTY_360 year-fraction handles mid-month dates via standard formula`() {
+        // 30/360 between 2025-03-15 and 2025-09-15:
+        // days = 360*0 + 30*(9-3) + (15-15) = 180  →  180/360 = 0.5
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 3, 15),
+                LocalDate.of(2025, 9, 15),
+                DayCountConvention.THIRTY_360
+            )
+        assertThat(yf).isEqualByComparingTo(BigDecimal("0.5"))
+    }
+
+    @Test
+    fun `ACT_ACT year-fraction over non-leap calendar year is 1`() {
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+                DayCountConvention.ACT_ACT
+            )
+        // 365 / 365 (2025 not a leap year) = 1
+        assertThat(yf).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `ACT_ACT year-fraction over a leap year is 1`() {
+        // 2024 = 366 days. ACT/ACT splits at year boundary so still produces 1.
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2025, 1, 1),
+                DayCountConvention.ACT_ACT
+            )
+        assertThat(yf).isEqualByComparingTo(BigDecimal.ONE)
+    }
+
+    @Test
+    fun `ACT_ACT year-fraction spanning two years sums each portion correctly`() {
+        // Mid-2024 (leap, from Jul 1) → Mid-2025 (non-leap, to Jul 1):
+        // 2024-07-01 → 2025-01-01 = 184 days / 366 ≈ 0.5027
+        // 2025-01-01 → 2025-07-01 = 181 days / 365 ≈ 0.4959
+        // total ≈ 0.9986
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2024, 7, 1),
+                LocalDate.of(2025, 7, 1),
+                DayCountConvention.ACT_ACT
+            )
+        assertThat(yf.toDouble()).isCloseTo(
+            0.9986,
+            org.assertj.core.data.Offset
+                .offset(0.001)
+        )
+    }
+
+    @Test
+    fun `ACT_ACT year-fraction sub-year interval inside a single year`() {
+        // Q1 2025 = 90 days / 365 ≈ 0.2466
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 4, 1),
+                DayCountConvention.ACT_ACT
+            )
+        assertThat(yf.toDouble()).isCloseTo(
+            90.0 / 365.0,
+            org.assertj.core.data.Offset
+                .offset(0.0001)
+        )
+    }
+
+    @Test
+    fun `yearFraction same start and end returns zero`() {
+        val sameDay = LocalDate.of(2025, 6, 15)
+        assertThat(accrual.yearFraction(sameDay, sameDay, DayCountConvention.ACT_365_FIXED))
+            .isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(accrual.yearFraction(sameDay, sameDay, DayCountConvention.ACT_ACT))
+            .isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(accrual.yearFraction(sameDay, sameDay, DayCountConvention.THIRTY_360))
+            .isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `yearFraction with end before start is rejected`() {
+        assertThrows<IllegalArgumentException> {
+            accrual.yearFraction(
+                LocalDate.of(2025, 12, 31),
+                LocalDate.of(2025, 1, 1)
+            )
+        }
+    }
+
+    @Test
+    fun `yearFraction default convention is ACT_365_FIXED`() {
+        // Default-arg path: caller passes only the two dates.
+        val explicit =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+                DayCountConvention.ACT_365_FIXED
+            )
+        val defaulted =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1)
+            )
+        assertThat(defaulted).isEqualByComparingTo(explicit)
+    }
+
+    @Test
+    fun `compound default convention is ACT_365_FIXED`() {
+        val explicit = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 5, DayCountConvention.ACT_365_FIXED)
+        val defaulted = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 5)
+        assertThat(defaulted).isEqualByComparingTo(explicit)
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly default convention is ACT_365_FIXED`() {
+        val explicit =
+            accrual.futureValueOfAnnuityMonthly(
+                BigDecimal(100),
+                BigDecimal("0.06"),
+                12,
+                DayCountConvention.ACT_365_FIXED
+            )
+        val defaulted = accrual.futureValueOfAnnuityMonthly(BigDecimal(100), BigDecimal("0.06"), 12)
+        assertThat(defaulted).isEqualByComparingTo(explicit)
+    }
+
+    @Test
+    fun `compound returns principal unchanged when principal is zero`() {
+        val result = accrual.compound(BigDecimal.ZERO, BigDecimal("0.05"), 10)
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `compound returns principal unchanged when rate is zero`() {
+        val result = accrual.compound(BigDecimal(1000), BigDecimal.ZERO, 10)
+        assertThat(result).isEqualByComparingTo(BigDecimal(1000))
+    }
+
+    @Test
+    fun `compoundOneYear with zero rate returns principal unchanged`() {
+        val result = accrual.compoundOneYear(BigDecimal(1000), BigDecimal.ZERO)
+        assertThat(result).isEqualByComparingTo(BigDecimal(1000))
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly with negative monthly payment returns zero`() {
+        // Defensive guard — projection inputs are user-driven and a
+        // negative figure shouldn't silently compound into a negative
+        // future value.
+        val result =
+            accrual.futureValueOfAnnuityMonthly(
+                monthlyPayment = BigDecimal(-100),
+                annualRate = BigDecimal("0.05"),
+                totalMonths = 24
+            )
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `futureValueOfAnnuityMonthly with negative months rejected`() {
+        assertThrows<IllegalArgumentException> {
+            accrual.futureValueOfAnnuityMonthly(BigDecimal(100), BigDecimal("0.05"), -1)
+        }
+    }
+
+    @Test
+    fun `compound for many years produces large but finite values`() {
+        // 1000 @ 5% for 100 years ≈ 131,501 — guard against overflow /
+        // precision loss with DECIMAL128.
+        val result = accrual.compound(BigDecimal(1000), BigDecimal("0.05"), 100)
+        assertThat(result.toDouble()).isCloseTo(
+            131501.26,
+            org.assertj.core.data.Offset
+                .offset(1.0)
+        )
+    }
+
+    @Test
+    fun `compound chained one-year matches single multi-year call`() {
+        // Five single-year ticks must equal one 5-year compound. Sanity
+        // check that callers can interleave compoundOneYear inside a
+        // projection loop without diverging from the closed-form value.
+        var stepwise = BigDecimal(1000)
+        repeat(5) { stepwise = accrual.compoundOneYear(stepwise, BigDecimal("0.04")) }
+        val direct = accrual.compound(BigDecimal(1000), BigDecimal("0.04"), 5)
+        assertThat(stepwise.setScale(4, RoundingMode.HALF_UP))
+            .isEqualByComparingTo(direct.setScale(4, RoundingMode.HALF_UP))
+    }
+
+    @Test
+    fun `THIRTY_360 year-fraction caps both endpoints at day 30`() {
+        // start day 31 → d1 caps to 30; end day 31 → d2 caps to 30 (because d1==30 triggers cap).
+        // 2025-01-31 → 2025-12-31 under 30/360:
+        //   360*0 + 30*(12-1) + (30 - 30) = 330  →  330/360 ≈ 0.9167
+        val yf =
+            accrual.yearFraction(
+                LocalDate.of(2025, 1, 31),
+                LocalDate.of(2025, 12, 31),
+                DayCountConvention.THIRTY_360
+            )
+        assertThat(yf.toDouble()).isCloseTo(
+            330.0 / 360.0,
+            org.assertj.core.data.Offset
+                .offset(0.0001)
+        )
+    }
+
+    @Test
+    fun `DayCountConvention enum exposes all four supported rules`() {
+        // Quick guard so a future "drop a convention to save a switch
+        // arm" refactor surfaces a test failure rather than a silent
+        // behaviour change.
+        assertThat(DayCountConvention.entries).containsExactly(
+            DayCountConvention.ACT_365_FIXED,
+            DayCountConvention.ACT_360,
+            DayCountConvention.ACT_ACT,
+            DayCountConvention.THIRTY_360
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Promotes the accrual package staged in svc-retire #32 to jar-common so other services can adopt the same compound-interest math without copy/paste. svc-position will need it for **fixed deposit** positions; svc-rebalance has parallel needs for fixed-income rebalancing models.

## Package: \`com.beancounter.common.accrual\`
- \`InterestAccrual\` (\`@Component\`):
  - \`compound(principal, annualRate, years, convention)\`
  - \`compoundOneYear(principal, annualRate)\` — hot-path single step
  - \`futureValueOfAnnuityMonthly(monthly, annualRate, totalMonths, convention)\`
  - \`yearFraction(start, end, convention)\` — for fractional-period work
- \`DayCountConvention\` enum: \`ACT_365_FIXED\` (default), \`ACT_360\`, \`ACT_ACT\` (ISDA simplified), \`THIRTY_360\`
- Convention is an explicit parameter on every method so the rule is visible at call sites and on response contracts. Whole-year arithmetic is convention-agnostic today; the plumbing is in place for fractional periods.

## Downstream
- **svc-retire PR #32** depends on this. Once this lands + CircleCI republishes the SNAPSHOT, #32 will be updated to drop its local copy and import from jar-common.

## Test plan
- [x] 10 unit tests cover compound, FV-of-annuity (zero rate, zero months, non-trivial), negative-years rejection, ACT/365 / ACT/360 / 30/360 year-fractions
- [x] \`./gradlew :jar-common:test :jar-common:formatKotlin :jar-common:lintKotlin\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for four day-count conventions for accurate year-fraction calculations
  * Compound interest calculations with single-year optimization
  * Monthly annuity future-value calculator with sensible defaults and robust input handling
  * Leap-year and month-end rules handled for precise accruals

* **Tests**
  * Expanded test suite covering compounding, annuities, all day-count rules, edge cases and validation rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->