### PR TITLE
perf(news): parallelize EODHD per-ticker news fetch

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.marketdata.providers.NewsProvider
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.news.NewsArticle
@@ -8,6 +9,11 @@ import com.beancounter.marketdata.providers.eodhd.news.NewsArticleTicker
 import com.beancounter.marketdata.providers.eodhd.news.NewsFetch
 import com.beancounter.marketdata.providers.eodhd.news.NewsFetchRepo
 import jakarta.transaction.Transactional
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -40,6 +46,10 @@ class EodhdNewsService(
 ) : NewsProvider {
     private val log = LoggerFactory.getLogger(EodhdNewsService::class.java)
 
+    // Bounds the upstream fan-out so a large holdings list can't fire one EODHD request per ticker
+    // simultaneously — that would amplify load and trip the shared ~1200/day quota in a single burst.
+    private val fetchGate = Semaphore(MAX_CONCURRENT_FETCHES)
+
     @Transactional
     override fun getNewsSentiment(
         tickers: String,
@@ -50,11 +60,7 @@ class EodhdNewsService(
         if (symbols.isEmpty()) return emptyMap()
 
         val refreshCutoff = LocalDateTime.now().minusHours(newsProperties.refreshAfterHours)
-        for (symbol in symbols) {
-            if (shouldRefresh(symbol, refreshCutoff)) {
-                refreshFromUpstream(symbol)
-            }
-        }
+        refreshStaleSymbols(symbols.filter { shouldRefresh(it, refreshCutoff) })
 
         val retentionStart = LocalDateTime.now().minusDays(newsProperties.retentionDays)
         val stored = newsArticleRepo.findByTickersAfter(symbols, retentionStart)
@@ -82,30 +88,77 @@ class EodhdNewsService(
         return meta == null || meta.lastFetchedAt.isBefore(cutoff)
     }
 
-    private fun refreshFromUpstream(symbol: String) {
+    /**
+     * Refresh each stale symbol from EODHD. The upstream HTTP call is the slow part — one network
+     * round-trip per symbol — so the fetches fan out across [Dispatchers.IO] and run concurrently.
+     * A 10-ticker agent query that previously did 10 serial round-trips (~21s observed in Sentry)
+     * collapses to a single round-trip's latency.
+     *
+     * Persistence stays on the calling thread. This method runs inside a `@Transactional` boundary,
+     * and the bound Hibernate session is single-threaded — DB writes must never touch it from a
+     * coroutine dispatcher thread. So coroutines do network-only work; the results are persisted
+     * serially here. [runBlockingTraced] keeps the OTel/Sentry span attached across the dispatcher
+     * switch (see jar-common CoroutineTracing).
+     */
+    private fun refreshStaleSymbols(symbols: List<String>) {
+        if (symbols.isEmpty()) return
+        val fetched =
+            runBlockingTraced {
+                symbols
+                    .map { symbol ->
+                        async(Dispatchers.IO) { fetchGate.withPermit { symbol to fetchUpstream(symbol) } }
+                    }.awaitAll()
+            }
+        for ((symbol, outcome) in fetched) {
+            persist(symbol, outcome)
+        }
+    }
+
+    private fun fetchUpstream(symbol: String): FetchResult =
         try {
-            val fresh =
+            FetchResult.Success(
                 eodhdProxy.getNews(
                     symbol = symbol,
                     limit = newsProperties.providerLimit,
                     from = null,
                     apiKey = eodhdConfig.apiKey
                 )
-            upsertAll(symbol, fresh)
-            newsFetchRepo.save(NewsFetch(symbol, LocalDateTime.now(), fresh.size))
+            )
         } catch (
             @Suppress("TooGenericExceptionCaught")
             e: Exception
         ) {
             log.debug("EODHD news lookup failed for {}: {}", symbol, e.message)
-            // Burn the refresh cooldown even on failure — otherwise a transient EODHD outage
-            // or 429 turns every subsequent request into a quota-amplifying retry storm. Next
-            // attempt waits `refresh-after-hours`, matching the success-path backoff. Articles
-            // already in the DB keep serving in the meantime.
-            val existing = newsFetchRepo.findById(symbol).orElseGet { NewsFetch(symbol) }
-            existing.lastFetchedAt = LocalDateTime.now()
-            newsFetchRepo.save(existing)
+            FetchResult.Failure
         }
+
+    private fun persist(
+        symbol: String,
+        outcome: FetchResult
+    ) {
+        when (outcome) {
+            is FetchResult.Success -> {
+                upsertAll(symbol, outcome.articles)
+                newsFetchRepo.save(NewsFetch(symbol, LocalDateTime.now(), outcome.articles.size))
+            }
+            FetchResult.Failure -> {
+                // Burn the refresh cooldown even on failure — otherwise a transient EODHD outage
+                // or 429 turns every subsequent request into a quota-amplifying retry storm. Next
+                // attempt waits `refresh-after-hours`, matching the success-path backoff. Articles
+                // already in the DB keep serving in the meantime.
+                val existing = newsFetchRepo.findById(symbol).orElseGet { NewsFetch(symbol) }
+                existing.lastFetchedAt = LocalDateTime.now()
+                newsFetchRepo.save(existing)
+            }
+        }
+    }
+
+    private sealed interface FetchResult {
+        data class Success(
+            val articles: List<EodhdNewsArticle>
+        ) : FetchResult
+
+        data object Failure : FetchResult
     }
 
     private fun upsertAll(
@@ -255,6 +308,9 @@ class EodhdNewsService(
         }
 
     companion object {
+        // Caps simultaneous EODHD news round-trips per request. 8 covers a typical portfolio's
+        // holdings in one wave while leaving headroom under the shared daily quota.
+        private const val MAX_CONCURRENT_FETCHES = 8
         private const val SUMMARY_CHARS = 400
         private const val BULLISH_THRESHOLD = 0.35
         private const val BEARISH_THRESHOLD = -0.35

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.dao.DataIntegrityViolationException
@@ -24,6 +25,9 @@ import org.springframework.test.util.ReflectionTestUtils
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Optional
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Unit tests for [EodhdNewsService] with repos mocked. End-to-end persistence is covered by the
@@ -60,6 +64,34 @@ internal class EodhdNewsServiceTest {
 
         verify(proxy).getNews(eq("AAPL.US"), eq(10), eq(null), eq("demo"))
         verify(fetchRepo).save(any<NewsFetch>())
+    }
+
+    @Test
+    fun `per-symbol upstream refreshes run concurrently`() {
+        // A batch of N stale tickers must fan out to N concurrent EODHD calls, not N serial ones.
+        // Each fetch rendezvous at a CyclicBarrier sized to the batch: the barrier only trips once
+        // every party has arrived, which can only happen if the fetches are genuinely in flight at
+        // the same time. A serial loop leaves a single party waiting until it times out, so the
+        // rendezvous count never reaches the batch size. Deterministic — no sleeps or timing windows.
+        val symbols = listOf("AAPL.US", "MSFT.US", "GOOG.US")
+        symbols.forEach { whenever(fetchRepo.findById(it)).thenReturn(Optional.empty()) }
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        val rendezvous = CyclicBarrier(symbols.size)
+        val arrived = AtomicInteger(0)
+        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenAnswer {
+            // Throws TimeoutException (caught by the service → Failure) if the parties never meet,
+            // i.e. if the fetches run serially.
+            rendezvous.await(5, TimeUnit.SECONDS)
+            arrived.incrementAndGet()
+            listOf(eodhArticle(0.5))
+        }
+
+        service.getNewsSentiment("AAPL,MSFT,GOOG")
+
+        assertThat(arrived.get()).isEqualTo(symbols.size)
+        verify(proxy, times(3)).getNews(any(), any(), anyOrNull(), any())
     }
 
     @Test


### PR DESCRIPTION
## Problem

Sentry trace of a bc-agent query showed `bc-data/api/news` at ~21s (10 tickers) + ~11s (4 tickers) — dominating a 29s trace. Everything else sub-second.

Root cause: `EodhdNewsService.getNewsSentiment` refreshed stale tickers in a **serial blocking loop** — one EODHD HTTP round-trip per ticker, summed.

## Fix

- Fan out per-symbol upstream fetches across `Dispatchers.IO`, bounded by a `Semaphore(8)` so a large holdings list can't burst the shared ~1200/day EODHD quota.
- DB writes stay serial on the `@Transactional` thread — Hibernate session is single-threaded, so coroutines do network-only work; results persist afterward.
- `runBlockingTraced` keeps the OTel/Sentry span attached across the dispatcher switch.
- Failure-path cooldown burn preserved (no quota retry-storm).

10 serial round-trips → ~1 round-trip latency.

## Tests

- New `per-symbol upstream refreshes run concurrently` — deterministic `CyclicBarrier` rendezvous (no sleeps); serial impl can't trip the barrier.
- Full `:svc-data:test` green, formatKotlin + lintKotlin clean, semgrep clean.

Local code-review skill run pre-push.

@coderabbitai ignore