### PR TITLE
feat(telemetry): runBlockingTraced propagates OTel Context across coroutines

### DIFF
--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -29,6 +29,13 @@ dependencies {
     implementation(platform(libs.spring.boot.dependencies))
     implementation(platform("io.opentelemetry:opentelemetry-bom:1.54.1"))
     implementation("io.opentelemetry:opentelemetry-sdk")
+    // Bridges OTel `Context` to Kotlin coroutine `CoroutineContext` so the
+    // current Span propagates across suspension and dispatcher switches
+    // (e.g. `runBlocking(Dispatchers.IO)` inside a Spring MVC handler).
+    // Exposed as `api` because consumers call `Context.current().asContextElement()`
+    // when wrapping coroutine builders.
+    api("io.opentelemetry:opentelemetry-extension-kotlin")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation(libs.servlet.api)
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -26,8 +26,10 @@ dependencies {
     api(libs.micrometer.tracing.bridge.otel)
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation(platform(libs.spring.boot.dependencies))
-    implementation(platform("io.opentelemetry:opentelemetry-bom:1.54.1"))
+    // BOMs are `api` so downstream modules (jar-shell, svc-data, etc.) inherit
+    // the version constraints for the `api(...)` artifacts below.
+    api(platform(libs.spring.boot.dependencies))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.54.1"))
     implementation("io.opentelemetry:opentelemetry-sdk")
     // Bridges OTel `Context` to Kotlin coroutine `CoroutineContext` so the
     // current Span propagates across suspension and dispatcher switches

--- a/jar-common/src/main/kotlin/com/beancounter/common/telemetry/CoroutineTracing.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/telemetry/CoroutineTracing.kt
@@ -1,0 +1,30 @@
+package com.beancounter.common.telemetry
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Coroutine builders that propagate the current OpenTelemetry `Context`
+ * (and therefore the active Sentry span / trace) into the launched
+ * coroutine.
+ *
+ * Default `runBlocking { ... }` creates a fresh `CoroutineContext` with
+ * no link to OTel's thread-local. When the inner coroutine resumes on
+ * another dispatcher (e.g. `Dispatchers.IO`) `Context.current()` falls
+ * back to root and any `http.server` span the OTel agent is recording
+ * detaches — observed on `svc-data` `/assets/search`, the only
+ * controller wrapping its work in `runBlocking`, whose `http.server`
+ * spans never reach Sentry.
+ *
+ * Use [runBlockingTraced] in place of `runBlocking` for any blocking
+ * coroutine started from a Spring MVC handler, scheduled job, or
+ * message listener whose trace must continue.
+ */
+fun <T> runBlockingTraced(
+    context: CoroutineContext = EmptyCoroutineContext,
+    block: suspend CoroutineScope.() -> T
+): T = runBlocking(Context.current().asContextElement() + context, block)

--- a/jar-common/src/test/kotlin/com/beancounter/common/telemetry/CoroutineTracingTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/telemetry/CoroutineTracingTest.kt
@@ -1,0 +1,46 @@
+package com.beancounter.common.telemetry
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for the OTel-Context propagation bug that left
+ * svc-data `/assets/search` invisible in Sentry: the controller wraps
+ * its provider call in `runBlocking(Dispatchers.IO) { ... }`, which
+ * drops the current OTel `Context` on resume, detaching the
+ * `http.server` span.
+ */
+class CoroutineTracingTest {
+    private val traceKey: ContextKey<String> = ContextKey.named("bc-test-trace")
+
+    @Test
+    fun `bare runBlocking on IO dispatcher loses OTel Context`() {
+        val outer = Context.current().with(traceKey, "outer-value")
+        val captured =
+            outer.makeCurrent().use {
+                runBlocking(Dispatchers.IO) {
+                    Context.current().get(traceKey)
+                }
+            }
+        // Documents the bug. If this ever starts returning "outer-value"
+        // the upstream coroutines/OTel libs have started auto-propagating
+        // and [runBlockingTraced] becomes a no-op.
+        assertThat(captured).isNull()
+    }
+
+    @Test
+    fun `runBlockingTraced propagates OTel Context across dispatchers`() {
+        val outer = Context.current().with(traceKey, "outer-value")
+        val captured =
+            outer.makeCurrent().use {
+                runBlockingTraced(Dispatchers.IO) {
+                    Context.current().get(traceKey)
+                }
+            }
+        assertThat(captured).isEqualTo("outer-value")
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.contracts.AssetSearchResponse
 import com.beancounter.common.contracts.AssetSearchResult
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.marketdata.assets.figi.FigiConfig
 import com.beancounter.marketdata.assets.figi.FigiFilterRequest
 import com.beancounter.marketdata.assets.figi.FigiGateway
@@ -19,7 +20,6 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
@@ -124,7 +124,7 @@ class AssetSearchService(
         keyword: String,
         market: String
     ): List<AssetSearchResult> =
-        runBlocking {
+        runBlockingTraced {
             withTimeoutOrNull(SEARCH_TIMEOUT_MS) {
                 runCatching {
                     val resolved = marketService.getMarket(market)
@@ -170,7 +170,7 @@ class AssetSearchService(
         // providers don't cooperatively cancel, so the real wall-clock cap comes from the
         // per-client HTTP timeouts (see `eodhdSearchRestClient`).
         val external =
-            runBlocking {
+            runBlockingTraced {
                 supervisorScope {
                     val providerTasks =
                         mdFactory.getAllProviders().map { provider ->

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.marketdata.providers.MarketDataPriceProvider
 import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
@@ -16,7 +17,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -72,7 +72,7 @@ class AlphaPriceService(
         val providerArguments = getInstance(priceRequest, alphaConfig)
         val requests = mutableMapOf<Int, Deferred<String>>()
 
-        runBlocking {
+        runBlockingTraced {
             supervisorScope {
                 for (batchId in providerArguments.batch.keys) {
                     requests[batchId] =
@@ -87,7 +87,7 @@ class AlphaPriceService(
             }
         }
 
-        return runBlocking {
+        return runBlockingTraced {
             getMarketData(providerArguments, requests, priceRequest.currentMode)
         }
     }

--- a/svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
+++ b/svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
@@ -6,9 +6,9 @@ import com.beancounter.common.model.MarketData.Companion.isSplit
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.event.config.EventLoaderConfig
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -56,7 +56,7 @@ class EventLoader(
         val portfolio = portfolioService.getPortfolioById(portfolioId)
         val authContext = loginService.loginM2m()
         loginService.setAuthContext(authContext)
-        runBlocking {
+        runBlockingTraced {
             val dates = dateSplitter.dateRange(date, "today")
             log.info("Loading missing events from date: $dates, portfolio: ${portfolio.code}/$portfolioId")
             for (processDate in dates) {

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.model.PeriodicCashFlows
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
 import com.beancounter.common.model.Totals
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.common.utils.CashUtils
 import com.beancounter.position.model.ValuationData
 import io.sentry.Breadcrumb
@@ -16,7 +17,6 @@ import io.sentry.Sentry
 import io.sentry.SentryLevel
 import io.sentry.kotlin.SentryContext
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -49,7 +49,7 @@ class PositionValuationService(
         )
 
         val (priceResponse, fxResponse) =
-            runBlocking {
+            runBlockingTraced {
                 getValuationData(positions)
             }
 

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
@@ -13,6 +13,7 @@ import com.beancounter.common.model.PortfolioBreakdown
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
 import com.beancounter.common.model.setMarketValue
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.position.service.MarketValueUpdateProducer
 import com.beancounter.position.service.PositionService
@@ -20,7 +21,6 @@ import com.beancounter.position.service.PositionValuationService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Configuration
@@ -137,7 +137,7 @@ class ValuationService
             // portfolio each response belongs to so we can build a per-portfolio
             // breakdown alongside the aggregated view.
             val portfolioTransactions =
-                runBlocking(Dispatchers.IO) {
+                runBlockingTraced(Dispatchers.IO) {
                     portfolios
                         .map { portfolio ->
                             async {


### PR DESCRIPTION
## Summary

- New jar-common helper `runBlockingTraced { ... }` that prepends `Context.current().asContextElement()` to the coroutine context. Bare `runBlocking` starts a fresh `CoroutineContext` with no link to OTel's thread-local; when the inner coroutine resumes on `Dispatchers.IO` (or any non-Tomcat thread) the Spring MVC `http.server` span the OTel agent is recording detaches and Sentry loses it.
- Live impact: `svc-data` `/assets/search` was the only AssetController endpoint whose `http.server` spans never reached Sentry, because it's the only one wrapping its provider call in `runBlocking`. Every other endpoint (e.g. `/api/assets/{assetId}`, `/api/currencies`, `/api/fx`, `/api/me`) is recorded correctly.
- Migrates all six existing bare-`runBlocking` call-sites to `runBlockingTraced`: `AssetSearchService` (2), `AlphaPriceService` (2), `PositionValuationService`, `ValuationService` (with `Dispatchers.IO`), `EventLoader`.

## Implementation

- `jar-common/build.gradle.kts` exposes `opentelemetry-extension-kotlin` and `kotlinx-coroutines-core` as `api` so every service inherits both on classpath.
- TDD: red test confirms `runBlocking(Dispatchers.IO)` drops a value set on `Context.current()`; green test confirms `runBlockingTraced(Dispatchers.IO)` preserves it.
- Signature mirrors `runBlocking(context, block)` so adoption is a one-line swap; user-supplied `CoroutineContext` wins on conflict via the `+` precedence.

## Test plan

- [x] `./gradlew :jar-common:check` (unit tests + lint)
- [x] `./gradlew :svc-data:test --tests *AssetSearch* --tests *AlphaPrice*`
- [x] `./gradlew :svc-position:test --tests *Valuation*`
- [x] `./gradlew :svc-event:test --tests *EventLoader*`
- [x] `./gradlew formatKotlin lintKotlin`
- [ ] After deploy: query Sentry for any trace covering `GET /api/assets/search` and confirm a child `project.name:data span.op:http.server` exists on the same `trace`.

@coderabbitai ignore