### PR TITLE
fix(client): demote 4xx to WARN, retry+timeout bcData price calls

### DIFF
--- a/jar-client/src/main/kotlin/com/beancounter/client/config/RestClientConfig.kt
+++ b/jar-client/src/main/kotlin/com/beancounter/client/config/RestClientConfig.kt
@@ -10,27 +10,32 @@ import org.springframework.web.client.RestClient
 
 /**
  * Configuration for RestClient used by all jar-client services.
+ *
+ * Timeouts are externalised via `marketdata.client.connect-timeout-ms` and
+ * `marketdata.client.read-timeout-ms`. Services that issue large batch calls
+ * to bc-data (e.g. svc-position bulk price valuation) should raise the read
+ * timeout in their own application.yml. Retries on transient
+ * ResourceAccessException are handled by Resilience4j `@Retry(name = "bcData")`
+ * at the call site — bumping the timeout reduces noise; retry covers what's
+ * left.
  */
 @Configuration
 class RestClientConfig {
     @Bean
     fun bcDataRestClient(
-        @Value($$"${marketdata.url:http://localhost:9510/api}") baseUrl: String
+        @Value($$"${marketdata.url:http://localhost:9510/api}") baseUrl: String,
+        @Value($$"${marketdata.client.connect-timeout-ms:5000}") connectTimeoutMs: Int,
+        @Value($$"${marketdata.client.read-timeout-ms:30000}") readTimeoutMs: Int
     ): RestClient =
         RestClient
             .builder()
             .baseUrl(baseUrl)
             .requestFactory(
                 SimpleClientHttpRequestFactory().apply {
-                    setConnectTimeout(CONNECT_TIMEOUT_MS)
-                    setReadTimeout(READ_TIMEOUT_MS)
+                    setConnectTimeout(connectTimeoutMs)
+                    setReadTimeout(readTimeoutMs)
                 }
             ).requestInterceptor(SentryTracingInterceptor())
             .defaultStatusHandler(RestClientErrorHandler())
             .build()
-
-    companion object {
-        private const val CONNECT_TIMEOUT_MS = 5000
-        private const val READ_TIMEOUT_MS = 30000
-    }
 }

--- a/jar-client/src/main/kotlin/com/beancounter/client/services/PriceService.kt
+++ b/jar-client/src/main/kotlin/com/beancounter/client/services/PriceService.kt
@@ -8,6 +8,7 @@ import com.beancounter.common.contracts.EnsureHistoryResponse
 import com.beancounter.common.contracts.PriceRequest
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.exception.BusinessException
+import io.github.resilience4j.retry.annotation.Retry
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -23,6 +24,7 @@ class PriceService(
     private val restClient: RestClient,
     private val tokenService: TokenService
 ) {
+    @Retry(name = "bcData")
     fun getPrices(
         priceRequest: PriceRequest,
         token: String = tokenService.bearerToken
@@ -37,6 +39,7 @@ class PriceService(
             .body(PriceResponse::class.java)
             ?: throw BusinessException("Failed to get prices")
 
+    @Retry(name = "bcData")
     fun getBulkPrices(
         bulkPriceRequest: BulkPriceRequest,
         token: String = tokenService.bearerToken

--- a/jar-common/src/main/kotlin/com/beancounter/common/client/RestClientErrorHandler.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/client/RestClientErrorHandler.kt
@@ -44,7 +44,16 @@ class RestClientErrorHandler : ResponseErrorHandler {
                 "Failed to read response body"
             }
 
-        log.error("HTTP error [$statusCode] $reason")
+        // 4xx is caller fault (bad id, missing portfolio, expired token). Logged
+        // at WARN so it doesn't trip Sentry's ERROR filter — callers that
+        // probe-and-fallback (e.g. PerformanceController.resolvePortfolio) would
+        // otherwise generate a Sentry event per fallback. 5xx is a real
+        // server-side problem and stays at ERROR.
+        if (response.statusCode.is4xxClientError) {
+            log.warn("HTTP error [$statusCode] $reason")
+        } else {
+            log.error("HTTP error [$statusCode] $reason")
+        }
 
         throw when (statusCode) {
             HttpStatus.UNAUTHORIZED.value() -> UnauthorizedException(reason)

--- a/jar-common/src/test/kotlin/com/beancounter/common/client/RestClientErrorHandlerTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/client/RestClientErrorHandlerTest.kt
@@ -1,0 +1,118 @@
+package com.beancounter.common.client
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.exception.ForbiddenException
+import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.exception.SystemException
+import com.beancounter.common.exception.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.ClientHttpResponse
+import org.springframework.mock.http.client.MockClientHttpResponse
+import java.net.URI
+
+/**
+ * Verifies that 4xx responses log at WARN (client / caller fault) while 5xx
+ * responses log at ERROR (server / "get-out-of-bed" issues). Prevents
+ * Sentry noise from controllers that probe-and-fallback (e.g. POSITION-40).
+ */
+class RestClientErrorHandlerTest {
+    private lateinit var logger: Logger
+    private lateinit var appender: ListAppender<ILoggingEvent>
+    private val handler = RestClientErrorHandler()
+    private val uri = URI.create("http://bc-data/api/portfolios/DBS")
+
+    @BeforeEach
+    fun attachAppender() {
+        logger = LoggerFactory.getLogger(RestClientErrorHandler::class.java) as Logger
+        appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+    }
+
+    @AfterEach
+    fun detachAppender() {
+        logger.detachAppender(appender)
+    }
+
+    @Test
+    fun `404 logs at WARN and throws NotFoundException`() {
+        assertThatThrownBy {
+            handler.handleError(uri, HttpMethod.GET, response(HttpStatus.NOT_FOUND, "Portfolio not found: DBS"))
+        }.isInstanceOf(NotFoundException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.WARN)
+            assertThat(it.formattedMessage).contains("404").contains("Portfolio not found: DBS")
+        })
+    }
+
+    @Test
+    fun `401 logs at WARN and throws UnauthorizedException`() {
+        assertThatThrownBy { handler.handleError(uri, HttpMethod.GET, response(HttpStatus.UNAUTHORIZED, "no token")) }
+            .isInstanceOf(UnauthorizedException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.WARN)
+        })
+    }
+
+    @Test
+    fun `403 logs at WARN and throws ForbiddenException`() {
+        assertThatThrownBy { handler.handleError(uri, HttpMethod.GET, response(HttpStatus.FORBIDDEN, "nope")) }
+            .isInstanceOf(ForbiddenException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.WARN)
+        })
+    }
+
+    @Test
+    fun `400 logs at WARN and throws BusinessException`() {
+        assertThatThrownBy { handler.handleError(uri, HttpMethod.GET, response(HttpStatus.BAD_REQUEST, "bad input")) }
+            .isInstanceOf(BusinessException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.WARN)
+        })
+    }
+
+    @Test
+    fun `500 logs at ERROR and throws SystemException`() {
+        assertThatThrownBy {
+            handler.handleError(
+                uri,
+                HttpMethod.GET,
+                response(HttpStatus.INTERNAL_SERVER_ERROR, "boom")
+            )
+        }.isInstanceOf(SystemException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.ERROR)
+            assertThat(it.formattedMessage).contains("500").contains("boom")
+        })
+    }
+
+    @Test
+    fun `503 logs at ERROR and throws SystemException`() {
+        assertThatThrownBy {
+            handler.handleError(
+                uri,
+                HttpMethod.GET,
+                response(HttpStatus.SERVICE_UNAVAILABLE, "down")
+            )
+        }.isInstanceOf(SystemException::class.java)
+        assertThat(appender.list).singleElement().satisfies({
+            assertThat(it.level).isEqualTo(Level.ERROR)
+        })
+    }
+
+    private fun response(
+        status: HttpStatus,
+        body: String
+    ): ClientHttpResponse = MockClientHttpResponse(body.toByteArray(Charsets.UTF_8), status)
+}

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -60,6 +60,12 @@ otel:
 
 marketdata:
   url: "http://localhost:9510/api"
