### PR TITLE
fix(benchmark): snap monthlyDates cursor to month-end when anchor is last-of-month

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/BenchmarkService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/BenchmarkService.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
 
 /**
  * Computes a benchmark "Growth of 1000" series for a market index aligned to the
@@ -88,20 +89,33 @@ class BenchmarkService(
         return PerformanceResponse(PerformanceData(portfolio.currency, series))
     }
 
+    /**
+     * Monthly grid from [startDate] to [endDate] inclusive. When the anchor is
+     * the last day of its month, every subsequent point is snapped back to the
+     * last day of its month so the grid stays on month-ends rather than
+     * drifting forward by a day after February. java.time's `plusMonths`
+     * clamps day-of-month to the target month's max once, then keeps the
+     * clamped day forever (e.g. 2026-03-31 → 2026-04-30 → 2026-05-30, never
+     * recovers May 31). The snap reverses that drift.
+     *
+     * `endDate` is always present in the result; deduplicated via the set so
+     * the grid lands exactly on `endDate` when it coincides with a month-end
+     * point instead of being appended as an extra trailing element.
+     */
     internal fun monthlyDates(
         startDate: LocalDate,
         endDate: LocalDate
     ): List<LocalDate> {
-        val dates = mutableListOf<LocalDate>()
+        val anchorIsMonthEnd = startDate == startDate.with(TemporalAdjusters.lastDayOfMonth())
+        val dates = sortedSetOf<LocalDate>()
         var cursor = startDate
         while (!cursor.isAfter(endDate)) {
             dates.add(cursor)
-            cursor = cursor.plusMonths(1)
+            val next = cursor.plusMonths(1)
+            cursor = if (anchorIsMonthEnd) next.with(TemporalAdjusters.lastDayOfMonth()) else next
         }
-        if (dates.last() != endDate) {
-            dates.add(endDate)
-        }
-        return dates
+        dates.add(endDate)
+        return dates.toList()
     }
 
     private fun closesByDate(

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/BenchmarkServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/BenchmarkServiceTest.kt
@@ -82,6 +82,42 @@ class BenchmarkServiceTest {
         assertThat(dates.last()).isEqualTo(end)
     }
 
+    /**
+     * Month-end anchor: cursor.plusMonths(1) drifts forward by a day after
+     * the first short month (e.g. 2026-03-31 → 2026-04-30 → 2026-05-30).
+     * Snap each cursor to last-day-of-month so the grid stays on month-ends
+     * and doesn't emit a spurious extra point alongside `endDate`.
+     */
+    @Test
+    fun `monthlyDates snaps to month-end when anchor is the last day of its month`() {
+        val start = LocalDate.of(2026, 3, 31)
+        val end = LocalDate.of(2026, 5, 31)
+        val dates = benchmarkService.monthlyDates(start, end)
+        assertThat(dates)
+            .containsExactly(
+                LocalDate.of(2026, 3, 31),
+                LocalDate.of(2026, 4, 30),
+                LocalDate.of(2026, 5, 31)
+            )
+    }
+
+    /**
+     * Endpoint coincides with a month-end cadence point: it should appear
+     * exactly once (no duplicate trailing append).
+     */
+    @Test
+    fun `monthlyDates does not duplicate endDate when it lands on a cadence point`() {
+        val start = LocalDate.of(2024, 1, 31)
+        val end = LocalDate.of(2024, 3, 31)
+        val dates = benchmarkService.monthlyDates(start, end)
+        assertThat(dates)
+            .containsExactly(
+                LocalDate.of(2024, 1, 31),
+                LocalDate.of(2024, 2, 29), // leap year
+                LocalDate.of(2024, 3, 31)
+            )
+    }
+
     @Test
     fun `series rebases first close to 1000 and scales subsequent closes`() {
         val today = dateUtils.date


### PR DESCRIPTION
## Summary
\`BenchmarkService.monthlyDates\` drifted forward by a day after the first short-month boundary because \`LocalDate.plusMonths\` clamps day-of-month once and never recovers it. A month-end anchor of \`2026-03-31\` produced grid points \`[03-31, 04-30, 05-30]\` instead of \`[03-31, 04-30, 05-31]\`, then the existing fallback appended \`endDate\` as a spurious extra trailing point.

Fix: when the anchor is the last day of its month, snap each subsequent cursor step to \`TemporalAdjusters.lastDayOfMonth()\`. Switch the collector to \`sortedSetOf\` so an \`endDate\` that coincides with a cadence point doesn't duplicate.

## Why it surfaced today
Today (2026-05-31) is itself a month-end and the existing \`series rebases first close to 1000\` test seeds prices keyed on \`today.minusMonths(2)\`/\`minusMonths(1)\`/\`today\` — first time CI ran on a date where every seed was a month-end AND endDate was a month-end. Latent in the service for any month-end-aligned input.

## Test plan
- [x] \`./gradlew :svc-position:test :svc-position:formatKotlin :svc-position:lintKotlin\` — clean
- [x] semgrep clean
- [x] New tests: \`monthlyDates snaps to month-end when anchor is the last day of its month\` + \`monthlyDates does not duplicate endDate when it lands on a cadence point\`
- [x] Pre-existing \`series rebases first close to 1000 and scales subsequent closes\` now passes on month-end dates

## Reviewer notes
- Locally reviewed against the bc-data code-review skill before push (no findings) — \`@coderabbitai ignore\` set to preserve quota.
- Unblocks #904 CI.

@coderabbitai ignore