### PR TITLE
feat(svc-data): admin PATCH /assets/admin/{id} to edit category and name

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
@@ -499,6 +499,44 @@ class AssetController(
         @RequestBody assetInput: AssetInput
     ): AssetResponse = AssetResponse(ownedAssetService.updateOwnedAsset(assetId, assetInput))
 
+    @PatchMapping(
+        value = ["/admin/{assetId}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @PreAuthorize("hasAuthority('${AuthConstants.SCOPE_ADMIN}')")
+    @Operation(
+        summary = "Admin: update any asset's category and/or name",
+        description = """
+            Admin-only escalation of PATCH /assets/me/{assetId} that bypasses
+            ownership and allows editing the classification (category) and
+            display name of ANY asset — including public-market assets such as
+            a Mutual Fund whose category needs correcting to ETF.
+
+            Currency is NOT editable here on purpose: changing a public asset's
+            currency would silently re-denominate every user's holdings of it.
+            Use a dedicated migration path for that case.
+
+            Sector classification lives on a separate endpoint
+            (PUT /classifications/{assetId}) and is unaffected by this call.
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Asset updated successfully",
+                content = [Content(schema = Schema(implementation = AssetResponse::class))]
+            ),
+            ApiResponse(responseCode = "403", description = "Caller lacks the admin role"),
+            ApiResponse(responseCode = "404", description = "Asset not found")
+        ]
+    )
+    fun updateAnyAsset(
+        @Parameter(description = "Asset ID to update", example = "abc123")
+        @PathVariable assetId: String,
+        @RequestBody assetInput: AssetInput
+    ): AssetResponse = AssetResponse(assetService.updateAsset(assetId, assetInput))
+
     @GetMapping(
         value = ["/me/export"],
         produces = [MediaType.TEXT_PLAIN_VALUE]

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -37,6 +37,8 @@ class AssetService(
     private val marketService: MarketService,
     private val keyGenUtils: KeyGenUtils,
     private val assetFinder: AssetFinder,
+    private val assetCategoryConfig: AssetCategoryConfig,
+    private val accountingTypeService: AccountingTypeService,
     transactionManager: PlatformTransactionManager
 ) : Assets {
     // New transaction template for recovery lookups after constraint violations
@@ -201,6 +203,53 @@ class AssetService(
         } else {
             foundAsset
         }
+    }
+
+    /**
+     * Admin-only update: rewrite an asset's category and/or display name
+     * regardless of ownership. The asset's currency is sourced from the
+     * existing accountingType — admin classification edits must not silently
+     * re-denominate a public asset. The matching AccountingType row is
+     * upserted via AccountingTypeService so existing report-grouping joins
+     * stay valid.
+     * @throws NotFoundException if asset not found
+     */
+    fun updateAsset(
+        assetId: String,
+        input: AssetInput
+    ): Asset {
+        val asset =
+            assetRepository.findById(assetId).orElseThrow {
+                NotFoundException("Asset not found: $assetId")
+            }
+        input.name?.let { asset.name = it }
+        if (input.category.isNotBlank()) {
+            val newCategoryId = input.category.uppercase()
+            val currency =
+                asset.accountingType?.currency
+                    ?: throw BusinessException(
+                        "Cannot resolve currency for asset $assetId — asset has no accountingType"
+                    )
+            val newAccountingType =
+                accountingTypeService.getOrCreate(
+                    category = newCategoryId,
+                    currency = currency
+                )
+            asset.accountingType = newAccountingType
+            asset.category = newAccountingType.category
+            assetCategoryConfig.get(newAccountingType.category)?.let {
+                asset.assetCategory = it
+            }
+        }
+        log.info(
+            "Admin updated asset {} name='{}' category={}",
+            assetId,
+            asset.name,
+            asset.category
+        )
+        // saveAndFlush — AssetEntityListener (@PostUpdate) needs an immediate
+        // flush to rehydrate transient fields on the managed instance.
+        return assetRepository.saveAndFlush(asset)
     }
 
     /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetControllerTest.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.input.AssetInput
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Status
+import com.beancounter.common.model.SystemUser
 import com.beancounter.common.utils.AssetKeyUtils.Companion.toKey
 import com.beancounter.common.utils.AssetUtils.Companion.getAssetInput
 import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
@@ -527,5 +528,87 @@ internal class AssetControllerTest {
         assertThat(result.andReturn().resolvedException!!)
             .isNotNull
             .isInstanceOfAny(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `admin can patch any asset category and name`() {
+        // Create a public-market asset (not user-owned)
+        val asset = getTestAsset(market = NASDAQ, code = "ADMINEDIT")
+        val createMap = mapOf(toKey(asset) to getAssetInput(NASDAQ.code, asset.code))
+        val createResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post(ASSET_ROOT)
+                        .with(
+                            SecurityMockMvcRequestPostProcessors
+                                .jwt()
+                                .jwt(mockAuthConfig.getUserToken())
+                        ).with(csrf())
+                        .content(objectMapper.writeValueAsString(AssetRequest(createMap)))
+                        .contentType(APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+        val created =
+            objectMapper
+                .readValue<AssetUpdateResponse>(createResult.response.contentAsString)
+                .data[toKey(asset)]!!
+
+        val update =
+            AssetInput(
+                market = NASDAQ.code,
+                code = asset.code,
+                name = "Updated Admin Name",
+                category = "ETF"
+            )
+
+        val mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .patch("$ASSET_ROOT/admin/{assetId}", created.id)
+                        .with(
+                            SecurityMockMvcRequestPostProcessors
+                                .jwt()
+                                .jwt(mockAuthConfig.getUserToken())
+                        ).with(csrf())
+                        .content(objectMapper.writeValueAsString(update))
+                        .contentType(APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andReturn()
+
+        val response = objectMapper.readValue<AssetResponse>(mvcResult.response.contentAsString)
+        assertThat(response.data.id).isEqualTo(created.id)
+        assertThat(response.data.name).isEqualTo("Updated Admin Name")
+        assertThat(response.data.assetCategory.id).isEqualTo("ETF")
+    }
+
+    @Test
+    fun `non-admin cannot patch admin asset endpoint`() {
+        val noRoles =
+            mockAuthConfig.tokenUtils.getNoRolesToken(
+                SystemUser(email = "noroles@testing.com")
+            )
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .patch("$ASSET_ROOT/admin/{assetId}", "any-id")
+                    .with(
+                        SecurityMockMvcRequestPostProcessors
+                            .jwt()
+                            .jwt(noRoles)
+                    ).with(csrf())
+                    .content(
+                        objectMapper.writeValueAsString(
+                            AssetInput(
+                                market = NASDAQ.code,
+                                code = "X",
+                                category = "ETF"
+                            )
+                        )
+                    ).contentType(APPLICATION_JSON)
+            ).andExpect(status().isForbidden)
     }
 }


### PR DESCRIPTION
## Summary

Adds admin-only `PATCH /assets/admin/{assetId}` that lets an admin edit the **category** and **display name** of ANY asset — not just user-owned ones. Use case: correcting a miscategorised public asset (e.g. flipping a Mutual Fund classified as `MUTUAL_FUND` to `ETF`).

Same pattern as `ClassificationController`'s `SCOPE_ADMIN` endpoints:

```kotlin
@PreAuthorize("hasAuthority('${AuthConstants.SCOPE_ADMIN}')")
@PatchMapping("/admin/{assetId}")
```

### What's editable
- ✅ `category` — routed through `AccountingTypeService.getOrCreate` so reporting joins stay valid
- ✅ `name`
- ❌ `currency` — explicitly NOT editable. Changing currency on a public asset would silently re-denominate every user's holdings of it.
- ❌ `sector` — unchanged path, lives on `PUT /classifications/{assetId}` (already admin-only).

### Audit
`AssetService.updateAsset` logs at INFO with assetId / new name / new category.

## Test plan

- [x] `admin can patch any asset category and name` → 200, category becomes ETF, name updated
- [x] `non-admin cannot patch admin asset endpoint` → 403
- [x] `./gradlew testSmart` clean
- [x] `./gradlew formatKotlin` clean
- [x] `./gradlew lintKotlin` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now update asset names and category assignments through a new admin-only endpoint.

* **Tests**
  * Added authorization tests to verify admin and non-admin access controls for the new asset update functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->