### PR TITLE
feat(sentry): ship ERROR slf4j logs to Sentry Logs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ sentry-opentelemetry = { module = "io.sentry:sentry-opentelemetry-core", version
 sentry-spring-boot = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
 micrometer-tracing-bridge-otel = { module = "io.micrometer:micrometer-tracing-bridge-otel", version.ref = "micrometer-tracing" }
 sentry-jdbc = { module = "io.sentry:sentry-jdbc", version.ref = "sentry" }
+sentry-logback = { module = "io.sentry:sentry-logback", version.ref = "sentry" }
 jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 assertj = { module = "org.assertj:assertj-core", version = "3.27.7" }

--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -13,6 +13,10 @@ dependencies {
     api(libs.jackson.kotlin)
     api(libs.sentry.opentelemetry)
     api(libs.sentry.spring.boot)
+    // Logback appender: ships ERROR+ events as Sentry Log records when
+    // sentry.logs.enabled=true. Auto-registered by sentry-spring-boot
+    // starter; no logback-spring.xml changes needed.
+    api(libs.sentry.logback)
     // Bridges Micrometer Observations -> OTel spans so every Beancounter
     // service that pulls jar-common emits Spring AI / Spring MVC / Hikari
     // / Resilience4j / Spring Data observations as OTel spans, which the

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -38,6 +38,13 @@ sentry:
   environment: local
   traces-sample-rate: .2
   debug: false
+  # Ship ERROR-level slf4j logs as Sentry Log records via sentry-logback
+  # appender (auto-registered by spring-boot starter). Gated by env so
+  # local dev doesn't ship; kauri overrides SENTRY_LOGS_ENABLED=true.
+  logs:
+    enabled: ${SENTRY_LOGS_ENABLED:false}
+  logging:
+    minimum-level: error
   # Drop high-frequency RabbitMQ noise from APM (see svc-position application.yml).
   ignored-transactions:
     - "basic\\.ack"

--- a/svc-event/src/main/resources/application.yml
+++ b/svc-event/src/main/resources/application.yml
@@ -13,6 +13,11 @@ sentry:
   environment: local
   traces-sample-rate: 1
   debug: false
+  # Ship ERROR-level slf4j logs as Sentry Log records (see svc-data).
+  logs:
+    enabled: ${SENTRY_LOGS_ENABLED:false}
+  logging:
+    minimum-level: error
   # Drop high-frequency RabbitMQ noise from APM (see svc-position application.yml).
   ignored-transactions:
     - "basic\\.ack"

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -41,6 +41,11 @@ sentry:
   environment: local
   traces-sample-rate: 1
   debug: false
+  # Ship ERROR-level slf4j logs as Sentry Log records (see svc-data).
+  logs:
+    enabled: ${SENTRY_LOGS_ENABLED:false}
+  logging:
+    minimum-level: error
   # Drop the high-frequency RabbitMQ noise from the Most Frequent
   # Transactions report: AMQP basic.ack fires per consumer ack (8.9k/day),
   # the bc-perf-invalidate-demo topic fires per portfolio mutation


### PR DESCRIPTION
## Summary
- Add `sentry-logback` to `jar-common` (api dep) so every BC JVM service auto-registers Sentry's `SentryAppender` via the Spring Boot starter — no `logback-spring.xml` edits needed.
- Enable Sentry Logs in `svc-data`, `svc-position`, `svc-event` `application.yml` at `minimum-level: error`, gated by `SENTRY_LOGS_ENABLED` env (default `false`).
- Local dev stays off; kauri turns on once `bc-deploy` adds `SENTRY_LOGS_ENABLED=true` to the `bc-common` configmap (follow-up PR there).

Why ERROR only: keeps the Logs quota bounded. Lower-level slf4j calls continue to attach as breadcrumbs on existing Sentry issue events.

Downstream: `svc-retire` / `svc-rebalance` pull `jar-common` too, so they pick up the appender for free on their next `jar-common` bump.

## Test plan
- [x] `./gradlew testSmart` green
- [x] `./gradlew formatKotlin lintKotlin` green
- [x] semgrep scan on changed files — no findings
- [ ] After merge + `jar-common` publish + bc-deploy env flip: trigger an ERROR log in `bc-data`, confirm it appears in Sentry Logs view tagged `environment=kauri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentry error logging integration to capture ERROR-level application logs and forward them as Sentry records for improved error monitoring and visibility, controlled via environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/beancounter/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->