### PR TITLE
feat(eodhd): batch EOD price fetch via /api/eod-bulk-last-day

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfig.kt
@@ -31,8 +31,14 @@ import java.time.LocalDate
 class EodhdConfig(
     val marketService: MarketService
 ) : DataProviderConfig {
-    @Value($$"${beancounter.market.providers.eodhd.batchSize:1}")
-    var assetsPerRequest = 1
+    // Bulk endpoint groups up to N symbols per HTTP round-trip (see
+    // `EodhdPriceService.fetchBulk`). Default sized for the scheduled
+    // PortfolioValuationSchedule fan-out — covers a typical kauri valuation
+    // cycle (~14 unique held US tickers) in a single bulk call instead of N
+    // serial `/api/eod/{symbol}` round-trips. Raise via env var if a single
+    // portfolio holds more positions than this.
+    @Value($$"${beancounter.market.providers.eodhd.batchSize:50}")
+    var assetsPerRequest = 50
 
     @Value($$"${beancounter.market.providers.eodhd.markets:}")
     var markets: String? = null
@@ -47,6 +53,15 @@ class EodhdConfig(
         marketService
             .getMarket(market.code)
             .getAlias(EodhdPriceService.ID)
+
+    /**
+     * EODHD exchange code for [market], resolved via `MarketService` so the alias map
+     * configured in `application.yml` is honoured. Falls back to the raw market code
+     * when no `eodhd` alias is configured. Public to support bulk-endpoint routing in
+     * [EodhdPriceService.fetchBulk] where the exchange goes in the URL path.
+     */
+    fun getExchange(market: Market): String =
+        translateMarketCode(market).takeUnless { it.isNullOrEmpty() } ?: market.code
 
     override fun getMarketDate(
         market: Market,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.marketdata.providers.eodhd.model.EodhdBulkPrice
 import com.beancounter.marketdata.providers.eodhd.model.EodhdDividend
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.model.EodhdPrice
@@ -48,6 +49,35 @@ class EodhdGateway(
                 apiKey
             ).retrieve()
             .body<Array<EodhdPrice>>()
+            ?.toList()
+            ?: emptyList()
+
+    /**
+     * Bulk last-day EOD prices for multiple symbols on a single exchange.
+     *
+     * GET /api/eod-bulk-last-day/{exchange}?symbols={csv}&date={date}&api_token={apiKey}&fmt=json
+     *
+     * `symbols` is a comma-separated list of raw codes (the EXCHANGE in the path is the default
+     * suffix). One HTTP round-trip replaces N per-symbol [getPrice] calls for the scheduled
+     * portfolio-valuation fan-out; per-symbol quota is identical (1 API call per ticker) but
+     * wall-clock collapses from N × ~1s to 1 × ~1s.
+     */
+    fun getBulkPrices(
+        exchange: String,
+        symbols: String,
+        date: String,
+        apiKey: String = DEMO_KEY
+    ): List<EodhdBulkPrice> =
+        restClient
+            .get()
+            .uri(
+                "/api/eod-bulk-last-day/{exchange}?symbols={symbols}&date={date}&api_token={apiKey}&fmt=json",
+                exchange,
+                symbols,
+                date,
+                apiKey
+            ).retrieve()
+            .body<Array<EodhdBulkPrice>>()
             ?.toList()
             ?: emptyList()
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -8,7 +8,9 @@ import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.MarketDataPriceProvider
+import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
+import com.beancounter.marketdata.providers.eodhd.model.EodhdBulkPrice
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -47,25 +49,93 @@ class EodhdPriceService(
         val providerArguments = getInstance(priceRequest, eodhdConfig, dateUtils)
         val results = mutableListOf<MarketData>()
         for (batchId in providerArguments.batch.keys) {
-            val symbol = providerArguments.batch[batchId] ?: continue
-            val asset = providerArguments.getAsset(symbol)
+            val symbols = providerArguments.getAssets(batchId)
+            if (symbols.isEmpty()) continue
             val priceDate = providerArguments.getBatchConfigs(batchId)?.date ?: dateUtils.today()
-            // A 4xx for one symbol must not abort the whole batch — bc-position
-            // schedules valuations across every portfolio, so one bad ticker would
-            // otherwise halt every portfolio sequenced after it.
-            val rows =
-                try {
-                    eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
-                } catch (e: HttpClientErrorException) {
-                    log.warn("EODHD {} for {} on {} — skipping", e.statusCode, symbol, priceDate)
-                    continue
-                }
             results.addAll(
-                eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows)
+                if (symbols.size > 1) {
+                    fetchBulk(providerArguments, batchId, symbols, priceDate)
+                } else {
+                    fetchSingle(providerArguments, symbols.first(), priceDate)
+                }
             )
         }
         return results
     }
+
+    /**
+     * Single-symbol fan-out path — kept for batches of size 1 (e.g. an ad-hoc valuation
+     * for one asset). 4xx is swallowed per [getMarketData]'s batch-isolation guarantee.
+     */
+    private fun fetchSingle(
+        providerArguments: ProviderArguments,
+        symbol: String,
+        priceDate: String
+    ): List<MarketData> {
+        val asset = providerArguments.getAsset(symbol)
+        // A 4xx for one symbol must not abort the whole batch — bc-position
+        // schedules valuations across every portfolio, so one bad ticker would
+        // otherwise halt every portfolio sequenced after it.
+        val rows =
+            try {
+                eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
+            } catch (e: HttpClientErrorException) {
+                log.warn("EODHD {} for {} on {} — skipping", e.statusCode, symbol, priceDate)
+                return emptyList()
+            }
+        return eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows)
+    }
+
+    /**
+     * Multi-symbol bulk path — collapses N per-symbol HTTP round-trips into one
+     * `/api/eod-bulk-last-day/{exchange}` call. All assets in a batch share a single
+     * market (enforced upstream by `ProviderArguments.split`), so the exchange code is
+     * unambiguous. A symbol that's missing from the bulk response gets a zero-close row
+     * via [EodhdAdapter.toMarketData] for parity with the per-symbol path.
+     */
+    private fun fetchBulk(
+        providerArguments: ProviderArguments,
+        batchId: Int,
+        symbols: List<String>,
+        priceDate: String
+    ): List<MarketData> {
+        val assetsByDpKey = symbols.associateWith { providerArguments.getAsset(it) }
+        val market = assetsByDpKey.values.first().market
+        val exchange = eodhdConfig.getExchange(market)
+        val csv = symbols.joinToString(",")
+
+        val bulkRows: List<EodhdBulkPrice> =
+            try {
+                eodhdProxy.getBulkPrices(exchange, csv, priceDate, eodhdConfig.apiKey)
+            } catch (e: HttpClientErrorException) {
+                log.warn(
+                    "EODHD bulk {} for batch {} ({} symbols) on {} — falling back to per-symbol",
+                    e.statusCode,
+                    batchId,
+                    symbols.size,
+                    priceDate
+                )
+                return symbols.flatMap { fetchSingle(providerArguments, it, priceDate) }
+            }
+
+        val rowsByCode = bulkRows.groupBy { it.code.uppercase() }
+        val parsedDate = LocalDate.parse(priceDate)
+        return assetsByDpKey.flatMap { (_, asset) ->
+            val matched = rowsByCode[asset.code.uppercase()].orEmpty().map(::toEodhdPrice)
+            eodhdAdapter.toMarketData(asset, parsedDate, matched)
+        }
+    }
+
+    private fun toEodhdPrice(bulk: EodhdBulkPrice) =
+        com.beancounter.marketdata.providers.eodhd.model.EodhdPrice(
+            date = bulk.date,
+            open = bulk.open,
+            high = bulk.high,
+            low = bulk.low,
+            close = bulk.close,
+            adjustedClose = bulk.adjustedClose,
+            volume = bulk.volume
+        )
 
     override fun getId(): String = ID
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdProxy.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.marketdata.providers.eodhd.model.EodhdBulkPrice
 import com.beancounter.marketdata.providers.eodhd.model.EodhdDividend
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.model.EodhdPrice
@@ -26,6 +27,20 @@ class EodhdProxy(
     ): List<EodhdPrice> =
         eodhdGateway.getPrice(
             symbol,
+            date,
+            apiKey
+        )
+
+    @RateLimiter(name = "eodhd")
+    fun getBulkPrices(
+        exchange: String,
+        symbols: String,
+        date: String,
+        apiKey: String
+    ): List<EodhdBulkPrice> =
+        eodhdGateway.getBulkPrices(
+            exchange,
+            symbols,
             date,
             apiKey
         )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/model/EodhdBulkPrice.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/model/EodhdBulkPrice.kt
@@ -1,0 +1,25 @@
+package com.beancounter.marketdata.providers.eodhd.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * EODHD bulk last-day EOD price row.
+ *
+ * Endpoint: GET /api/eod-bulk-last-day/{EXCHANGE}?symbols=...&date=...&fmt=json
+ * Returns an array of these objects — one per ticker the bulk endpoint
+ * resolved. The `code` field (raw symbol without exchange suffix) is what
+ * lets the adapter map rows back to the originating BC asset.
+ */
+data class EodhdBulkPrice(
+    val code: String,
+    val date: LocalDate,
+    val open: BigDecimal = BigDecimal.ZERO,
+    val high: BigDecimal = BigDecimal.ZERO,
+    val low: BigDecimal = BigDecimal.ZERO,
+    val close: BigDecimal = BigDecimal.ZERO,
+    @param:JsonProperty("adjusted_close")
+    val adjustedClose: BigDecimal = BigDecimal.ZERO,
+    val volume: Long = 0L
+)

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -552,7 +552,10 @@ beancounter:
       # Plan reference: https://eodhd.com/pricing
       eodhd:
         url: https://eodhd.com
-        batchSize: 1
+        # batchSize > 1 routes through `/api/eod-bulk-last-day/{exchange}` so the
+        # nightly PortfolioValuationSchedule collapses N per-symbol round-trips
+        # into a single HTTP call (per-symbol quota is unchanged at 1 call each).
+        batchSize: 50
         markets: ""
         news:
           # Top-N articles returned to the caller after ranking. Keep small —

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -9,11 +9,15 @@ import com.beancounter.marketdata.Constants.Companion.AAPL
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.MarketDataBoot
 import com.beancounter.marketdata.providers.eodhd.EodhdPriceService.Companion.ID
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -39,6 +43,13 @@ internal class EodhdApiTest {
 
     @Autowired
     private lateinit var eodhdPriceService: EodhdPriceService
+
+    // Reset between tests so per-test stub/verify counters don't bleed into
+    // siblings — the bulk-routing tests register `/api/eod-bulk-last-day/US`
+    // stubs that would otherwise carry over and turn the per-symbol 404 test
+    // into a bulk-path test.
+    @AfterEach
+    fun resetWireMock() = WireMock.reset()
 
     @Test
     fun `returns priced market data for a US symbol`() {
@@ -118,6 +129,92 @@ internal class EodhdApiTest {
 
         assertThat(date).isNotNull
         assertThat(date.toString()).matches("\\d{4}-\\d{2}-\\d{2}")
+    }
+
+    @Test
+    fun `multi-symbol batch routes through the bulk last-day endpoint`() {
+        // Regression: pre-bulk implementation hit `/api/eod/{symbol}` once per asset,
+        // taking ~1s × N round-trips on the cold-cache PortfolioValuationSchedule
+        // fan-out. Bulk endpoint collapses N requests to 1; this asserts the routing
+        // change holds AND both symbols' prices come back mapped to the right assets.
+        val body = ClassPathResource("mock/eodhd/bulk-US-AAPL-MSFT.json").file.readText()
+        stubFor(
+            get(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+                .willReturn(
+                    aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(body)
+                        .withStatus(200)
+                )
+        )
+
+        val result =
+            eodhdPriceService.getMarketData(
+                PriceRequest(
+                    "2024-11-29",
+                    listOf(PriceAsset(AAPL), PriceAsset(MSFT))
+                )
+            )
+
+        // Bulk endpoint called once with both symbols and the requested date as query params.
+        WireMock.verify(
+            1,
+            getRequestedFor(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+                .withQueryParam("symbols", equalTo("AAPL.US,MSFT.US"))
+                .withQueryParam("date", equalTo("2024-11-29"))
+        )
+
+        // Per-symbol fallback path NOT exercised.
+        WireMock.verify(0, getRequestedFor(urlPathEqualTo("/api/eod/AAPL.US")))
+        WireMock.verify(0, getRequestedFor(urlPathEqualTo("/api/eod/MSFT.US")))
+
+        assertThat(result).hasSize(2)
+        val byCode = result.associateBy { it.asset.code }
+        assertThat(byCode["AAPL"]?.close).isEqualByComparingTo(BigDecimal("237.33"))
+        assertThat(byCode["MSFT"]?.close).isEqualByComparingTo(BigDecimal("423.46"))
+        result.forEach { md -> assertThat(md.source).isEqualTo(ID) }
+    }
+
+    @Test
+    fun `missing symbol in bulk response yields a zero-close row for parity with per-symbol path`() {
+        // Bulk response only carries AAPL — MSFT was requested but EODHD omitted it
+        // (delisted, bad symbol, weekend). The adapter must still emit a row for MSFT
+        // so downstream callers see every requested asset, matching per-symbol behaviour.
+        val body = """[
+            {
+              "code": "AAPL",
+              "exchange_short_name": "US",
+              "date": "2024-11-29",
+              "open": 234.81,
+              "high": 237.81,
+              "low": 233.97,
+              "close": 237.33,
+              "adjusted_close": 237.33,
+              "volume": 28481377
+            }
+        ]"""
+        stubFor(
+            get(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+                .willReturn(
+                    aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(body)
+                        .withStatus(200)
+                )
+        )
+
+        val result =
+            eodhdPriceService.getMarketData(
+                PriceRequest(
+                    "2024-11-29",
+                    listOf(PriceAsset(AAPL), PriceAsset(MSFT))
+                )
+            )
+
+        assertThat(result).hasSize(2)
+        val byCode = result.associateBy { it.asset.code }
+        assertThat(byCode["AAPL"]?.close).isEqualByComparingTo(BigDecimal("237.33"))
+        assertThat(byCode["MSFT"]?.close).isEqualByComparingTo(BigDecimal.ZERO)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -139,7 +139,7 @@ internal class EodhdApiTest {
         // change holds AND both symbols' prices come back mapped to the right assets.
         val body = ClassPathResource("mock/eodhd/bulk-US-AAPL-MSFT.json").file.readText()
         stubFor(
-            get(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+            get(urlPathEqualTo(BULK_LAST_DAY_US))
                 .willReturn(
                     aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -159,7 +159,7 @@ internal class EodhdApiTest {
         // Bulk endpoint called once with both symbols and the requested date as query params.
         WireMock.verify(
             1,
-            getRequestedFor(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+            getRequestedFor(urlPathEqualTo(BULK_LAST_DAY_US))
                 .withQueryParam("symbols", equalTo("AAPL.US,MSFT.US"))
                 .withQueryParam("date", equalTo("2024-11-29"))
         )
@@ -194,7 +194,7 @@ internal class EodhdApiTest {
             }
         ]"""
         stubFor(
-            get(urlPathEqualTo("/api/eod-bulk-last-day/US"))
+            get(urlPathEqualTo(BULK_LAST_DAY_US))
                 .willReturn(
                     aResponse()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -321,5 +321,9 @@ internal class EodhdApiTest {
                         .withStatus(200)
                 )
         )
+    }
+
+    private companion object {
+        const val BULK_LAST_DAY_US = "/api/eod-bulk-last-day/US"
     }
 }

--- a/svc-data/src/test/resources/mock/eodhd/bulk-US-AAPL-MSFT.json
+++ b/svc-data/src/test/resources/mock/eodhd/bulk-US-AAPL-MSFT.json
@@ -1,0 +1,24 @@
+[
+  {
+    "code": "AAPL",
+    "exchange_short_name": "US",
+    "date": "2024-11-29",
+    "open": 234.81,
+    "high": 237.81,
+    "low": 233.97,
+    "close": 237.33,
+    "adjusted_close": 237.33,
+    "volume": 28481377
+  },
+  {
+    "code": "MSFT",
+    "exchange_short_name": "US",
+    "date": "2024-11-29",
+    "open": 423.18,
+    "high": 425.20,
+    "low": 421.04,
+    "close": 423.46,
+    "adjusted_close": 423.46,
+    "volume": 13157487
+  }
+]


### PR DESCRIPTION
## Summary

- Routes EODHD price fetches through `/api/eod-bulk-last-day/{exchange}?symbols={csv}&date={date}` whenever a batch carries 2+ symbols. EodhdPriceService now collapses N per-symbol HTTP round-trips into a single bulk call, with the existing per-symbol path retained as fallback for size-1 batches and bulk HTTP errors.
- Bumps `beancounter.market.providers.eodhd.batchSize` default from `1` to `50` so the scheduled PortfolioValuationSchedule fan-out lands as one HTTP call in the typical kauri portfolio.
- New `EodhdBulkPrice` model with the `code` field that lets the adapter map response rows back to the originating BC asset. Missing symbols in the bulk response receive a zero-close row via the existing `EodhdAdapter.zeroPrice` path, matching the per-symbol path's behaviour.

## Why

Sentry trace `dcaa3e9f863331949a54dde873164b76` (2026-06-05 21:00 UTC, first PortfolioValuationSchedule of the morning) sat at 24s wall clock fanning out per-symbol `GET /api/eod/{symbol}` calls (IEMG, NVDA, KARS, EWJ, ADBE, PLD, SCHG, COWZ.US, MOAT.US, ...) at ~900-1500ms each. The per-symbol API-call quota is identical (1 call per ticker either way), so the bulk endpoint just trades N TCP round-trips for one — the win is wall clock and concurrency pressure on the EODHD rate limiter, not quota.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk price fetching now consolidates multiple market data requests into a single API call for improved efficiency.
  * Default batch size increased from 1 to 50 for optimized API usage.
  * Automatic fallback to per-symbol requests ensures reliability if bulk requests fail.

* **Tests**
  * Added batch routing validation tests for bulk endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->