### PR TITLE
feat(svc-position): resolve /allocation ids via per-id fetch, not caller portfolios filter

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
@@ -431,13 +431,41 @@ class PositionController(
             required = false
         ) targetCurrency: String?
     ): AllocationResponse {
-        val allPortfolios = portfolioServiceClient.portfolios.data
-        val selectedPortfolios =
+        // When `ids` is supplied, fetch each portfolio by id directly through
+        // svc-data rather than filtering the caller's `portfolios` list.
+        // The old filter silently dropped any id the caller couldn't see in
+        // their own portfolio list — fatal for M2M callers (svc-retire
+        // projecting a shared INDEPENDENCE_PLAN), whose `portfolios` is empty
+        // and whose intent is to read the plan owner's portfolios. The per-id
+        // path delegates visibility to svc-data's `canView()`, which returns
+        // true for `AuthConstants.SYSTEM` M2M tokens AND for owners / active
+        // shares of regular user tokens. Net effect: M2M with valid ids gets
+        // the owner's portfolios; user tokens behave identically to before
+        // for ids they could already see.
+        val selectedPortfolios: Collection<com.beancounter.common.model.Portfolio> =
             if (ids.isNullOrBlank()) {
-                allPortfolios
+                portfolioServiceClient.portfolios.data
             } else {
-                val idSet = ids.split(",").map { it.trim() }.toSet()
-                allPortfolios.filter { it.id in idSet }
+                ids
+                    .split(",")
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                    .mapNotNull { id ->
+                        try {
+                            portfolioServiceClient.getPortfolioById(id)
+                        } catch (e: com.beancounter.common.exception.BusinessException) {
+                            // Only "not visible / not found" cases are
+                            // swallowed. Other failures (network, auth)
+                            // propagate so genuine problems aren't silently
+                            // treated as missing ids.
+                            log.debug(
+                                "Skipping portfolio {} (not visible to caller): {}",
+                                id,
+                                e.message
+                            )
+                            null
+                        }
+                    }
             }
 
         if (selectedPortfolios.isEmpty()) {

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
@@ -320,4 +320,73 @@ class PositionControllerTest {
             eq(true)
         )
     }
+
+    /**
+     * Allocation must resolve `ids` via per-id fetches (`getPortfolioById`)
+     * rather than filtering the caller's `portfolios` list. The old filter
+     * silently dropped any id the caller couldn't see — fatal for service-
+     * account callers like svc-retire that hold no portfolios of their own
+     * but must read another user's (shared INDEPENDENCE_PLAN projection).
+     */
+    @Test
+    fun `allocation fetches each id via getPortfolioById without consulting caller portfolios list`() {
+        val portfolio2 = TestHelpers.createTestPortfolio("portfolio-2")
+        whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
+        whenever(portfolioServiceClient.getPortfolioById("portfolio-2")).thenReturn(portfolio2)
+        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+            .thenReturn(testPositionResponse)
+        whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
+            com.beancounter.common.contracts
+                .AllocationData()
+        )
+
+        positionController.allocation(asAt = "2024-01-15", ids = "test-portfolio,portfolio-2", targetCurrency = null)
+
+        verify(portfolioServiceClient).getPortfolioById("test-portfolio")
+        verify(portfolioServiceClient).getPortfolioById("portfolio-2")
+        val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        assertThat(captor.firstValue.map { it.id }.toSet()).isEqualTo(setOf("test-portfolio", "portfolio-2"))
+    }
+
+    @Test
+    fun `allocation skips ids that getPortfolioById rejects (caller cannot see them)`() {
+        whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
+        whenever(portfolioServiceClient.getPortfolioById("not-visible"))
+            .thenThrow(
+                com.beancounter.common.exception
+                    .BusinessException("Unable to find portfolio not-visible")
+            )
+        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+            .thenReturn(testPositionResponse)
+        whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
+            com.beancounter.common.contracts
+                .AllocationData()
+        )
+
+        positionController.allocation(asAt = "2024-01-15", ids = "test-portfolio,not-visible", targetCurrency = null)
+
+        val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
+    }
+
+    @Test
+    fun `allocation falls back to caller portfolios when no ids supplied`() {
+        val portfoliosResponse = PortfoliosResponse(listOf(testPortfolio))
+        whenever(portfolioServiceClient.portfolios).thenReturn(portfoliosResponse)
+        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+            .thenReturn(testPositionResponse)
+        whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
+            com.beancounter.common.contracts
+                .AllocationData()
+        )
+
+        positionController.allocation(asAt = "2024-01-15", ids = null, targetCurrency = null)
+
+        verify(portfolioServiceClient).portfolios
+        val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
+    }
 }


### PR DESCRIPTION
## Summary
PR2 of the shared-plan owner-scoping rollout (see [SHARED_PROJECTION.md](https://github.com/monowai/bc-claude/blob/main/SHARED_PROJECTION.md)). svc-position only.

When \`/allocation\` is called with \`ids=\`, fetch each portfolio via \`portfolioServiceClient.getPortfolioById(id)\` rather than filtering the caller's full \`portfolios\` list. Visibility delegates to svc-data's \`canView()\` — owners + active-share users keep their existing access, M2M tokens get the \`AuthConstants.SYSTEM\` short-circuit so svc-retire can read a shared INDEPENDENCE_PLAN owner's portfolios.

## Why
The old filter pattern \`portfolioServiceClient.portfolios.data.filter { it.id in idSet }\` silently dropped any id the caller couldn't see in their own portfolio list. M2M callers (svc-retire) have an empty \`portfolios\` list, so the filter wiped the entire request and returned an empty allocation — defeating the cross-service intent of \`ids=\` being a caller-asserted scope.

## Behaviour change
- M2M callers with \`ids=<owner-ids>\` now get the owner's portfolios (previously: empty)
- User callers behave identically for ids they could see before (caller-visible filter via \`canView\`)
- User callers requesting an id they CAN'T see: still silently dropped (matches old behaviour; logged at DEBUG)
- Per-id \`BusinessException\` is the only swallowed exception; network/auth failures propagate

## Test plan
- [x] \`./gradlew :svc-position:test :svc-position:formatKotlin :svc-position:lintKotlin\` — clean
- [x] semgrep clean
- [x] New \`PositionControllerTest\` cases:
  - per-id fetch happy path
  - not-visible id skip
  - null-ids fallback to caller portfolios
- [x] Existing aggregated/sector-exposure tests untouched (those methods still use the old filter pattern; out of scope)

## Reviewer notes
Locally reviewed against the in-repo code-review skill before push (one narrow-the-catch finding addressed) — \`@coderabbitai ignore\` set to preserve quota.

@coderabbitai ignore