### PR TITLE
feat(trn): add created_at + sort cash-ladder by tradeDate desc, createdAt desc

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/model/Trn.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/Trn.kt
@@ -16,9 +16,11 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import java.math.BigDecimal
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -109,7 +111,13 @@ data class Trn(
     @JdbcTypeCode(SqlTypes.JSON)
     var subAccounts: Map<String, BigDecimal>? = null,
     @ManyToOne
-    var createdBy: SystemUser? = null
+    var createdBy: SystemUser? = null,
+    // Server-generated creation timestamp. Used as the chronological
+    // tie-break within a single tradeDate (e.g. cash-ladder ordering)
+    // because trn ids are random UUIDs and don't sort by time.
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
 ) {
     companion object {
         const val VERSION: String = "4"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -279,7 +279,7 @@ interface TrnRepository :
             "and (t.cashAsset.id = ?2 OR (t.asset.id = ?2 AND t.trnType = 'FX_BUY')) " +
             "and t.tradeDate <= ?3 " +
             "and t.status = ?4 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByPortfolioIdAndCashAssetId(
         portfolioId: String,

--- a/svc-data/src/main/resources/db/migration/V26__add_trn_created_at.sql
+++ b/svc-data/src/main/resources/db/migration/V26__add_trn_created_at.sql
@@ -1,0 +1,19 @@
+-- Adds a server-generated creation timestamp to trn so the cash-ladder
+-- (and any future chronological view of transactions) can order
+-- consistently within the same tradeDate. Trn ids are random strings
+-- (UUID-style) so an `id desc` tie-break does NOT reflect chronology;
+-- this column does.
+--
+-- Existing rows get a sensible-but-imperfect backfill: NOW() at
+-- migration time. Order within historical same-date trns is unrecoverable
+-- so they will all share the migration timestamp and sort by id within
+-- that ms — acceptable for legacy data.
+
+ALTER TABLE trn
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE
+    NOT NULL DEFAULT now();
+
+-- Index supports the cash-ladder query's `tradeDate desc, createdAt desc`
+-- secondary sort over the (portfolio, cashAsset) hot path.
+CREATE INDEX IF NOT EXISTS idx_trn_tradedate_createdat
+    ON trn (trade_date DESC, created_at DESC);


### PR DESCRIPTION
## Summary

Trn ids are random UUID-style strings so they don't tie-break chronologically within the same `tradeDate`. The cash-ladder UI hit this with the new Open Brokerage wizard posting a same-day WITHDRAWAL + DEPOSIT pair the UI couldn't order intuitively.

- **V26 migration**: `trn.created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()` + index `(trade_date desc, created_at desc)`. Existing rows backfill to migration time — acceptable for legacy data since within-date chronology there is unrecoverable.
- **Trn entity**: `createdAt: Instant` with `@CreationTimestamp` (Hibernate populates on insert; matches DB default).
- **TrnRepository.findByPortfolioIdAndCashAssetId**: orders by `tradeDate desc, createdAt desc` — chronologically correct for the cash-ladder.

Other Trn queries with plain `order by tradeDate` are left as-is; PR scoped to the cash-ladder fix.

## Test plan

- [x] `./gradlew testSmart` — all green (CashLadder tests included)
- [x] `./gradlew formatKotlin lintKotlin` — clean
- [x] Migration `V26` staged and committed
- [ ] After merge: bc-view PR #754 reverts its frontend reverse+sort hack (already committed locally — `trust the backend's order`)

@coderabbitai ignore