### PR TITLE
fix(svc-data): owner-only access to portfolio share listing

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareService.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.contracts.PendingSharesResponse
 import com.beancounter.common.contracts.ShareInviteRequest
 import com.beancounter.common.contracts.ShareRequestAccess
 import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.exception.ForbiddenException
 import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.PortfolioShare
@@ -212,9 +213,19 @@ class PortfolioShareService(
 
     /**
      * Get shares for a specific portfolio (owner view).
+     *
+     * Owner-only: a viewer with an accepted share can `find()` the
+     * portfolio via `canView`, but listing every other user the owner
+     * shared with leaks the owner's adviser/collaborator graph. Gate
+     * here rather than at `find()` since `find()` is the shared
+     * cross-service viewability check.
      */
     fun getPortfolioShares(portfolioId: String): Collection<PortfolioShare> {
+        val caller = systemUserService.getOrThrow()
         val portfolio = portfolioService.find(portfolioId)
+        if (portfolio.owner.id != caller.id) {
+            throw ForbiddenException("Only the portfolio owner can list its shares")
+        }
         return portfolioShareRepository
             .findByPortfolioAndStatusNot(
                 portfolio,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/portfolio/PortfolioShareControllerTest.kt
@@ -447,6 +447,64 @@ internal class PortfolioShareControllerTest {
     }
 
     @Test
+    fun `portfolio shares listing is owner-only`() {
+        val portfolio =
+            portfolioCreate(
+                PortfolioInput("OWNER_LIST", "Owner List", USD.code, NZD.code),
+                mockMvc,
+                clientToken
+            ).data.first()
+
+        val inviteRequest =
+            ShareInviteRequest(
+                portfolioIds = listOf(portfolio.id),
+                adviserEmail = "adviser@testing.com"
+            )
+        val inviteResult =
+            mockMvc
+                .perform(
+                    post("$SHARES_ROOT/invite")
+                        .with(jwt().jwt(clientToken))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsBytes(inviteRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+        val shareId =
+            objectMapper
+                .readValue(
+                    inviteResult.response.contentAsString,
+                    PortfolioSharesResponse::class.java
+                ).data
+                .first()
+                .id
+        mockMvc
+            .perform(
+                post("$SHARES_ROOT/$shareId/accept")
+                    .with(jwt().jwt(adviserToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        // Owner sees the list.
+        mockMvc
+            .perform(
+                get("$SHARES_ROOT/portfolio/${portfolio.id}")
+                    .with(jwt().jwt(clientToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        // Adviser with accepted share gets 403 — `canView` lets them
+        // see the portfolio, but they must not enumerate co-share targets.
+        mockMvc
+            .perform(
+                get("$SHARES_ROOT/portfolio/${portfolio.id}")
+                    .with(jwt().jwt(adviserToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
     fun `managed portfolios returns active shares for adviser`() {
         val portfolio =
             portfolioCreate(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/share/ResourceShareControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/share/ResourceShareControllerTest.kt
@@ -281,6 +281,122 @@ internal class ResourceShareControllerTest {
     }
 
     @Test
+    fun `adviser can revoke their own resource share`() {
+        // Viewer self-revoke is the user-visible "leave shared plan"
+        // action — verifies the adviser side can drop access without
+        // the owner being involved.
+        val inviteRequest =
+            ResourceShareInviteRequest(
+                resourceType = ShareResourceType.INDEPENDENCE_PLAN,
+                resourceIds = listOf("plan-self-revoke"),
+                adviserEmail = "rs-adviser@testing.com"
+            )
+        val inviteResult =
+            mockMvc
+                .perform(
+                    post("$RESOURCE_SHARES_ROOT/invite")
+                        .with(jwt().jwt(clientToken))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsBytes(inviteRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val shareId =
+            objectMapper
+                .readValue(
+                    inviteResult.response.contentAsString,
+                    ResourceSharesResponse::class.java
+                ).data
+                .first()
+                .id
+
+        mockMvc
+            .perform(
+                post("$RESOURCE_SHARES_ROOT/$shareId/accept")
+                    .with(jwt().jwt(adviserToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        // Adviser revokes their own access.
+        mockMvc
+            .perform(
+                delete("$RESOURCE_SHARES_ROOT/$shareId")
+                    .with(jwt().jwt(adviserToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk)
+
+        // Post-revoke: checkAccess must return false. Guards the
+        // shared-plan projection path in svc-retire — once revoked,
+        // the adviser must not still pull owner-scoped data.
+        val recheckResult =
+            mockMvc
+                .perform(
+                    get("$RESOURCE_SHARES_ROOT/check/INDEPENDENCE_PLAN/plan-self-revoke")
+                        .with(jwt().jwt(adviserToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+        val recheck =
+            objectMapper.readValue(
+                recheckResult.response.contentAsString,
+                ShareAccessCheck::class.java
+            )
+        assertThat(recheck.hasAccess).isFalse()
+    }
+
+    @Test
+    fun `unrelated user cannot revoke a resource share`() {
+        val inviteRequest =
+            ResourceShareInviteRequest(
+                resourceType = ShareResourceType.INDEPENDENCE_PLAN,
+                resourceIds = listOf("plan-third-party"),
+                adviserEmail = "rs-adviser@testing.com"
+            )
+        val inviteResult =
+            mockMvc
+                .perform(
+                    post("$RESOURCE_SHARES_ROOT/invite")
+                        .with(jwt().jwt(clientToken))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsBytes(inviteRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val shareId =
+            objectMapper
+                .readValue(
+                    inviteResult.response.contentAsString,
+                    ResourceSharesResponse::class.java
+                ).data
+                .first()
+                .id
+
+        val outsiderToken =
+            registerUser(
+                mockMvc,
+                mockAuthConfig.getUserToken(
+                    SystemUser(
+                        id = "rs-outsider",
+                        email = "rs-outsider@testing.com",
+                        auth0 = "auth0|rs-outsider"
+                    )
+                )
+            )
+
+        mockMvc
+            .perform(
+                delete("$RESOURCE_SHARES_ROOT/$shareId")
+                    .with(jwt().jwt(outsiderToken))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().is4xxClientError)
+    }
+
+    @Test
     fun `cannot share resources with yourself`() {
         val request =
             ResourceShareInviteRequest(


### PR DESCRIPTION
@coderabbitai ignore

## Summary
- `GET /shares/portfolio/{portfolioId}` previously let any share-target on a portfolio enumerate every other share on it (advisers, requesters). Tightens the endpoint to portfolio owners — non-owners with active shares now get 403.
- Adds integration coverage: owner sees the list, share-target with accepted access gets 403, third-party gets 4xx.
- Adds resource-share post-revoke tests: adviser self-revoke succeeds and `checkAccess` returns false afterwards (guards the svc-retire shared-plan projection path); unrelated user cannot revoke a share they have no role on.

## Test plan
- [ ] `./gradlew :svc-data:test --tests PortfolioShareControllerTest --tests ResourceShareControllerTest` — passing locally.
- [ ] Deploy to kauri and verify owner-only listing on a real portfolio.