### PR TITLE
fix(svc-data): portfolio edit no longer zeroes market value

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioInputAdapter.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioInputAdapter.kt
@@ -57,14 +57,12 @@ class PortfolioInputAdapter internal constructor(
         data: PortfolioInput,
         existing: Portfolio
     ): Portfolio =
-        Portfolio(
-            existing.id,
-            data.code.uppercase(Locale.getDefault()),
-            data.name,
+        existing.copy(
+            code = data.code.uppercase(Locale.getDefault()),
+            name = data.name,
             active = data.active,
             currency = currencyService.getCode(data.currency),
             base = currencyService.getCode(data.base),
-            owner = existing.owner,
             cashPortfolioId = data.cashPortfolioId
         )
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
@@ -22,7 +22,7 @@ import java.util.function.Consumer
  */
 @Service
 @Transactional
-@Suppress("TooManyFunctions") // PortfolioService has 11 functions, threshold is 11
+@Suppress("TooManyFunctions") // PortfolioService has 12 functions, threshold is 11
 class PortfolioService(
     private val portfolioInputAdapter: PortfolioInputAdapter,
     private val portfolioRepository: PortfolioRepository,
@@ -123,6 +123,10 @@ class PortfolioService(
         }
         throw NotFoundException("Portfolio not found: $id")
     }
+
+    // Unauthenticated lookup for system-internal callers (stream consumers).
+    // Skips canView — no JWT in scope on the stream thread.
+    fun findOrNull(id: String): Portfolio? = portfolioRepository.findById(id).orElse(null)
 
     fun findByCode(code: String): Portfolio {
         val systemUser = systemUserService.getOrThrow()

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioStreamConsumer.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioStreamConsumer.kt
@@ -21,7 +21,19 @@ class PortfolioStreamConsumer(
     fun portfolioConsumer(): Consumer<Portfolio> =
         Consumer { portfolio ->
             log.trace("Received portfolio update: {}", portfolio.code)
-            val updatedPortfolio = portfolio.copy(lastUpdated = Instant.now())
+            // Only apply valuation fields from the producer; identity/config
+            // (code/name/active/currency/base/owner/cashPortfolioId) comes
+            // from the DB to avoid stale values overwriting recent user edits.
+            val existing = portfolioService.findOrNull(portfolio.id) ?: return@Consumer
+            val updatedPortfolio =
+                existing.copy(
+                    marketValue = portfolio.marketValue,
+                    irr = portfolio.irr,
+                    gainOnDay = portfolio.gainOnDay,
+                    assetClassification = portfolio.assetClassification,
+                    valuedAt = portfolio.valuedAt,
+                    lastUpdated = Instant.now()
+                )
             portfolioService.maintain(updatedPortfolio)
         }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioServiceTest.kt
@@ -79,4 +79,53 @@ class PortfolioServiceTest {
                 BigDecimal.ONE
             )
     }
+
+    @Test
+    fun `update preserves valuation fields and applies cashPortfolioId`() {
+        Mockito.`when`(tokenService.isServiceToken).thenReturn(true)
+        assertThat(systemUserService.registerSystemAccount("beancounter:system")).isNotNull
+
+        val created =
+            portfolioService
+                .save(
+                    listOf(
+                        PortfolioInput(
+                            code = "UPDP",
+                            name = "Update Portfolio",
+                            currency = "USD",
+                            base = "USD"
+                        )
+                    )
+                ).iterator()
+                .next()
+
+        // Simulate bc-position stream having written valuation back to the DB.
+        portfolioService.maintain(
+            created.copy(
+                marketValue = BigDecimal("1234.56"),
+                irr = BigDecimal("0.05"),
+                gainOnDay = BigDecimal("12.34"),
+                valuedAt = java.time.LocalDate.of(2026, 5, 27)
+            )
+        )
+
+        // Now user edits the portfolio and assigns a cash funding portfolio.
+        val updated =
+            portfolioService.update(
+                created.id,
+                PortfolioInput(
+                    code = "UPDP",
+                    name = "Update Portfolio",
+                    currency = "USD",
+                    base = "USD",
+                    cashPortfolioId = "FUNDING-1"
+                )
+            )
+
+        assertThat(updated.cashPortfolioId).isEqualTo("FUNDING-1")
+        assertThat(updated.marketValue).isEqualByComparingTo(BigDecimal("1234.56"))
+        assertThat(updated.irr).isEqualByComparingTo(BigDecimal("0.05"))
+        assertThat(updated.gainOnDay).isEqualByComparingTo(BigDecimal("12.34"))
+        assertThat(updated.valuedAt).isEqualTo(java.time.LocalDate.of(2026, 5, 27))
+    }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioStreamConsumerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioStreamConsumerTest.kt
@@ -3,9 +3,12 @@ package com.beancounter.marketdata.portfolio
 import com.beancounter.common.model.Portfolio
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 
 /**
@@ -14,31 +17,56 @@ import java.math.BigDecimal
  */
 class PortfolioStreamConsumerTest {
     @Test
-    fun `portfolioConsumer should call portfolioService maintain with lastUpdated set`() {
-        // Given
+    fun `portfolioConsumer applies valuation but preserves identity from DB`() {
         val portfolioService = mock<PortfolioService>()
         val consumer = PortfolioStreamConsumer(portfolioService)
 
-        val portfolio =
+        // DB state has the user's most recent edit (cashPortfolioId set, custom name).
+        val existing =
             Portfolio(
                 id = "1",
                 code = "TEST",
-                name = "Test Portfolio",
+                name = "User Renamed",
+                cashPortfolioId = "FUNDING-1"
+            )
+        whenever(portfolioService.findOrNull("1")).thenReturn(existing)
+
+        // Stream payload from bc-position carries stale identity but fresh valuation.
+        val incoming =
+            Portfolio(
+                id = "1",
+                code = "STALE",
+                name = "Stale Name",
                 marketValue = BigDecimal.TEN,
-                irr = BigDecimal.ONE
+                irr = BigDecimal.ONE,
+                cashPortfolioId = null
             )
 
-        // When
-        consumer.portfolioConsumer().accept(portfolio)
+        consumer.portfolioConsumer().accept(incoming)
 
-        // Then - verify maintain is called with a portfolio that has lastUpdated set
         val captor = argumentCaptor<Portfolio>()
         verify(portfolioService).maintain(captor.capture())
 
-        val savedPortfolio = captor.firstValue
-        assertThat(savedPortfolio.id).isEqualTo(portfolio.id)
-        assertThat(savedPortfolio.code).isEqualTo(portfolio.code)
-        assertThat(savedPortfolio.name).isEqualTo(portfolio.name)
-        assertThat(savedPortfolio.lastUpdated).isNotNull()
+        val saved = captor.firstValue
+        // Identity comes from the DB — stale stream values are ignored.
+        assertThat(saved.code).isEqualTo("TEST")
+        assertThat(saved.name).isEqualTo("User Renamed")
+        assertThat(saved.cashPortfolioId).isEqualTo("FUNDING-1")
+        // Valuation comes from the stream.
+        assertThat(saved.marketValue).isEqualTo(BigDecimal.TEN)
+        assertThat(saved.irr).isEqualTo(BigDecimal.ONE)
+        assertThat(saved.lastUpdated).isNotNull()
+    }
+
+    @Test
+    fun `portfolioConsumer skips when portfolio no longer exists`() {
+        val portfolioService = mock<PortfolioService>()
+        val consumer = PortfolioStreamConsumer(portfolioService)
+        whenever(portfolioService.findOrNull("gone")).thenReturn(null)
+
+        consumer.portfolioConsumer().accept(Portfolio(id = "gone"))
+
+        verify(portfolioService).findOrNull("gone")
+        verify(portfolioService, never()).maintain(any())
     }
 }


### PR DESCRIPTION
## Summary
- `PortfolioInputAdapter.fromInput` was constructing a fresh `Portfolio` with positional args, leaving `marketValue`, `irr`, `gainOnDay`, `valuedAt`, `lastUpdated`, `assetClassification` at their data-class defaults. JPA merge then wiped those columns — editing a portfolio (e.g. assigning a `cashPortfolioId`) reset its market value to 0 in the portfolios list.
- `PortfolioStreamConsumer` echoed the inbound `bc-pos-mv` payload back to the DB. bc-position's cached `Portfolio` could carry a stale `cashPortfolioId` which then silently overwrote the user's just-saved value, producing the "sometimes set, sometimes not" flapping on re-edit.

## Fix
- `fromInput` now `existing.copy(...)`s and only overlays user-editable fields. Valuation/owner survive PATCH.
- `PortfolioStreamConsumer` loads the existing row from the DB (`portfolioService.findOrNull`) and applies only the valuation fields from the stream; identity/config (`code`/`name`/`active`/`currency`/`base`/`owner`/`cashPortfolioId`) come from the DB. Skips when the portfolio no longer exists.
- New `PortfolioService.findOrNull` for the stream thread (no JWT in scope; skips `canView`).

## Test plan
- [x] `./gradlew :svc-data:test --tests PortfolioServiceTest --tests PortfolioStreamConsumerTest` — green.
- [x] `./gradlew formatKotlin lintKotlin` — green.
- [x] semgrep scan on changed files — clean.
- [ ] Manual: edit a portfolio in bc-view, assign Cash Funding Portfolio, save, return to list — market value should be unchanged. Re-open edit — funding portfolio value should be persistent across refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio updates now correctly preserve valuation metrics when modifying portfolio details.
  * Stream processing of portfolio updates now maintains identity information from the database while applying new valuations.
  * System gracefully handles cases where portfolios no longer exist.

* **Tests**
  * Added comprehensive tests verifying preservation of valuation data during updates and proper handling of missing portfolios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->