### PR TITLE
chore(security): bump Spring + fix CRLF in trn export

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,11 @@
 [versions]
 kotlin = "2.3.20"
 kotlinter = "5.4.2"
-spring-boot = "3.5.13"
+spring-boot = "3.5.14"
 spring-cloud = "2025.0.2"
 spring-cloud-contract = "4.3.1"
 spring-data-bom = "2025.0.8"
-spring-security = "6.5.9"
+spring-security = "6.5.10"
 spring-doc = "2.8.15"
 jackson = "2.21.1"
 mockitoKotlin = '5.4.0'

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
@@ -73,7 +72,7 @@ class TrnExportController(
             example = "portfolio-123"
         ) @PathVariable("portfolioId") portfolioId: String
     ) {
-        response.contentType = MediaType.TEXT_PLAIN_VALUE
+        response.contentType = "text/csv"
         response.setHeader(
             HttpHeaders.CONTENT_DISPOSITION,
             "attachment; filename=\"${sanitizeFilename(portfolioId)}.csv\""

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
@@ -76,7 +76,7 @@ class TrnExportController(
         response.contentType = MediaType.TEXT_PLAIN_VALUE
         response.setHeader(
             HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=\"$portfolioId.csv\""
+            "attachment; filename=\"${sanitizeFilename(portfolioId)}.csv\""
         )
         val trnResponse =
             trnService.findForPortfolio(
@@ -96,5 +96,11 @@ class TrnExportController(
             )
         }
         csvWriter.close()
+    }
+
+    companion object {
+        private val UNSAFE_FILENAME_CHARS = Regex("[^A-Za-z0-9._-]")
+
+        fun sanitizeFilename(value: String): String = value.replace(UNSAFE_FILENAME_CHARS, "_")
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnExportControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnExportControllerTest.kt
@@ -1,0 +1,27 @@
+package com.beancounter.marketdata.trn
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TrnExportControllerTest {
+    @Test
+    fun `sanitizeFilename strips CR LF to block header splitting`() {
+        val malicious = "abc\r\nSet-Cookie: pwn=1"
+        assertThat(TrnExportController.sanitizeFilename(malicious))
+            .doesNotContain("\r")
+            .doesNotContain("\n")
+            .isEqualTo("abc__Set-Cookie__pwn_1")
+    }
+
+    @Test
+    fun `sanitizeFilename keeps safe characters`() {
+        assertThat(TrnExportController.sanitizeFilename("portfolio-123_demo.v2"))
+            .isEqualTo("portfolio-123_demo.v2")
+    }
+
+    @Test
+    fun `sanitizeFilename replaces path traversal and quoting characters`() {
+        assertThat(TrnExportController.sanitizeFilename("../etc/passwd\""))
+            .isEqualTo(".._etc_passwd_")
+    }
+}


### PR DESCRIPTION
## Summary

Addresses Snyk findings surfaced in today's `monowai` scan.

- **Bump `spring-boot` 3.5.13 → 3.5.14** — clears `spring-web` Incomplete Cleanup (High), `spring-webmvc`/`spring-webflux` HTTP Request Smuggling, and `spring-boot` Symlink Attack / weak PRNG / Insecure Temporary File / Host-Mismatch (Critical + High) transitive findings.
- **Bump `spring-security` 6.5.9 → 6.5.10** — clears TOCTOU race + Information Exposure (7 transitive paths each) and `spring-security-oauth2-jose` Insufficient Verification of Data Authenticity.
- **Fix CRLF Header Injection in `TrnExportController.export`** (Snyk finding `b95643cd-6e11-47d7-b423-139a04740467`, CWE-93). `portfolioId` flowed unsanitised from `@PathVariable` into the `Content-Disposition` header, so a request containing `\r\n` could split the HTTP response. New helper `sanitizeFilename` replaces anything outside `[A-Za-z0-9._-]` with `_` and is covered by unit tests.

Tomcat-embed CVEs (Snyk wants `spring-boot-starter-tomcat@4.0.0` — Spring Boot 4) and the `spring-cloud-function-context` DoS findings are deliberately **not** included here: the former requires a major-version Spring Boot upgrade, and `spring-cloud 2025.0.3` is not yet published on Maven Central (build broke when attempted, see commit message). Recommend tracking those as separate follow-ups.

## Test plan

- [x] `./gradlew :svc-data:test --tests com.beancounter.marketdata.trn.TrnExportControllerTest` (new unit tests pass)
- [x] `./gradlew testSmart` (full suite)
- [x] `./gradlew formatKotlin lintKotlin`
- [x] Local semgrep scan on modified files: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV export safety: filenames are now sanitized to block unsafe characters and ensure proper download behavior.

* **Tests**
  * Added unit tests validating filename sanitization and CSV export handling.

* **Chores**
  * Bumped Spring Boot and Spring Security to the latest patch versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->