### PR TITLE
feat(svc-data): route asset search through configured provider; wire EODHD /search

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -70,19 +70,40 @@ jobs:
       - name: Run Codacy (best-effort, non-blocking)
         id: codacy
         if: steps.gate.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
+        # Keep continue-on-error so this never blocks the workflow — we want a
+        # visible red ✗ on the step plus a warning annotation when Codacy
+        # errors or reports findings, without gating the Claude review or PR.
         continue-on-error: true
         env:
           BASE_SHA: ${{ steps.diff.outputs.base_sha }}
         run: |
+          EXIT_CODE=0
           if [ -x .codacy/cli.sh ]; then
             # Limit Codacy to the changed files — full-repo scans take minutes.
             mapfile -t CHANGED < <(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD)
             if [ "${#CHANGED[@]}" -gt 0 ]; then
-              .codacy/cli.sh analyze --format sarif "${CHANGED[@]}" > codacy.sarif 2>codacy.log || true
+              .codacy/cli.sh analyze --format sarif "${CHANGED[@]}" > codacy.sarif 2>codacy.log || EXIT_CODE=$?
             fi
           fi
           # Always emit the file (even empty) so the next step can read unconditionally.
           test -f codacy.sarif || echo '{}' > codacy.sarif
+
+          # CLI itself errored — surface as a warning annotation and fail the
+          # step (continue-on-error keeps the workflow green).
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo "::warning::Codacy CLI exited $EXIT_CODE — see step log for details."
+            echo "--- codacy.log (tail) ---"
+            tail -n 50 codacy.log 2>/dev/null || true
+            exit "$EXIT_CODE"
+          fi
+
+          # CLI succeeded; count SARIF findings on changed files and warn
+          # (but don't fail) when any are present.
+          FINDINGS=$(jq '[.runs[]?.results[]?] | length' codacy.sarif 2>/dev/null || echo 0)
+          if [ "$FINDINGS" -gt 0 ]; then
+            echo "::warning::Codacy reported $FINDINGS finding(s) on changed files — see codacy.sarif."
+            exit 1
+          fi
 
       - name: Claude review
         if: steps.gate.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -15,6 +15,13 @@ import com.beancounter.marketdata.providers.alpha.AlphaProxy
 import com.beancounter.marketdata.providers.marketstack.MarketStackConfig
 import com.beancounter.marketdata.providers.marketstack.MarketStackGateway
 import com.beancounter.marketdata.registration.SystemUserService
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -106,21 +113,26 @@ class AssetSearchService(
      * Ask the market's configured price provider to search for matching assets. Mirrors price
      * routing — whichever provider [MdFactory] hands back for `market` is the same one that will
      * be priced from, so the search surface and the price surface agree. Returns empty if the
-     * market is unknown or the provider has no search wired (default interface impl).
+     * market is unknown, the provider has no search wired (default interface impl), or the
+     * provider call exceeds [SEARCH_TIMEOUT_MS].
+     *
+     * The wall-clock cap exists because EODHD's RestClient is sized for batch price downloads
+     * (5s connect / 30s read); an interactive header keystroke can't wait that long for one
+     * stuck provider while the rest of the chain is alive.
      */
     private fun searchViaConfiguredProvider(
         keyword: String,
         market: String
     ): List<AssetSearchResult> =
-        try {
-            val resolved = marketService.getMarket(market)
-            mdFactory.getMarketDataProvider(resolved).searchAssets(keyword, market)
-        } catch (
-            @Suppress("TooGenericExceptionCaught")
-            e: Exception
-        ) {
-            log.debug("Provider search for '{}' on {} failed: {}", keyword, market, e.message)
-            emptyList()
+        runBlocking {
+            withTimeoutOrNull(SEARCH_TIMEOUT_MS) {
+                runCatching {
+                    val resolved = marketService.getMarket(market)
+                    mdFactory.getMarketDataProvider(resolved).searchAssets(keyword, market)
+                }.onFailure {
+                    log.debug("Provider search for '{}' on {} failed: {}", keyword, market, it.message)
+                }.getOrDefault(emptyList())
+            } ?: emptyList()
         }
 
     private fun searchPrivateAssets(keyword: String): AssetSearchResponse {
@@ -147,27 +159,49 @@ class AssetSearchService(
         val results = searchLocalDbAssets(keyword)
         if (results.isNotEmpty()) return AssetSearchResponse(results)
 
-        val providerHits =
-            mdFactory.getAllProviders().flatMap { provider ->
-                try {
-                    provider.searchAssets(keyword, null)
-                } catch (
-                    @Suppress("TooGenericExceptionCaught")
-                    e: Exception
-                ) {
-                    log.debug(
-                        "Provider {} search for '{}' failed: {}",
-                        provider.getId(),
-                        keyword,
-                        e.message
-                    )
-                    emptyList()
-                }
-            }
-        val figiHits = if (figiConfig.enabled) searchFigiGlobal(keyword).data else emptyList()
+        // Fan out concurrently — one slow provider (e.g. EODHD with a 5s connect timeout) must
+        // not block FIGI/Alpha behind it. supervisorScope isolates failures so a thrown
+        // provider doesn't cancel its siblings; withTimeoutOrNull caps the wall-clock wait per
+        // provider at SEARCH_TIMEOUT_MS so the user response can't drift beyond that even when
+        // the underlying RestClient is configured for longer batch reads.
         val merged =
-            (providerHits + figiHits).distinctBy {
-                "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
+            runBlocking {
+                supervisorScope {
+                    val providerTasks =
+                        mdFactory.getAllProviders().map { provider ->
+                            async(Dispatchers.IO) {
+                                withTimeoutOrNull(SEARCH_TIMEOUT_MS) {
+                                    runCatching {
+                                        provider.searchAssets(keyword, null)
+                                    }.onFailure {
+                                        log.debug(
+                                            "Provider {} search for '{}' failed: {}",
+                                            provider.getId(),
+                                            keyword,
+                                            it.message
+                                        )
+                                    }.getOrDefault(emptyList())
+                                } ?: emptyList()
+                            }
+                        }
+                    val figiTask: Deferred<List<AssetSearchResult>>? =
+                        if (figiConfig.enabled) {
+                            async(Dispatchers.IO) {
+                                withTimeoutOrNull(SEARCH_TIMEOUT_MS) {
+                                    runCatching {
+                                        searchFigiGlobal(keyword).data.toList()
+                                    }.getOrDefault(emptyList())
+                                } ?: emptyList()
+                            }
+                        } else {
+                            null
+                        }
+                    val providerHits = providerTasks.awaitAll().flatten()
+                    val figiHits = figiTask?.await() ?: emptyList()
+                    (providerHits + figiHits).distinctBy {
+                        "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
+                    }
+                }
             }
         return AssetSearchResponse(merged)
     }
@@ -399,6 +433,11 @@ class AssetSearchService(
         }
 
     companion object {
+        // Per-provider wall-clock cap for interactive asset search. External provider
+        // RestClients are sized for batch price downloads (EODHD: 5s connect / 30s read);
+        // header-bar keystrokes can't tolerate that latency when one provider is stalled.
+        private const val SEARCH_TIMEOUT_MS = 3000L
+
         private val ALLOWED_SECURITY_TYPES =
             setOf(
                 "COMMON STOCK",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -156,15 +156,20 @@ class AssetSearchService(
      * intentionally null-market only.
      */
     private fun searchLocalAssets(keyword: String): AssetSearchResponse {
-        val results = searchLocalDbAssets(keyword)
-        if (results.isNotEmpty()) return AssetSearchResponse(results)
+        val dbResults = searchLocalDbAssets(keyword)
+
+        // Short-circuit only when the DB has an exact ticker match — otherwise a name-only
+        // substring hit (e.g. "TSM" matching "Huntsman") would shadow real ticker results
+        // from providers (Taiwan Semi). Substring-only DB hits get merged with the fan-out.
+        val hasExactCode = dbResults.any { it.symbol.equals(keyword, ignoreCase = true) }
+        if (hasExactCode) return AssetSearchResponse(dbResults)
 
         // Fan out concurrently — one slow provider (e.g. EODHD with a 5s connect timeout) must
         // not block FIGI/Alpha behind it. supervisorScope isolates failures so a thrown
         // provider doesn't cancel its siblings; withTimeoutOrNull caps the wall-clock wait per
         // provider at SEARCH_TIMEOUT_MS so the user response can't drift beyond that even when
         // the underlying RestClient is configured for longer batch reads.
-        val merged =
+        val external =
             runBlocking {
                 supervisorScope {
                     val providerTasks =
@@ -196,20 +201,20 @@ class AssetSearchService(
                         } else {
                             null
                         }
-                    val providerHits = providerTasks.awaitAll().flatten()
-                    val figiHits = figiTask?.await() ?: emptyList()
-                    (providerHits + figiHits)
-                        .distinctBy {
-                            "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
-                        }
-                        // US-first ordering — header users overwhelmingly look up US tickers,
-                        // so surface those before LON/ASX/etc duplicates. Stable sort keeps
-                        // intra-group ordering from the concurrent fan-out.
-                        .sortedBy {
-                            if ((it.market ?: "").uppercase() in US_MARKETS) 0 else 1
-                        }
+                    providerTasks.awaitAll().flatten() + (figiTask?.await() ?: emptyList())
                 }
             }
+        val merged =
+            (dbResults + external)
+                .distinctBy {
+                    "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
+                }
+                // US-first ordering — header users overwhelmingly look up US tickers,
+                // so surface those before LON/ASX/etc duplicates. Stable sort keeps
+                // intra-group ordering from the DB-then-fan-out merge.
+                .sortedBy {
+                    if ((it.market ?: "").uppercase() in US_MARKETS) 0 else 1
+                }
         return AssetSearchResponse(merged)
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -9,6 +9,7 @@ import com.beancounter.marketdata.assets.figi.FigiFilterRequest
 import com.beancounter.marketdata.assets.figi.FigiGateway
 import com.beancounter.marketdata.assets.figi.FigiSearch
 import com.beancounter.marketdata.markets.MarketService
+import com.beancounter.marketdata.providers.MdFactory
 import com.beancounter.marketdata.providers.alpha.AlphaConfig
 import com.beancounter.marketdata.providers.alpha.AlphaProxy
 import com.beancounter.marketdata.providers.marketstack.MarketStackConfig
@@ -32,7 +33,8 @@ class AssetSearchService(
     private val figiGateway: FigiGateway,
     private val figiConfig: FigiConfig,
     private val marketService: MarketService,
-    private val systemUserService: SystemUserService
+    private val systemUserService: SystemUserService,
+    private val mdFactory: MdFactory
 ) {
     private val log = LoggerFactory.getLogger(AssetSearchService::class.java)
 
@@ -97,6 +99,27 @@ class AssetSearchService(
         return AssetSearchResponse(filtered + newFromExternal)
     }
 
+    /**
+     * Ask the market's configured price provider to search for matching assets. Mirrors price
+     * routing — whichever provider [MdFactory] hands back for `market` is the same one that will
+     * be priced from, so the search surface and the price surface agree. Returns empty if the
+     * market is unknown or the provider has no search wired (default interface impl).
+     */
+    private fun searchViaConfiguredProvider(
+        keyword: String,
+        market: String
+    ): List<AssetSearchResult> =
+        try {
+            val resolved = marketService.getMarket(market)
+            mdFactory.getMarketDataProvider(resolved).searchAssets(keyword, market)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.debug("Provider search for '{}' on {} failed: {}", keyword, market, e.message)
+            emptyList()
+        }
+
     private fun searchPrivateAssets(keyword: String): AssetSearchResponse {
         val user = systemUserService.getActiveUser()
         if (user == null) {
@@ -129,13 +152,36 @@ class AssetSearchService(
                 }
         val results = deduped.take(50).map { toLocalSearchResult(it) }
 
-        // Fall back to FIGI global search when local results are empty
-        if (results.isEmpty() && figiConfig.enabled) {
-            log.debug("No local results for '{}', falling back to FIGI global search", keyword)
-            return searchFigiGlobal(keyword)
-        }
+        if (results.isNotEmpty()) return AssetSearchResponse(results)
 
-        return AssetSearchResponse(results)
+        // No DB hit. Fan out across every registered price provider's search surface so a
+        // keyword from the header bar (no market) reaches EODHD / Alpha / MarketStack / etc.
+        // Providers that don't honour null-market simply contribute nothing (default impl
+        // returns empty). FIGI global runs alongside, then results are merged + deduped by
+        // (symbol, market).
+        val providerHits =
+            mdFactory.getAllProviders().flatMap { provider ->
+                try {
+                    provider.searchAssets(keyword, null)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught")
+                    e: Exception
+                ) {
+                    log.debug(
+                        "Provider {} search for '{}' failed: {}",
+                        provider.getId(),
+                        keyword,
+                        e.message
+                    )
+                    emptyList()
+                }
+            }
+        val figiHits = if (figiConfig.enabled) searchFigiGlobal(keyword).data else emptyList()
+        val merged =
+            (providerHits + figiHits).distinctBy {
+                "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
+            }
+        return AssetSearchResponse(merged)
     }
 
     // Markets that use FIGI for search (configured via figi.search.markets)
@@ -147,6 +193,17 @@ class AssetSearchService(
         keyword: String,
         market: String?
     ): AssetSearchResponse {
+        // First ask the market's configured price provider. Symmetric with price routing —
+        // EODHD (on kauri) and any other provider that wires `searchAssets` answers here before
+        // the FIGI/MarketStack/Alpha chain runs. Non-search providers (cash, custom, morningstar)
+        // return empty via the interface default and fall through unchanged.
+        if (market != null) {
+            val providerHits = searchViaConfiguredProvider(keyword, market)
+            if (providerHits.isNotEmpty()) {
+                return AssetSearchResponse(providerHits)
+            }
+        }
+
         // Use FIGI for markets configured in figi.search.markets.
         // FIGI's filter endpoint returns exact-ticker hits and full-name
         // matches but does poorly on short ticker prefixes (e.g. "COW")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -111,14 +111,14 @@ class AssetSearchService(
 
     /**
      * Ask the market's configured price provider to search for matching assets. Mirrors price
-     * routing — whichever provider [MdFactory] hands back for `market` is the same one that will
-     * be priced from, so the search surface and the price surface agree. Returns empty if the
-     * market is unknown, the provider has no search wired (default interface impl), or the
-     * provider call exceeds [SEARCH_TIMEOUT_MS].
+     * routing — whichever provider [MdFactory] hands back for `market` is the same one that
+     * will be priced from, so the search surface and the price surface agree.
      *
-     * The wall-clock cap exists because EODHD's RestClient is sized for batch price downloads
-     * (5s connect / 30s read); an interactive header keystroke can't wait that long for one
-     * stuck provider while the rest of the chain is alive.
+     * Note on the [withTimeoutOrNull] wrapper: it can only cancel suspending code. Blocking
+     * Spring `RestClient` calls inside the provider don't poll the cancellation flag, so the
+     * real wall-clock cap is enforced at the HTTP layer — see `eodhdSearchRestClient` in
+     * [com.beancounter.marketdata.config.ExternalApiRestClientConfig]. The coroutine timeout
+     * stays as belt-and-suspenders for any future provider with short suspension points.
      */
     private fun searchViaConfiguredProvider(
         keyword: String,
@@ -164,11 +164,11 @@ class AssetSearchService(
         val hasExactCode = dbResults.any { it.symbol.equals(keyword, ignoreCase = true) }
         if (hasExactCode) return AssetSearchResponse(dbResults)
 
-        // Fan out concurrently — one slow provider (e.g. EODHD with a 5s connect timeout) must
-        // not block FIGI/Alpha behind it. supervisorScope isolates failures so a thrown
-        // provider doesn't cancel its siblings; withTimeoutOrNull caps the wall-clock wait per
-        // provider at SEARCH_TIMEOUT_MS so the user response can't drift beyond that even when
-        // the underlying RestClient is configured for longer batch reads.
+        // Fan out concurrently — one slow provider must not block FIGI/Alpha behind it.
+        // supervisorScope isolates failures so a thrown provider doesn't cancel its siblings.
+        // The withTimeoutOrNull wrapper is best-effort — blocking RestClient calls inside the
+        // providers don't cooperatively cancel, so the real wall-clock cap comes from the
+        // per-client HTTP timeouts (see `eodhdSearchRestClient`).
         val external =
             runBlocking {
                 supervisorScope {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -198,9 +198,16 @@ class AssetSearchService(
                         }
                     val providerHits = providerTasks.awaitAll().flatten()
                     val figiHits = figiTask?.await() ?: emptyList()
-                    (providerHits + figiHits).distinctBy {
-                        "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
-                    }
+                    (providerHits + figiHits)
+                        .distinctBy {
+                            "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
+                        }
+                        // US-first ordering — header users overwhelmingly look up US tickers,
+                        // so surface those before LON/ASX/etc duplicates. Stable sort keeps
+                        // intra-group ordering from the concurrent fan-out.
+                        .sortedBy {
+                            if ((it.market ?: "").uppercase() in US_MARKETS) 0 else 1
+                        }
                 }
             }
         return AssetSearchResponse(merged)
@@ -437,6 +444,9 @@ class AssetSearchService(
         // RestClients are sized for batch price downloads (EODHD: 5s connect / 30s read);
         // header-bar keystrokes can't tolerate that latency when one provider is stalled.
         private const val SEARCH_TIMEOUT_MS = 3000L
+
+        // Markets that float to the top of header-bar fan-out results.
+        private val US_MARKETS = setOf("US", "NYSE", "NASDAQ", "AMEX")
 
         private val ALLOWED_SECURITY_TYPES =
             setOf(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -83,9 +83,12 @@ class AssetSearchService(
         keyword: String,
         market: String
     ): AssetSearchResponse {
-        val localResults = searchLocalAssets(keyword)
+        // Use the DB-only lookup here. Market-scoped searches go through
+        // `searchPublicAssets(market)` for external routing — the broader null-market fan-out
+        // inside `searchLocalAssets` would fire scoped + unscoped external calls on the same
+        // request, doubling latency and rate-limit pressure for no extra coverage.
         val filtered =
-            localResults.data.filter {
+            searchLocalDbAssets(keyword).filter {
                 it.market.equals(market, ignoreCase = true)
             }
 
@@ -133,32 +136,17 @@ class AssetSearchService(
     }
 
     /**
-     * Search all assets in the local database by code or name.
-     * Falls back to FIGI global search when local results are empty.
-     * De-duplicates by code, preferring US market when duplicates exist.
+     * Null-market (header bar) entry point: DB lookup first; on miss, fan out across every
+     * registered price provider's search surface plus FIGI global, merge + dedupe by
+     * `(symbol, market)`.
+     *
+     * Market-scoped searches must call [searchLocalDbAssets] directly — the fan-out here is
+     * intentionally null-market only.
      */
     private fun searchLocalAssets(keyword: String): AssetSearchResponse {
-        val assets = assetRepository.searchByCodeOrName(keyword)
-        // Group by code and pick the preferred market variant (US preferred)
-        val marketPriority = listOf("US", "NYSE", "NASDAQ", "ASX", "NZX")
-        val deduped =
-            assets
-                .groupBy { it.code.uppercase() }
-                .map { (_, variants) ->
-                    variants.minByOrNull { asset ->
-                        val idx = marketPriority.indexOf(asset.marketCode)
-                        if (idx >= 0) idx else marketPriority.size
-                    } ?: variants.first()
-                }
-        val results = deduped.take(50).map { toLocalSearchResult(it) }
-
+        val results = searchLocalDbAssets(keyword)
         if (results.isNotEmpty()) return AssetSearchResponse(results)
 
-        // No DB hit. Fan out across every registered price provider's search surface so a
-        // keyword from the header bar (no market) reaches EODHD / Alpha / MarketStack / etc.
-        // Providers that don't honour null-market simply contribute nothing (default impl
-        // returns empty). FIGI global runs alongside, then results are merged + deduped by
-        // (symbol, market).
         val providerHits =
             mdFactory.getAllProviders().flatMap { provider ->
                 try {
@@ -182,6 +170,26 @@ class AssetSearchService(
                 "${it.symbol.uppercase()}|${(it.market ?: "").uppercase()}"
             }
         return AssetSearchResponse(merged)
+    }
+
+    /**
+     * Pure DB-only lookup with the US-preferred dedupe. Used by both the null-market entry
+     * (`searchLocalAssets`) and market-scoped lookups (`searchMarketAssets`) so neither has to
+     * pay for the other's external fan-out.
+     */
+    private fun searchLocalDbAssets(keyword: String): List<AssetSearchResult> {
+        val assets = assetRepository.searchByCodeOrName(keyword)
+        val marketPriority = listOf("US", "NYSE", "NASDAQ", "ASX", "NZX")
+        val deduped =
+            assets
+                .groupBy { it.code.uppercase() }
+                .map { (_, variants) ->
+                    variants.minByOrNull { asset ->
+                        val idx = marketPriority.indexOf(asset.marketCode)
+                        if (idx >= 0) idx else marketPriority.size
+                    } ?: variants.first()
+                }
+        return deduped.take(50).map { toLocalSearchResult(it) }
     }
 
     // Markets that use FIGI for search (configured via figi.search.markets)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -103,7 +103,6 @@ class AssetService(
             } catch (_: DataIntegrityViolationException) {
                 // Race condition: another request created this asset concurrently
                 // Use new transaction as current one is marked for rollback
-                log.debug("Asset {} already exists, fetching existing", assetInput.code)
                 newTxTemplate.execute {
                     assetFinder.findLocally(assetInput)
                 } ?: throw BusinessException("Unable to resolve asset ${assetInput.code}")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfig.kt
@@ -15,19 +15,34 @@ class ExternalApiRestClientConfig {
     companion object {
         private const val CONNECT_TIMEOUT_MS = 5000
         private const val READ_TIMEOUT_MS = 30000
+
+        // Interactive asset-search calls (header bar). withTimeoutOrNull in the coroutine
+        // fan-out can't cancel a blocking RestClient call cooperatively, so the only way to
+        // cap user-visible latency is to set the underlying HTTP timeouts low. EODHD search
+        // returns a small JSON array — 2s connect / 3s read is plenty when the provider is
+        // healthy and forces a fast failure when it isn't.
+        private const val SEARCH_CONNECT_TIMEOUT_MS = 2000
+        private const val SEARCH_READ_TIMEOUT_MS = 3000
     }
 
-    private fun createRequestFactory(): SimpleClientHttpRequestFactory =
+    private fun createRequestFactory(
+        connectTimeoutMs: Int = CONNECT_TIMEOUT_MS,
+        readTimeoutMs: Int = READ_TIMEOUT_MS
+    ): SimpleClientHttpRequestFactory =
         SimpleClientHttpRequestFactory().apply {
-            setConnectTimeout(CONNECT_TIMEOUT_MS)
-            setReadTimeout(READ_TIMEOUT_MS)
+            setConnectTimeout(connectTimeoutMs)
+            setReadTimeout(readTimeoutMs)
         }
 
-    private fun buildRestClient(baseUrl: String): RestClient =
+    private fun buildRestClient(
+        baseUrl: String,
+        connectTimeoutMs: Int = CONNECT_TIMEOUT_MS,
+        readTimeoutMs: Int = READ_TIMEOUT_MS
+    ): RestClient =
         RestClient
             .builder()
             .baseUrl(baseUrl)
-            .requestFactory(createRequestFactory())
+            .requestFactory(createRequestFactory(connectTimeoutMs, readTimeoutMs))
             .requestInterceptor(SentryTracingInterceptor())
             .build()
 
@@ -60,4 +75,14 @@ class ExternalApiRestClientConfig {
     fun eodhdRestClient(
         @Value($$"${beancounter.market.providers.eodhd.url:https://eodhd.com}") baseUrl: String
     ): RestClient = buildRestClient(baseUrl)
+
+    @Bean
+    fun eodhdSearchRestClient(
+        @Value($$"${beancounter.market.providers.eodhd.url:https://eodhd.com}") baseUrl: String
+    ): RestClient =
+        buildRestClient(
+            baseUrl,
+            connectTimeoutMs = SEARCH_CONNECT_TIMEOUT_MS,
+            readTimeoutMs = SEARCH_READ_TIMEOUT_MS
+        )
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers
 
+import com.beancounter.common.contracts.AssetSearchResult
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.model.Asset
@@ -53,6 +54,20 @@ interface MarketDataPriceProvider {
      * and need read-time rebasement.
      */
     fun shipsAdjustedClose(): Boolean = false
+
+    /**
+     * Search the provider for assets matching `keyword`. Providers that have no search surface
+     * (cash, custom, morningstar) return the empty default; price providers wired to a real
+     * search endpoint (EODHD, AlphaVantage, MarketStack) override.
+     *
+     * `market` is the BC market code the caller is scoping to, or `null` for an unscoped search
+     * (e.g. the global header bar). Providers that require a market — like MarketStack, which
+     * needs an exchange MIC — return empty for `null` rather than fabricating a default.
+     */
+    fun searchAssets(
+        keyword: String,
+        market: String?
+    ): List<AssetSearchResult> = emptyList()
 
     companion object {
         // Default window when no caller-supplied `fromDate`. Matches the

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MdFactory.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MdFactory.kt
@@ -72,6 +72,13 @@ class MdFactory internal constructor(
     fun getMarketDataProvider(provider: String): MarketDataPriceProvider =
         providers[provider.uppercase(Locale.getDefault())]!!
 
+    /**
+     * Registered providers in declaration order. Used by asset-search fan-out so a header-bar
+     * keyword with no market still reaches every provider's search surface (e.g. EODHD when
+     * configured, regardless of FIGI's coverage).
+     */
+    fun getAllProviders(): Collection<MarketDataPriceProvider> = providers.values
+
     private fun resolveProvider(market: Market): MarketDataPriceProvider {
         // ToDo: Map Market to Provider
         for (key in providers.keys) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
@@ -19,7 +19,14 @@ import org.springframework.web.client.body
 @Component
 class EodhdGateway(
     @Qualifier("eodhdRestClient")
-    private val restClient: RestClient
+    private val restClient: RestClient,
+    // Search calls fire from the header bar on every keystroke. Use the dedicated
+    // short-timeout client (2s connect / 3s read) so a stalled EODHD edge can't drag
+    // the user response out for the 5s/30s price-tier defaults — the coroutine
+    // withTimeoutOrNull wrapper is cosmetic without a real HTTP-layer cap because
+    // blocking RestClient calls aren't cooperatively cancellable.
+    @Qualifier("eodhdSearchRestClient")
+    private val searchRestClient: RestClient
 ) {
     /**
      * Single-day EOD price for one symbol.
@@ -148,7 +155,7 @@ class EodhdGateway(
         query: String,
         apiKey: String = DEMO_KEY
     ): List<EodhdSearchResult> =
-        restClient
+        searchRestClient
             .get()
             .uri("/api/search/{query}?api_token={apiKey}&fmt=json", query, apiKey)
             .retrieve()

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.providers.eodhd
 import com.beancounter.marketdata.providers.eodhd.model.EodhdDividend
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.model.EodhdPrice
+import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import com.beancounter.marketdata.providers.eodhd.model.EodhdSplit
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
@@ -134,6 +135,26 @@ class EodhdGateway(
             ?.toList()
             ?: emptyList()
     }
+
+    /**
+     * Asset search by ticker code or name fragment.
+     *
+     * GET /api/search/{query}?api_token={apiKey}&fmt=json
+     *
+     * EODHD returns a JSON array of asset descriptors. Used by [EodhdPriceService.searchAssets]
+     * so the asset-lookup UI surfaces tickers EODHD will go on to price.
+     */
+    fun searchAssets(
+        query: String,
+        apiKey: String = DEMO_KEY
+    ): List<EodhdSearchResult> =
+        restClient
+            .get()
+            .uri("/api/search/{query}?api_token={apiKey}&fmt=json", query, apiKey)
+            .retrieve()
+            .body<Array<EodhdSearchResult>>()
+            ?.toList()
+            ?: emptyList()
 
     companion object {
         const val DEMO_KEY = "demo"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.common.contracts.AssetSearchResult
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.model.Asset
@@ -100,6 +101,39 @@ class EodhdPriceService(
     // that value as `MarketData.close` (see PR #875). SplitAdjuster must skip
     // dividing EODHD rows so corporate_event splits don't double-adjust them.
     override fun shipsAdjustedClose(): Boolean = true
+
+    /**
+     * Search EODHD `/api/search/{query}` for matches. Gated on the EODHD markets allowlist —
+     * an unconfigured deployment returns empty so [AssetSearchService] falls back to the legacy
+     * FIGI / AlphaVantage chain. `market` is informational only at this layer (EODHD searches
+     * globally and returns the exchange per result); the caller decides whether to filter.
+     */
+    override fun searchAssets(
+        keyword: String,
+        market: String?
+    ): List<AssetSearchResult> {
+        if (eodhdConfig.markets.isNullOrBlank()) return emptyList()
+        return try {
+            eodhdProxy
+                .searchAssets(keyword, eodhdConfig.apiKey)
+                .map { row ->
+                    AssetSearchResult(
+                        symbol = row.code,
+                        name = row.name,
+                        type = row.type ?: "Equity",
+                        region = row.exchange,
+                        currency = row.currency,
+                        market = row.exchange
+                    )
+                }
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.warn("EODHD search for '{}' failed: {}", keyword, e.message)
+            emptyList()
+        }
+    }
 
     companion object {
         const val ID = "EODHD"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdProxy.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.providers.eodhd
 import com.beancounter.marketdata.providers.eodhd.model.EodhdDividend
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.model.EodhdPrice
+import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import com.beancounter.marketdata.providers.eodhd.model.EodhdSplit
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter
 import org.springframework.stereotype.Service
@@ -74,6 +75,16 @@ class EodhdProxy(
             symbol,
             limit,
             from,
+            apiKey
+        )
+
+    @RateLimiter(name = "eodhd")
+    fun searchAssets(
+        query: String,
+        apiKey: String
+    ): List<EodhdSearchResult> =
+        eodhdGateway.searchAssets(
+            query,
             apiKey
         )
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/model/EodhdSearchResult.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/model/EodhdSearchResult.kt
@@ -1,0 +1,29 @@
+package com.beancounter.marketdata.providers.eodhd.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * EODHD search result row.
+ *
+ * Endpoint: GET /api/search/{query}?api_token={key}&fmt=json
+ * Returns an array of these objects.
+ *
+ * Field casing in the EODHD response is PascalCase; map explicitly so Kotlin property names stay
+ * idiomatic without relying on a global Jackson naming strategy.
+ */
+data class EodhdSearchResult(
+    @param:JsonProperty("Code")
+    val code: String,
+    @param:JsonProperty("Exchange")
+    val exchange: String,
+    @param:JsonProperty("Name")
+    val name: String,
+    @param:JsonProperty("Type")
+    val type: String? = null,
+    @param:JsonProperty("Country")
+    val country: String? = null,
+    @param:JsonProperty("Currency")
+    val currency: String? = null,
+    @param:JsonProperty("ISIN")
+    val isin: String? = null
+)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.assets
 
+import com.beancounter.common.contracts.AssetSearchResult
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.Market
 import com.beancounter.common.utils.BcJson
@@ -10,6 +11,8 @@ import com.beancounter.marketdata.assets.figi.FigiFilterResult
 import com.beancounter.marketdata.assets.figi.FigiGateway
 import com.beancounter.marketdata.assets.figi.FigiResponse
 import com.beancounter.marketdata.markets.MarketService
+import com.beancounter.marketdata.providers.MarketDataPriceProvider
+import com.beancounter.marketdata.providers.MdFactory
 import com.beancounter.marketdata.providers.alpha.AlphaConfig
 import com.beancounter.marketdata.providers.alpha.AlphaProxy
 import com.beancounter.marketdata.providers.marketstack.MarketStackConfig
@@ -18,7 +21,9 @@ import com.beancounter.marketdata.registration.SystemUserService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -45,7 +50,10 @@ class AssetSearchPublicFallbackTest {
         figiTickerHits: Collection<FigiResponse> = emptyList(),
         figiFilterHits: FigiFilterResponse = FigiFilterResponse(),
         alphaResponse: String = alphaJson,
-        alphaProxy: AlphaProxy = mock { on { search(any(), any()) } doReturn alphaResponse }
+        alphaProxy: AlphaProxy = mock { on { search(any(), any()) } doReturn alphaResponse },
+        marketProvider: MarketDataPriceProvider =
+            mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+        allProviders: Collection<MarketDataPriceProvider> = listOf(marketProvider)
     ): Pair<AssetSearchService, AlphaProxy> {
         val alphaConfig =
             mock<AlphaConfig> {
@@ -64,6 +72,11 @@ class AssetSearchPublicFallbackTest {
                 enabled = true
                 searchMarkets = "US"
             }
+        val mdFactory =
+            mock<MdFactory> {
+                on { getMarketDataProvider(any<Market>()) } doReturn marketProvider
+                on { getAllProviders() } doReturn allProviders
+            }
         val service =
             AssetSearchService(
                 assetRepository =
@@ -80,7 +93,8 @@ class AssetSearchPublicFallbackTest {
                 figiConfig = figiConfig,
                 marketService =
                     mock<MarketService> { on { getMarket(any()) } doReturn usMarket },
-                systemUserService = mock<SystemUserService>()
+                systemUserService = mock<SystemUserService>(),
+                mdFactory = mdFactory
             )
         return service to alphaProxy
     }
@@ -162,6 +176,65 @@ class AssetSearchPublicFallbackTest {
         assertThat(results.data).isNotEmpty
         assertThat(results.data.first().symbol).isEqualTo("COWZ")
         verify(alphaProxy, never()).search(any(), any())
+    }
+
+    @Test
+    fun `market search routes through configured price provider before legacy chain`() {
+        val provider =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn
+                    listOf(
+                        AssetSearchResult(
+                            symbol = "HYSA",
+                            name = "Pacer International HY Corp Bond ETF",
+                            type = "ETF",
+                            region = "US",
+                            currency = "USD",
+                            market = "US"
+                        )
+                    )
+            }
+        val alphaProxy = mock<AlphaProxy>()
+        val (service, _) = buildService(marketProvider = provider, alphaProxy = alphaProxy)
+
+        val results = service.search("HYSA", "US")
+
+        assertThat(results.data)
+            .extracting<String> { it.symbol }
+            .containsExactly("HYSA")
+        verify(provider).searchAssets(eq("HYSA"), eq("US"))
+        verify(alphaProxy, never()).search(any(), any())
+    }
+
+    @Test
+    fun `null-market search fans out across all registered providers`() {
+        val provider =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn
+                    listOf(
+                        AssetSearchResult(
+                            symbol = "HYSA",
+                            name = "Pacer International HY Corp Bond ETF",
+                            type = "ETF",
+                            region = "US",
+                            currency = "USD",
+                            market = "US"
+                        )
+                    )
+            }
+        val (service, _) =
+            buildService(
+                marketProvider =
+                    mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                allProviders = listOf(provider)
+            )
+
+        val results = service.search("HYSA", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.symbol }
+            .contains("HYSA")
+        verify(provider).searchAssets(eq("HYSA"), anyOrNull())
     }
 
     companion object {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
@@ -241,6 +242,44 @@ class AssetSearchPublicFallbackTest {
         verify(provider).searchAssets(eq("HYSA"), isNull())
         // Header-bar search must not hit AlphaVantage as a side effect of the fan-out.
         verify(alphaProxy, never()).search(any(), any())
+    }
+
+    @Test
+    fun `null-market fan-out keeps healthy provider results when sibling throws`() {
+        // Regression guard for the supervisorScope wrapper: a thrown provider must not
+        // cancel siblings or propagate up. Real-world trigger: EODHD connect-timeout while
+        // FIGI/Alpha are healthy.
+        val healthy =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn
+                    listOf(
+                        AssetSearchResult(
+                            symbol = "HYSA",
+                            name = HYSA_NAME,
+                            type = "ETF",
+                            region = "US",
+                            currency = "USD",
+                            market = "US"
+                        )
+                    )
+            }
+        val broken =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doThrow RuntimeException("upstream down")
+                on { getId() } doReturn "BROKEN"
+            }
+        val (service, _) =
+            buildService(
+                marketProvider =
+                    mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                allProviders = listOf(broken, healthy)
+            )
+
+        val results = service.search("HYSA", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.symbol }
+            .contains("HYSA")
     }
 
     companion object {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -222,11 +223,13 @@ class AssetSearchPublicFallbackTest {
                         )
                     )
             }
+        val alphaProxy = mock<AlphaProxy>()
         val (service, _) =
             buildService(
                 marketProvider =
                     mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
-                allProviders = listOf(provider)
+                allProviders = listOf(provider),
+                alphaProxy = alphaProxy
             )
 
         val results = service.search("HYSA", null)
@@ -234,7 +237,10 @@ class AssetSearchPublicFallbackTest {
         assertThat(results.data)
             .extracting<String> { it.symbol }
             .contains("HYSA")
-        verify(provider).searchAssets(eq("HYSA"), anyOrNull())
+        // Forwarded market must be null — anyOrNull() would mask a leaked non-null.
+        verify(provider).searchAssets(eq("HYSA"), isNull())
+        // Header-bar search must not hit AlphaVantage as a side effect of the fan-out.
+        verify(alphaProxy, never()).search(any(), any())
     }
 
     companion object {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -245,6 +245,44 @@ class AssetSearchPublicFallbackTest {
     }
 
     @Test
+    fun `null-market fan-out returns US-market hits before non-US`() {
+        val provider =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn
+                    listOf(
+                        AssetSearchResult(
+                            symbol = "ABC",
+                            name = "ABC London",
+                            type = "Equity",
+                            region = "LON",
+                            currency = "GBP",
+                            market = "LON"
+                        ),
+                        AssetSearchResult(
+                            symbol = "ABC",
+                            name = "ABC US",
+                            type = "Equity",
+                            region = "US",
+                            currency = "USD",
+                            market = "US"
+                        )
+                    )
+            }
+        val (service, _) =
+            buildService(
+                marketProvider =
+                    mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                allProviders = listOf(provider)
+            )
+
+        val results = service.search("ABC", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.market }
+            .containsExactly("US", "LON")
+    }
+
+    @Test
     fun `null-market fan-out keeps healthy provider results when sibling throws`() {
         // Regression guard for the supervisorScope wrapper: a thrown provider must not
         // cancel siblings or propagate up. Real-world trigger: EODHD connect-timeout while

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -186,7 +186,7 @@ class AssetSearchPublicFallbackTest {
                     listOf(
                         AssetSearchResult(
                             symbol = "HYSA",
-                            name = "Pacer International HY Corp Bond ETF",
+                            name = HYSA_NAME,
                             type = "ETF",
                             region = "US",
                             currency = "USD",
@@ -214,7 +214,7 @@ class AssetSearchPublicFallbackTest {
                     listOf(
                         AssetSearchResult(
                             symbol = "HYSA",
-                            name = "Pacer International HY Corp Bond ETF",
+                            name = HYSA_NAME,
                             type = "ETF",
                             region = "US",
                             currency = "USD",
@@ -239,5 +239,6 @@ class AssetSearchPublicFallbackTest {
 
     companion object {
         private const val MUTUAL_FUND = "Mutual Fund"
+        private const val HYSA_NAME = "Pacer International HY Corp Bond ETF"
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -55,7 +55,8 @@ class AssetSearchPublicFallbackTest {
         alphaProxy: AlphaProxy = mock { on { search(any(), any()) } doReturn alphaResponse },
         marketProvider: MarketDataPriceProvider =
             mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
-        allProviders: Collection<MarketDataPriceProvider> = listOf(marketProvider)
+        allProviders: Collection<MarketDataPriceProvider> = listOf(marketProvider),
+        dbAssets: List<com.beancounter.common.model.Asset> = emptyList()
     ): Pair<AssetSearchService, AlphaProxy> {
         val alphaConfig =
             mock<AlphaConfig> {
@@ -82,7 +83,7 @@ class AssetSearchPublicFallbackTest {
         val service =
             AssetSearchService(
                 assetRepository =
-                    mock { on { searchByCodeOrName(any()) } doReturn emptyList() },
+                    mock { on { searchByCodeOrName(any()) } doReturn dbAssets },
                 alphaProxy = alphaProxy,
                 alphaConfig = alphaConfig,
                 marketStackGateway = mock<MarketStackGateway>(),
@@ -242,6 +243,84 @@ class AssetSearchPublicFallbackTest {
         verify(provider).searchAssets(eq("HYSA"), isNull())
         // Header-bar search must not hit AlphaVantage as a side effect of the fan-out.
         verify(alphaProxy, never()).search(any(), any())
+    }
+
+    @Test
+    fun `DB substring-only match does not shadow provider exact-code match`() {
+        // Regression: searching "TSM" only returned "Huntsman" (DB substring on name) and never
+        // surfaced Taiwan Semiconductor from the provider fan-out. Fix: short-circuit on
+        // exact-code DB match only; otherwise merge DB + fan-out.
+        val huntsman =
+            com.beancounter.common.model.Asset(
+                id = "huntsman-us",
+                code = "HUN",
+                name = "Huntsman Corporation",
+                market =
+                    com.beancounter.common.model
+                        .Market("NYSE", currencyId = "USD"),
+                marketCode = "NYSE",
+                category = "Equity"
+            )
+        val provider =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn
+                    listOf(
+                        AssetSearchResult(
+                            symbol = "TSM",
+                            name = "Taiwan Semiconductor Manufacturing",
+                            type = "ADR",
+                            region = "US",
+                            currency = "USD",
+                            market = "US"
+                        )
+                    )
+            }
+        val (service, _) =
+            buildService(
+                marketProvider =
+                    mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                allProviders = listOf(provider),
+                dbAssets = listOf(huntsman)
+            )
+
+        val results = service.search("TSM", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.symbol }
+            .contains("TSM", "HUN")
+        verify(provider).searchAssets(eq("TSM"), isNull())
+    }
+
+    @Test
+    fun `exact-code DB match short-circuits the provider fan-out`() {
+        // Inverse of the TSM/Huntsman regression: when the DB already has an exact code match,
+        // don't burn external provider calls on every keystroke.
+        val tsm =
+            com.beancounter.common.model.Asset(
+                id = "tsm-us",
+                code = "TSM",
+                name = "Taiwan Semiconductor ADR",
+                market =
+                    com.beancounter.common.model
+                        .Market("NYSE", currencyId = "USD"),
+                marketCode = "NYSE",
+                category = "Equity"
+            )
+        val provider = mock<MarketDataPriceProvider>()
+        val (service, _) =
+            buildService(
+                marketProvider =
+                    mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                allProviders = listOf(provider),
+                dbAssets = listOf(tsm)
+            )
+
+        val results = service.search("TSM", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.symbol }
+            .containsExactly("TSM")
+        verify(provider, never()).searchAssets(any(), anyOrNull())
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -184,6 +184,32 @@ internal class EodhdApiTest {
         assertThat(result.first().source).isEqualTo(ID)
     }
 
+    @Test
+    fun `searchAssets surfaces EODHD search hits end-to-end`() {
+        // Covers EodhdPriceService.searchAssets → EodhdProxy.searchAssets → EodhdGateway
+        // through the real RestClient + WireMock, so all three layers see actual HTTP traffic
+        // instead of unit-level mocks.
+        val body = ClassPathResource("mock/eodhd/search-HYSA.json").file.readText()
+        stubFor(
+            get(urlPathEqualTo("/api/search/HYSA"))
+                .willReturn(
+                    aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(body)
+                        .withStatus(200)
+                )
+        )
+
+        val results = eodhdPriceService.searchAssets("HYSA", "US")
+
+        assertThat(results).hasSize(1)
+        val hit = results.first()
+        assertThat(hit.symbol).isEqualTo("HYSA")
+        assertThat(hit.market).isEqualTo("US")
+        assertThat(hit.currency).isEqualTo("USD")
+        assertThat(hit.type).isEqualTo("ETF")
+    }
+
     private fun stubEod(
         symbol: String,
         fixturePath: String

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
@@ -1,0 +1,103 @@
+package com.beancounter.marketdata.providers.eodhd
+
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.markets.MarketService
+import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.test.util.ReflectionTestUtils
+
+/**
+ * Unit tests for [EodhdPriceService.searchAssets]. End-to-end persistence is exercised by the
+ * Spring + WireMock stack ([EodhdApiTest]); this spec pins the routing logic, the
+ * empty-allowlist gate, and the response mapping shape.
+ */
+internal class EodhdPriceServiceSearchTest {
+    private val proxy = mock<EodhdProxy>()
+    private val marketService = mock<MarketService>()
+    private val adapter = mock<EodhdAdapter>()
+    private val dateUtils = DateUtils()
+
+    private fun configWithMarkets(markets: String): EodhdConfig =
+        EodhdConfig(marketService).also {
+            ReflectionTestUtils.setField(it, "apiKey", "demo")
+            ReflectionTestUtils.setField(it, "markets", markets)
+        }
+
+    @Test
+    fun `searchAssets returns mapped results from EODHD search`() {
+        val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(
+                EodhdSearchResult(
+                    code = "HYSA",
+                    exchange = "US",
+                    name = "Pacer International HY Corp Bond ETF",
+                    type = "ETF",
+                    country = "USA",
+                    currency = "USD",
+                    isin = "US69374H4047"
+                )
+            )
+        )
+
+        val results = service.searchAssets("HYSA", "US")
+
+        assertThat(results).hasSize(1)
+        val hysa = results.first()
+        assertThat(hysa.symbol).isEqualTo("HYSA")
+        assertThat(hysa.name).isEqualTo("Pacer International HY Corp Bond ETF")
+        assertThat(hysa.market).isEqualTo("US")
+        assertThat(hysa.currency).isEqualTo("USD")
+        assertThat(hysa.type).isEqualTo("ETF")
+    }
+
+    @Test
+    fun `searchAssets returns empty when EODHD markets allowlist is empty`() {
+        val service = EodhdPriceService(configWithMarkets(""), proxy, adapter, dateUtils)
+
+        val results = service.searchAssets("HYSA", "US")
+
+        assertThat(results).isEmpty()
+        verify(proxy, never()).searchAssets(any(), any())
+    }
+
+    @Test
+    fun `searchAssets with null market still queries EODHD when provider is enabled`() {
+        val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(
+                EodhdSearchResult(
+                    code = "HYSA",
+                    exchange = "US",
+                    name = "Pacer International HY Corp Bond ETF",
+                    type = "ETF",
+                    country = "USA",
+                    currency = "USD",
+                    isin = null
+                )
+            )
+        )
+
+        val results = service.searchAssets("HYSA", null)
+
+        assertThat(results).extracting<String> { it.symbol }.containsExactly("HYSA")
+        verify(proxy).searchAssets("HYSA", "demo")
+    }
+
+    @Test
+    fun `searchAssets swallows transient errors and returns empty`() {
+        val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenThrow(RuntimeException("boom"))
+
+        val results = service.searchAssets("HYSA", "US")
+
+        assertThat(results).isEmpty()
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
@@ -38,7 +38,7 @@ internal class EodhdPriceServiceSearchTest {
                 EodhdSearchResult(
                     code = "HYSA",
                     exchange = "US",
-                    name = "Pacer International HY Corp Bond ETF",
+                    name = HYSA_NAME,
                     type = "ETF",
                     country = "USA",
                     currency = "USD",
@@ -52,7 +52,7 @@ internal class EodhdPriceServiceSearchTest {
         assertThat(results).hasSize(1)
         val hysa = results.first()
         assertThat(hysa.symbol).isEqualTo("HYSA")
-        assertThat(hysa.name).isEqualTo("Pacer International HY Corp Bond ETF")
+        assertThat(hysa.name).isEqualTo(HYSA_NAME)
         assertThat(hysa.market).isEqualTo("US")
         assertThat(hysa.currency).isEqualTo("USD")
         assertThat(hysa.type).isEqualTo("ETF")
@@ -76,7 +76,7 @@ internal class EodhdPriceServiceSearchTest {
                 EodhdSearchResult(
                     code = "HYSA",
                     exchange = "US",
-                    name = "Pacer International HY Corp Bond ETF",
+                    name = HYSA_NAME,
                     type = "ETF",
                     country = "USA",
                     currency = "USD",
@@ -89,6 +89,10 @@ internal class EodhdPriceServiceSearchTest {
 
         assertThat(results).extracting<String> { it.symbol }.containsExactly("HYSA")
         verify(proxy).searchAssets("HYSA", "demo")
+    }
+
+    companion object {
+        private const val HYSA_NAME = "Pacer International HY Corp Bond ETF"
     }
 
     @Test

--- a/svc-data/src/test/resources/mock/eodhd/search-HYSA.json
+++ b/svc-data/src/test/resources/mock/eodhd/search-HYSA.json
@@ -1,0 +1,11 @@
+[
+  {
+    "Code": "HYSA",
+    "Exchange": "US",
+    "Name": "Pacer International HY Corp Bond ETF",
+    "Type": "ETF",
+    "Country": "USA",
+    "Currency": "USD",
+    "ISIN": "US69374H4047"
+  }
+]


### PR DESCRIPTION
## Summary
- Header-bar asset search sent no `market`, so `AssetSearchService` routed every header keyword through `searchLocalAssets` → DB + FIGI global only. AlphaVantage and EODHD were never asked. HYSA (real US ETF, returned by EODHD `/api/search/HYSA`) found nothing from the header; the assets page found it because `market=US` took the FIGI→Alpha fallback.
- Now: market-scoped search asks the market's configured price provider first (symmetric with `MdFactory` price routing), then falls back to the legacy FIGI/MarketStack/Alpha chain. Null-market search fans out across every registered provider's `searchAssets` and merges with FIGI global, deduped by `(symbol, market)`.
- EODHD `/api/search/{query}` is now wired in `EodhdGateway` / `EodhdProxy` / `EodhdPriceService.searchAssets`. Gated on the existing EODHD `markets` allowlist — deployments without EODHD configured see no behaviour change.

## Why this scope
- `MarketDataPriceProvider.searchAssets` has a default `emptyList()` so cash/custom/morningstar providers (no search surface) opt out cleanly.
- Alpha + MarketStack search bodies stay in `AssetSearchService` for now. A follow-up will move them into their own price services for full symmetry. Behaviour is preserved by the existing FIGI/Alpha fallback path.

## Test plan
- [x] `EodhdPriceServiceSearchTest` — happy path, allowlist gate, null-market still queries, transient error swallowed
- [x] `AssetSearchPublicFallbackTest` — provider routing wins over Alpha when market specified; null-market fans out across providers
- [x] `./gradlew testSmart formatKotlin lintKotlin` clean
- [ ] On kauri: header search for `HYSA` returns the EODHD row; `/assets/lookup?market=US` for `HYSA` still works
- [ ] On kauri: header search for already-local tickers (e.g. `AAPL`) still resolves from DB without hitting EODHD twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset search now prefers the configured market provider when a market is specified and can fan out across all registered providers for broader, deduped, market-prioritized results
  * EODHD integration adds asset search with mapped results and a dedicated, faster search client

* **Tests**
  * Added unit and integration tests for provider routing, fan-out ordering, resilience, EODHD mapping and error handling, plus a new EODHD mock fixture

* **Chores**
  * CI step now surfaces analysis errors and SARIF findings as non-blocking warnings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->