+  client:
+    # Bulk price valuation can be slow on cold-cache portfolios with many
+    # historical gaps. 60s gives bc-data room before the coroutine bails;
+    # Resilience4j @Retry on PriceService handles transient read timeouts.
+    connect-timeout-ms: 5000
+    read-timeout-ms: 60000
 beancounter:
   irr: 365
   valuation:


### PR DESCRIPTION
## Summary

Two open Sentry issues in `bc-position`:

- **POSITION-40** (escalating, 50 events / 4 min, 0 users impacted) — `PerformanceController.resolvePortfolio` probes `getPortfolioById` first and falls back to `getPortfolioByCode`. The 404 on the probe was logged at `ERROR` by `RestClientErrorHandler` before `runCatching` swallowed it, so every code-based lookup created a Sentry event. Split log level: 4xx → `WARN`, 5xx → `ERROR`. Same fix removes Sentry noise across any service that does probe-and-fallback against bc-data.

- **POSITION-36** (regressed, 61 events over 3 months) — scheduled bulk valuation occasionally times out on `bc-data /api/prices` (cold-cache portfolios with many historical gaps). Externalise the `bcData` client timeouts so each service can tune (`marketdata.client.{connect,read}-timeout-ms`), bump `svc-position` read timeout to 60s, and apply `@Retry(name = "bcData")` to `PriceService.getPrices` / `getBulkPrices`. Existing `bcData` retry config already lists `ResourceAccessException` with exponential backoff.

Fixes POSITION-40
Fixes POSITION-36

## Test plan

- [x] New `RestClientErrorHandlerTest` covers 400/401/403/404 → WARN, 500/503 → ERROR (red → green)
- [x] `./gradlew testSmart` green across `jar-common`, `jar-client`, `svc-position`, `svc-data`, `svc-event`
- [x] `./gradlew formatKotlin lintKotlin` clean
- [x] Semgrep scan on changed files — no findings
- [ ] Post-deploy: confirm POSITION-40 stops accumulating events on kauri
- [ ] Post-deploy: monitor POSITION-36 — retry should absorb transient timeouts; if still recurring after 60s timeout, root-cause batch size on bc-data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP connection and read timeouts are now configurable with sensible defaults
  * Automatic retry capability for market data retrieval operations

* **Bug Fixes**
  * Enhanced error logging with differentiated severity levels for client versus server errors

* **Tests**
  * Added comprehensive test coverage for error handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->