### PR TITLE
test(telemetry): extract repeated literal in CoroutineTracingTest

### DIFF
--- a/jar-common/src/test/kotlin/com/beancounter/common/telemetry/CoroutineTracingTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/telemetry/CoroutineTracingTest.kt
@@ -19,14 +19,14 @@ class CoroutineTracingTest {
 
     @Test
     fun `bare runBlocking on IO dispatcher loses OTel Context`() {
-        val outer = Context.current().with(traceKey, "outer-value")
+        val outer = Context.current().with(traceKey, OUTER_VALUE)
         val captured =
             outer.makeCurrent().use {
                 runBlocking(Dispatchers.IO) {
                     Context.current().get(traceKey)
                 }
             }
-        // Documents the bug. If this ever starts returning "outer-value"
+        // Documents the bug. If this ever starts returning the outer value
         // the upstream coroutines/OTel libs have started auto-propagating
         // and [runBlockingTraced] becomes a no-op.
         assertThat(captured).isNull()
@@ -34,13 +34,17 @@ class CoroutineTracingTest {
 
     @Test
     fun `runBlockingTraced propagates OTel Context across dispatchers`() {
-        val outer = Context.current().with(traceKey, "outer-value")
+        val outer = Context.current().with(traceKey, OUTER_VALUE)
         val captured =
             outer.makeCurrent().use {
                 runBlockingTraced(Dispatchers.IO) {
                     Context.current().get(traceKey)
                 }
             }
-        assertThat(captured).isEqualTo("outer-value")
+        assertThat(captured).isEqualTo(OUTER_VALUE)
+    }
+
+    private companion object {
+        const val OUTER_VALUE = "outer-value"
     }
 }


### PR DESCRIPTION
## Summary

- Codacy/detekt `StringLiteralDuplication` on `jar-common/src/test/kotlin/com/beancounter/common/telemetry/CoroutineTracingTest.kt` flagged three repeats of `"outer-value"`. Hoisted to a private companion-object constant `OUTER_VALUE`.

## Test plan

- [x] `./gradlew :jar-common:test --tests com.beancounter.common.telemetry.CoroutineTracingTest`
- [x] `./gradlew :jar-common:lintKotlin`

@coderabbitai ignore