### PR TITLE
fix(svc-position): aggregated accepts ids= to disambiguate colliding codes

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
@@ -342,6 +342,20 @@ class PositionController(
         ) codes: String?,
         @Parameter(
             description =
+                "Comma-separated portfolio ids to include. Takes precedence over `codes`. " +
+                    "Per-id resolution via portfolioServiceClient.getPortfolioById delegates " +
+                    "visibility to svc-data's canView — so owner / accepted-share callers get " +
+                    "their portfolios and M2M callers get the SYSTEM short-circuit. Use this " +
+                    "when codes can collide across users (a shared-plan viewer may own a " +
+                    "portfolio with the same code as the plan owner's).",
+            example = "id-1,id-2"
+        )
+        @RequestParam(
+            value = "ids",
+            required = false
+        ) ids: String?,
+        @Parameter(
+            description =
                 "Target currency for PORTFOLIO-view values (e.g., SGD, NZD). " +
                     "If not specified, values are returned in the first selected portfolio's currency.",
             example = "SGD"
@@ -351,13 +365,30 @@ class PositionController(
             required = false
         ) targetCurrency: String?
     ): PositionResponse {
-        val allPortfolios = portfolioServiceClient.portfolios.data
-        val selectedPortfolios =
-            if (codes.isNullOrBlank()) {
-                allPortfolios
+        val selectedPortfolios: Collection<com.beancounter.common.model.Portfolio> =
+            if (!ids.isNullOrBlank()) {
+                // Mirror /allocation's per-id fetch (see PR #906). Codes can
+                // collide across users; ids disambiguate.
+                ids
+                    .split(",")
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                    .mapNotNull { id ->
+                        try {
+                            portfolioServiceClient.getPortfolioById(id)
+                        } catch (e: com.beancounter.common.exception.BusinessException) {
+                            log.debug("Skipping portfolio {} (not visible to caller): {}", id, e.message)
+                            null
+                        }
+                    }
             } else {
-                val codeSet = codes.split(",").map { it.trim() }.toSet()
-                allPortfolios.filter { it.code in codeSet }
+                val allPortfolios = portfolioServiceClient.portfolios.data
+                if (codes.isNullOrBlank()) {
+                    allPortfolios
+                } else {
+                    val codeSet = codes.split(",").map { it.trim() }.toSet()
+                    allPortfolios.filter { it.code in codeSet }
+                }
             }
         val response =
             valuationService.getAggregatedPositions(

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
@@ -205,7 +205,7 @@ class PositionControllerTest {
             .thenReturn(testPositionResponse)
 
         // When
-        val result = positionController.aggregated(valuationDate, true, null, null)
+        val result = positionController.aggregated(valuationDate, true, null, null, null)
 
         // Then
         assertThat(result).isNotNull()
@@ -224,7 +224,7 @@ class PositionControllerTest {
             .thenReturn(testPositionResponse)
 
         // When
-        val result = positionController.aggregated(DateUtils.TODAY, true, null, null)
+        val result = positionController.aggregated(DateUtils.TODAY, true, null, null, null)
 
         // Then
         assertThat(result).isNotNull()
@@ -243,7 +243,7 @@ class PositionControllerTest {
             .thenReturn(emptyPositionResponse)
 
         // When
-        val result = positionController.aggregated(valuationDate, true, null, null)
+        val result = positionController.aggregated(valuationDate, true, null, null, null)
 
         // Then
         assertThat(result).isNotNull()
@@ -261,7 +261,7 @@ class PositionControllerTest {
             .thenReturn(testPositionResponse)
 
         // When
-        val result = positionController.aggregated(valuationDate, true, null, "SGD")
+        val result = positionController.aggregated(valuationDate, true, null, null, "SGD")
 
         // Then
         assertThat(result).isNotNull()
@@ -283,7 +283,7 @@ class PositionControllerTest {
             .thenReturn(testPositionResponse)
 
         // When - value=false means no valuations, so no conversion applicable
-        positionController.aggregated(valuationDate, false, null, "SGD")
+        positionController.aggregated(valuationDate, false, null, null, "SGD")
 
         // Then
         verify(allocationService, org.mockito.kotlin.never())
@@ -309,7 +309,7 @@ class PositionControllerTest {
             .thenReturn(testPositionResponse)
 
         // When - only request the test portfolio by its code
-        val result = positionController.aggregated(valuationDate, true, testPortfolio.code, null)
+        val result = positionController.aggregated(valuationDate, true, testPortfolio.code, null, null)
 
         // Then
         assertThat(result).isNotNull()
@@ -319,6 +319,56 @@ class PositionControllerTest {
             eq(valuationDate),
             eq(true)
         )
+    }
+
+    /**
+     * Aggregated `ids` filter takes precedence over `codes` and resolves
+     * each id via `getPortfolioById` (mirrors the PR #906 allocation
+     * pattern). Lets shared-plan callers disambiguate when two users own
+     * portfolios with the same code (e.g. Mike's "SGD" vs Ruby's "SGD").
+     */
+    @Test
+    fun `aggregated resolves ids via per-id fetch ignoring codes when both supplied`() {
+        whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
+        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+            .thenReturn(testPositionResponse)
+
+        positionController.aggregated(
+            asAt = "2024-01-15",
+            value = true,
+            codes = "SHOULD-IGNORE",
+            ids = "test-portfolio",
+            targetCurrency = null
+        )
+
+        verify(portfolioServiceClient).getPortfolioById("test-portfolio")
+        val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
+    }
+
+    @Test
+    fun `aggregated skips ids that getPortfolioById rejects`() {
+        whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
+        whenever(portfolioServiceClient.getPortfolioById("not-visible"))
+            .thenThrow(
+                com.beancounter.common.exception
+                    .BusinessException("Unable to find portfolio not-visible")
+            )
+        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+            .thenReturn(testPositionResponse)
+
+        positionController.aggregated(
+            asAt = "2024-01-15",
+            value = true,
+            codes = null,
+            ids = "test-portfolio,not-visible",
+            targetCurrency = null
+        )
+
+        val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
     }
 
     /**


### PR DESCRIPTION
## Summary
\`GET /aggregated\` filters by \`codes=\`, which aggregates BOTH portfolios when two users own portfolios with the same code (owner "SGD" + shared shared "SGD" — confirmed live on kauri's Wookie plan, where shared-plan Assets-by-Category still showed owner totals after PR742).

Add \`ids=\` mirroring \`/allocation\`'s per-id fetch (PR #906). When set, takes precedence over \`codes\`; each id resolves via \`portfolioServiceClient.getPortfolioById\` so visibility is delegated to svc-data's \`canView\` — owner / accepted-share callers get their portfolios, M2M callers get the SYSTEM short-circuit, and unknown ids are silently dropped (matches the allocation behaviour).

## Test plan
- [x] \`./gradlew :svc-position:test :svc-position:formatKotlin :svc-position:lintKotlin\` — clean
- [x] semgrep clean
- [x] New tests: ids-takes-precedence-over-codes; not-visible-id skip
- [ ] Manual on kauri: shared plan's Assets-by-Category shows shared portfolios only (no owner-pollution)

## Pairs with
bc-view fix that switches the shared-plan hook to send \`ids=\` instead of \`codes=\`.

## Reviewer notes
Locally reviewed against the in-repo code-review skill before push (no findings) — \`@coderabbitai ignore\` set.

@coderabbitai ignore