### PR TITLE
feat(agent): date-grounded prompts + market/sector news proxies

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -25,7 +25,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.HtmlUtils
 import reactor.core.publisher.Flux
+import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -50,7 +53,10 @@ class AgentController(
     private val environment: Environment,
     private val objectMapper: ObjectMapper,
     private val llmMetrics: LlmMetrics,
-    private val scopeAuthorizer: AgentScopeAuthorizer
+    private val scopeAuthorizer: AgentScopeAuthorizer,
+    // UTC clock for stamping the current date onto each user message. Defaulted so Spring wires it
+    // without a Clock bean; overridden in tests for a fixed date.
+    private val clock: Clock = Clock.systemUTC()
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
 
@@ -455,11 +461,27 @@ class AgentController(
         )
     }
 
-    private fun buildUserMessage(request: AgentQuery): String {
+    /**
+     * Assemble the user message: a current-date stamp, optional page context, then the question.
+     *
+     * The date line is load-bearing — the LLM has no inherent knowledge of today and otherwise
+     * answers from its training-cutoff frame (DeepSeek was dating "current" events to 2025). Stamped
+     * onto the user message rather than the system prompt so the static system prompt stays
+     * cache-stable across requests.
+     *
+     * `internal` for unit testing against a fixed [clock].
+     */
+    internal fun buildUserMessage(request: AgentQuery): String {
+        val dateLine = "[Current date: ${LocalDate.now(clock)}]"
         val ctx = request.context
-        if (ctx.isNullOrEmpty()) return request.query
-        val contextLine = ctx.entries.joinToString(", ") { "${it.key}: ${it.value}" }
-        return "[Page context: $contextLine]\n\n${request.query}"
+        val header =
+            if (ctx.isNullOrEmpty()) {
+                dateLine
+            } else {
+                val contextLine = ctx.entries.joinToString(", ") { "${it.key}: ${it.value}" }
+                "$dateLine\n[Page context: $contextLine]"
+            }
+        return "$header\n\n${request.query}"
     }
 }
 

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -161,6 +161,34 @@ object DomainSystemPrompts {
         - FX: `getFxRate(from, to)` is available but only for currency-pair
           questions; do not use it to reconstruct dollar holdings.
 
+        ### News & market context
+
+        Two complementary news tools — use both when explaining moves:
+
+        - `getNews(tickers)` — news tagged to specific holdings. Good for
+          "what's happening with NVDA?".
+        - `getMarketNews(scope)` — the macro/sector context that per-holding
+          news misses. A market-wide event (a jobs report, a Fed decision, a
+          broad sell-off) moves a portfolio without being tagged to any one
+          ticker, so `getNews` alone will look quiet on exactly the days that
+          matter most.
+
+        When the user asks **why the market or their portfolio moved**, what's
+        **happening today**, or for commentary on conditions:
+        1. Call `getMarketNews("market")` for the macro backdrop.
+        2. For the sectors the holdings sit in (infer from the `category`
+           column / well-known tickers — e.g. a tech-heavy book → call
+           `getMarketNews("technology")`), pull sector news too. One call per
+           sector; cover the few that dominate the weight, not all eleven.
+        3. Attribute the move: tie the biggest `changePercent` movers to the
+           macro/sector drivers. Lead with the driver, name the affected
+           holdings — don't just relay headlines.
+
+        A `{status: "unknown_scope", ...}` response means the scope wasn't a
+        known sector — retry with one of the `supportedScopes` it lists, or
+        `"market"`. A `{status: "no_coverage"}` means nothing live; say so
+        briefly rather than inventing.
+
         ### Closed positions
 
         Closed (zero-quantity) positions are filtered out before the tool
@@ -530,6 +558,8 @@ object DomainSystemPrompts {
         - Models / allocations / drift → Rebalance tools
           (`listRebalanceModels`, `getApprovedRebalancePlan`).
         - News / sentiment / "what's happening with X" → `getNews`.
+        - Why the market / portfolio moved, "what happened today", macro or
+          sector conditions → `getMarketNews(scope)` ('market' or a sector).
 
         Closed positions (quantity = 0) are excluded by default unless the
         user explicitly asks about historical / sold / closed holdings.

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/clients/AlphaVantageNewsClient.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/clients/AlphaVantageNewsClient.kt
@@ -41,6 +41,29 @@ class AlphaVantageNewsClient(
             .body(MAP_TYPE) ?: emptyMap()
     }
 
+    /**
+     * Market / sector news via svc-data's `/news/market` endpoint. [symbols] are verbatim EODHD
+     * proxy symbols (an index or a sector ETF) the caller has already chosen.
+     */
+    fun getMarketNews(
+        symbols: List<String>,
+        topics: String? = null
+    ): Map<String, Any> {
+        val params = mutableMapOf("symbols" to symbols.joinToString(","))
+        val queryParts = mutableListOf("symbols={symbols}")
+        if (!topics.isNullOrBlank()) {
+            params["topics"] = topics
+            queryParts.add("topics={topics}")
+        }
+        val uri = "/news/market?" + queryParts.joinToString("&")
+        return restClient
+            .get()
+            .uri(uri, params)
+            .header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+            .retrieve()
+            .body(MAP_TYPE) ?: emptyMap()
+    }
+
     companion object {
         private val MAP_TYPE = object : ParameterizedTypeReference<Map<String, Any>>() {}
     }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/config/TimeConfig.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/config/TimeConfig.kt
@@ -1,0 +1,16 @@
+package com.beancounter.agent.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+/**
+ * Supplies the application [Clock]. Injected into [com.beancounter.agent.AgentController] to stamp
+ * the current date onto each user message; a bean (rather than relying on a constructor default)
+ * makes the wiring explicit and lets tests substitute a fixed clock.
+ */
+@Configuration
+class TimeConfig {
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+}

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
@@ -114,13 +114,12 @@ class NewsTools(
         const val UNKNOWN_SCOPE_MESSAGE =
             "Unrecognised scope. Use 'market' for macro news or one of the listed sector names."
 
-        /** Broad-market index proxies — surface macro headlines (jobs, Fed, market-wide moves). */
+        // Proxy symbol maps below: INDEX_PROXIES surface broad-market macro headlines (jobs, Fed,
+        // market-wide moves); SECTOR_ETFS stand in for sector-wide sentiment via SPDR sector ETFs,
+        // which carry strong EODHD news coverage. SECTOR_ETFS keys are the scope vocabulary in
+        // SCOPE_DESC. MARKET_ALIASES are the scope strings that all mean "broad market".
         private val INDEX_PROXIES = listOf("GSPC.INDX", "DJI.INDX")
 
-        /**
-         * Sector → SPDR sector ETF proxy. Sector ETFs carry strong EODHD news coverage, so their
-         * headlines stand in for sector-wide sentiment. Keys are the scope vocabulary in [SCOPE_DESC].
-         */
         private val SECTOR_ETFS =
             mapOf(
                 "technology" to listOf("XLK.US"),
@@ -136,7 +135,6 @@ class NewsTools(
                 "communication" to listOf("XLC.US")
             )
 
-        /** Scope strings that all mean "broad market". */
         private val MARKET_ALIASES = setOf("market", "markets", "macro", "broad", "overall", "index")
     }
 }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
@@ -37,6 +37,35 @@ class NewsTools(
         }
     }
 
+    @Tool(description = MARKET_NEWS_DESC)
+    fun getMarketNews(
+        @ToolParam(description = SCOPE_DESC) scope: String
+    ): Map<String, Any> {
+        val key = scope.trim().lowercase()
+        val symbols = if (key.isBlank() || key in MARKET_ALIASES) INDEX_PROXIES else SECTOR_ETFS[key]
+        if (symbols == null) {
+            log.debug("getMarketNews: unknown scope '{}'", scope)
+            return mapOf(
+                "status" to "unknown_scope",
+                "scope" to scope,
+                "message" to UNKNOWN_SCOPE_MESSAGE,
+                "supportedScopes" to (listOf("market") + SECTOR_ETFS.keys.sorted())
+            )
+        }
+        log.debug("getMarketNews: scope={} -> {}", scope, symbols)
+        val raw = newsClient.getMarketNews(symbols)
+        val feed = raw["feed"] as? List<*>
+        return if (raw.isEmpty() || feed.isNullOrEmpty()) {
+            mapOf(
+                "status" to "no_coverage",
+                "scope" to scope,
+                "message" to NO_COVERAGE_MESSAGE
+            )
+        } else {
+            raw
+        }
+    }
+
     companion object {
         const val NEWS_DESC =
             "Get recent news articles and sentiment analysis for given ticker symbols. " +
@@ -68,5 +97,46 @@ class NewsTools(
         const val NO_COVERAGE_MESSAGE =
             "No live news coverage available for this ticker. This is common for " +
                 "non-US listings. Provide a general-knowledge summary instead — do not retry."
+
+        const val MARKET_NEWS_DESC =
+            "Get market-wide or sector-wide news and sentiment via index/sector proxies — the " +
+                "macro context that per-holding `getNews` misses (e.g. a jobs report, a Fed " +
+                "decision, or a broad sell-off that moves a portfolio but isn't tagged to any one " +
+                "ticker). Returns the same shape as getNews. Use this when the user asks why the " +
+                "market or their portfolio moved, what's happening today, or about a sector's " +
+                "conditions. To attribute a portfolio's move, also call this once per sector the " +
+                "holdings belong to. NEVER mention the underlying data provider."
+        const val SCOPE_DESC =
+            "What to fetch news for: 'market' for broad macro/market-wide news, or a sector name. " +
+                "Supported sectors: technology, financials, energy, healthcare, " +
+                "consumer_discretionary, consumer_staples, industrials, materials, utilities, " +
+                "real_estate, communication. Pass one scope per call."
+        const val UNKNOWN_SCOPE_MESSAGE =
+            "Unrecognised scope. Use 'market' for macro news or one of the listed sector names."
+
+        /** Broad-market index proxies — surface macro headlines (jobs, Fed, market-wide moves). */
+        private val INDEX_PROXIES = listOf("GSPC.INDX", "DJI.INDX")
+
+        /**
+         * Sector → SPDR sector ETF proxy. Sector ETFs carry strong EODHD news coverage, so their
+         * headlines stand in for sector-wide sentiment. Keys are the scope vocabulary in [SCOPE_DESC].
+         */
+        private val SECTOR_ETFS =
+            mapOf(
+                "technology" to listOf("XLK.US"),
+                "financials" to listOf("XLF.US"),
+                "energy" to listOf("XLE.US"),
+                "healthcare" to listOf("XLV.US"),
+                "consumer_discretionary" to listOf("XLY.US"),
+                "consumer_staples" to listOf("XLP.US"),
+                "industrials" to listOf("XLI.US"),
+                "materials" to listOf("XLB.US"),
+                "utilities" to listOf("XLU.US"),
+                "real_estate" to listOf("XLRE.US"),
+                "communication" to listOf("XLC.US")
+            )
+
+        /** Scope strings that all mean "broad market". */
+        private val MARKET_ALIASES = setOf("market", "markets", "macro", "broad", "overall", "index")
     }
 }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -138,19 +138,19 @@ class AgentControllerTest {
         // DeepSeek answered with a 2025 frame because nothing in the prompt bound "today" to a real
         // date. The user message must state the current date for every query.
         val fixed = java.time.Clock.fixed(java.time.Instant.parse("2026-06-06T10:00:00Z"), java.time.ZoneOffset.UTC)
+        val question = "how is the market today?"
 
         val withContext =
             controller(clock = fixed)
-                .buildUserMessage(AgentQuery("how is the market today?", context = mapOf("portfolioCode" to "VOO")))
-        val withoutContext =
-            controller(clock = fixed).buildUserMessage(AgentQuery("how is the market today?"))
+                .buildUserMessage(AgentQuery(question, context = mapOf("portfolioCode" to "VOO")))
+        val withoutContext = controller(clock = fixed).buildUserMessage(AgentQuery(question))
 
         assertThat(withContext).contains("2026-06-06")
         assertThat(withContext).contains("portfolioCode: VOO")
-        assertThat(withContext).contains("how is the market today?")
+        assertThat(withContext).contains(question)
         // Even with no page context, the date must still be present.
         assertThat(withoutContext).contains("2026-06-06")
-        assertThat(withoutContext).contains("how is the market today?")
+        assertThat(withoutContext).contains(question)
     }
 
     @Test

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -80,7 +80,8 @@ class AgentControllerTest {
     private fun controller(
         chatClient: ChatClient? = null,
         healthChecker: ServiceHealthChecker = stubChecker(),
-        scopeAuthorizer: AgentScopeAuthorizer = permissiveAuthorizer
+        scopeAuthorizer: AgentScopeAuthorizer = permissiveAuthorizer,
+        clock: java.time.Clock = java.time.Clock.systemUTC()
     ): AgentController =
         AgentController(
             chatClient,
@@ -94,7 +95,8 @@ class AgentControllerTest {
             environment,
             ObjectMapper(),
             LlmMetrics(),
-            scopeAuthorizer
+            scopeAuthorizer,
+            clock
         )
 
     private fun stubChecker(): ServiceHealthChecker =
@@ -129,6 +131,26 @@ class AgentControllerTest {
         org.mockito.kotlin
             .verify(checker)
             .check(llmAvailable = true)
+    }
+
+    @Test
+    fun `user message carries the current date so the model anchors to today not its training cutoff`() {
+        // DeepSeek answered with a 2025 frame because nothing in the prompt bound "today" to a real
+        // date. The user message must state the current date for every query.
+        val fixed = java.time.Clock.fixed(java.time.Instant.parse("2026-06-06T10:00:00Z"), java.time.ZoneOffset.UTC)
+
+        val withContext =
+            controller(clock = fixed)
+                .buildUserMessage(AgentQuery("how is the market today?", context = mapOf("portfolioCode" to "VOO")))
+        val withoutContext =
+            controller(clock = fixed).buildUserMessage(AgentQuery("how is the market today?"))
+
+        assertThat(withContext).contains("2026-06-06")
+        assertThat(withContext).contains("portfolioCode: VOO")
+        assertThat(withContext).contains("how is the market today?")
+        // Even with no page context, the date must still be present.
+        assertThat(withoutContext).contains("2026-06-06")
+        assertThat(withoutContext).contains("how is the market today?")
     }
 
     @Test

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/clients/AlphaVantageNewsClientTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/clients/AlphaVantageNewsClientTest.kt
@@ -1,0 +1,78 @@
+package com.beancounter.agent.clients
+
+import com.beancounter.auth.TokenService
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+
+/**
+ * Drives [AlphaVantageNewsClient] against a [MockRestServiceServer] so the URI assembly and the
+ * bearer header are pinned without standing up svc-data.
+ */
+class AlphaVantageNewsClientTest {
+    private val tokenService = mock<TokenService> { on { bearerToken } doReturn BEARER }
+
+    private fun clientWithServer(): Pair<AlphaVantageNewsClient, MockRestServiceServer> {
+        val builder = RestClient.builder().baseUrl(BASE_URL)
+        val server = MockRestServiceServer.bindTo(builder).build()
+        return AlphaVantageNewsClient(builder.build(), tokenService) to server
+    }
+
+    @Test
+    fun `getMarketNews requests the market endpoint with comma-joined proxy symbols`() {
+        val (client, server) = clientWithServer()
+        server
+            .expect(method(HttpMethod.GET))
+            .andExpect(
+                requestTo(
+                    allOf(containsString("/news/market"), containsString("GSPC.INDX"), containsString("DJI.INDX"))
+                )
+            ).andExpect(header("Authorization", BEARER))
+            .andRespond(withSuccess(FEED_JSON, MediaType.APPLICATION_JSON))
+
+        val result = client.getMarketNews(listOf("GSPC.INDX", "DJI.INDX"))
+
+        assertThat(result["count"]).isEqualTo(1)
+        server.verify()
+    }
+
+    @Test
+    fun `getNewsSentiment passes tickers, market and topics through to the news endpoint`() {
+        val (client, server) = clientWithServer()
+        server
+            .expect(method(HttpMethod.GET))
+            .andExpect(
+                requestTo(
+                    allOf(
+                        containsString("/news?"),
+                        containsString("AAPL"),
+                        containsString("US"),
+                        containsString("earnings")
+                    )
+                )
+            ).andExpect(header("Authorization", BEARER))
+            .andRespond(withSuccess(FEED_JSON, MediaType.APPLICATION_JSON))
+
+        val result = client.getNewsSentiment("AAPL", market = "US", topics = "earnings")
+
+        assertThat(result["count"]).isEqualTo(1)
+        server.verify()
+    }
+
+    private companion object {
+        const val BASE_URL = "http://bc-data"
+        const val BEARER = "Bearer test"
+        const val FEED_JSON = """{"feed":[{"title":"Tech Wreck"}],"count":1}"""
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/config/TimeConfigTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/config/TimeConfigTest.kt
@@ -1,0 +1,18 @@
+package com.beancounter.agent.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.ZoneOffset
+
+/**
+ * Pins that the supplied [java.time.Clock] is UTC — the agent stamps message dates from it, so a
+ * locally-zoned clock would drift the "current date" off the user's expectation near midnight.
+ */
+internal class TimeConfigTest {
+    @Test
+    fun `clock bean is UTC`() {
+        val clock = TimeConfig().clock()
+
+        assertThat(clock.zone).isEqualTo(ZoneOffset.UTC)
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/NewsToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/NewsToolsTest.kt
@@ -12,6 +12,11 @@ import org.mockito.kotlin.verifyNoInteractions
  * Verify that NewsTools delegates to AlphaVantageNewsClient correctly.
  */
 class NewsToolsTest {
+    private companion object {
+        const val MARKET = "market"
+        val INDEX_PROXIES = listOf("GSPC.INDX", "DJI.INDX")
+    }
+
     private val sampleResponse: Map<String, Any> =
         mapOf(
             "feed" to
@@ -98,14 +103,14 @@ class NewsToolsTest {
     fun `getMarketNews maps the market scope to broad index proxies`() {
         val client =
             mock<AlphaVantageNewsClient> {
-                on { getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null) } doReturn sampleResponse
+                on { getMarketNews(INDEX_PROXIES, null) } doReturn sampleResponse
             }
         val tools = NewsTools(client)
 
-        val result = tools.getMarketNews("market")
+        val result = tools.getMarketNews(MARKET)
 
         assertThat(result).isSameAs(sampleResponse)
-        verify(client).getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null)
+        verify(client).getMarketNews(INDEX_PROXIES, null)
     }
 
     @Test
@@ -141,11 +146,11 @@ class NewsToolsTest {
     fun `getMarketNews returns no_coverage when the proxy yields an empty feed`() {
         val client =
             mock<AlphaVantageNewsClient> {
-                on { getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null) } doReturn mapOf("feed" to emptyList<Any>())
+                on { getMarketNews(INDEX_PROXIES, null) } doReturn mapOf("feed" to emptyList<Any>())
             }
         val tools = NewsTools(client)
 
-        val result = tools.getMarketNews("market")
+        val result = tools.getMarketNews(MARKET)
 
         assertThat(result["status"]).isEqualTo("no_coverage")
     }

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/NewsToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/NewsToolsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 
 /**
  * Verify that NewsTools delegates to AlphaVantageNewsClient correctly.
@@ -89,6 +90,62 @@ class NewsToolsTest {
         val tools = NewsTools(client)
 
         val result = tools.getNews("GNE", "NZX")
+
+        assertThat(result["status"]).isEqualTo("no_coverage")
+    }
+
+    @Test
+    fun `getMarketNews maps the market scope to broad index proxies`() {
+        val client =
+            mock<AlphaVantageNewsClient> {
+                on { getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null) } doReturn sampleResponse
+            }
+        val tools = NewsTools(client)
+
+        val result = tools.getMarketNews("market")
+
+        assertThat(result).isSameAs(sampleResponse)
+        verify(client).getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null)
+    }
+
+    @Test
+    fun `getMarketNews maps a sector scope to its SPDR ETF proxy`() {
+        val client =
+            mock<AlphaVantageNewsClient> {
+                on { getMarketNews(listOf("XLK.US"), null) } doReturn sampleResponse
+            }
+        val tools = NewsTools(client)
+
+        // Case-insensitive scope resolution.
+        val result = tools.getMarketNews("Technology")
+
+        assertThat(result).isSameAs(sampleResponse)
+        verify(client).getMarketNews(listOf("XLK.US"), null)
+    }
+
+    @Test
+    fun `getMarketNews returns unknown_scope without hitting the client for a bad scope`() {
+        val client = mock<AlphaVantageNewsClient>()
+        val tools = NewsTools(client)
+
+        val result = tools.getMarketNews("crypto")
+
+        assertThat(result["status"]).isEqualTo("unknown_scope")
+        @Suppress("UNCHECKED_CAST")
+        val supported = result["supportedScopes"] as List<String>
+        assertThat(supported).contains("market", "technology", "energy")
+        verifyNoInteractions(client)
+    }
+
+    @Test
+    fun `getMarketNews returns no_coverage when the proxy yields an empty feed`() {
+        val client =
+            mock<AlphaVantageNewsClient> {
+                on { getMarketNews(listOf("GSPC.INDX", "DJI.INDX"), null) } doReturn mapOf("feed" to emptyList<Any>())
+            }
+        val tools = NewsTools(client)
+
+        val result = tools.getMarketNews("market")
 
         assertThat(result["status"]).isEqualTo("no_coverage")
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/NewsProvider.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/NewsProvider.kt
@@ -19,4 +19,19 @@ interface NewsProvider {
         market: String? = null,
         topics: String? = null
     ): Map<String, Any>
+
+    /**
+     * Market / sector news by verbatim proxy symbols (e.g. an index `GSPC.INDX` or a sector ETF
+     * `XLK.US`) rather than held tickers — the macro/sector signal that per-holding news misses.
+     *
+     * @param symbols fully-qualified provider symbols, already exchange-suffixed; NOT resolved
+     * @param topics  optional topic filter; provider-defined vocabulary
+     *
+     * Default returns an empty map: only providers with index/ETF news coverage (EODHD) implement
+     * it. AlphaVantage callers get the standard no-coverage signal.
+     */
+    fun getMarketNews(
+        symbols: List<String>,
+        topics: String? = null
+    ): Map<String, Any> = emptyMap()
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/NewsServiceFacade.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/NewsServiceFacade.kt
@@ -34,6 +34,11 @@ class NewsServiceFacade(
         topics: String?
     ): Map<String, Any> = activeProvider().getNewsSentiment(tickers, market, topics)
 
+    override fun getMarketNews(
+        symbols: List<String>,
+        topics: String?
+    ): Map<String, Any> = activeProvider().getMarketNews(symbols, topics)
+
     private fun activeProvider(): NewsProvider =
         when (provider.lowercase()) {
             "eodhd" -> {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsController.kt
@@ -42,4 +42,20 @@ class AlphaNewsController(
         @Parameter(description = "Optional topic filter", required = false)
         @RequestParam(required = false) topics: String? = null
     ): Map<String, Any> = newsService.getNewsSentiment(tickers, market, topics)
+
+    @GetMapping("/market", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(
+        summary = "Get market / sector news by proxy symbols",
+        description =
+            "Fetches news for verbatim proxy symbols — an index (e.g. GSPC.INDX) for market-wide " +
+                "macro moves, or a sector ETF (e.g. XLK.US) for sector-level moves. Used to surface " +
+                "context that per-holding news misses. Only the EODHD provider has index/ETF news " +
+                "coverage; other providers return no coverage."
+    )
+    fun getMarketNews(
+        @Parameter(description = "Comma-separated EODHD proxy symbols", example = "GSPC.INDX,XLK.US")
+        @RequestParam symbols: String,
+        @Parameter(description = "Optional topic filter", required = false)
+        @RequestParam(required = false) topics: String? = null
+    ): Map<String, Any> = newsService.getMarketNews(symbols.split(","), topics)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -55,8 +55,30 @@ class EodhdNewsService(
         tickers: String,
         market: String?,
         topics: String?
+    ): Map<String, Any> = newsForSymbols(resolveSymbols(tickers, market), topics)
+
+    /**
+     * Market / sector news via proxy symbols. svc-agent passes already-resolved EODHD symbols
+     * (e.g. `GSPC.INDX` for the S&P 500, `XLK.US` for the tech sector SPDR) so macro and sector-wide
+     * moves surface even when no held ticker is tagged in the article. Symbols are verbatim — unlike
+     * [getNewsSentiment] there's no ticker+market resolution step — and otherwise share the same
+     * DB-backed refresh / rank / project pipeline.
+     */
+    @Transactional
+    override fun getMarketNews(
+        symbols: List<String>,
+        topics: String?
+    ): Map<String, Any> = newsForSymbols(symbols.map { it.trim().uppercase() }.filter { it.isNotBlank() }, topics)
+
+    /**
+     * Shared read path: refresh any stale symbols from upstream, then rank the stored articles by
+     * sentiment magnitude and project to the `{feed, count}` shape. Returns an empty map when no
+     * symbols resolve or nothing ranks — the no-coverage signal svc-agent's NewsTools expects.
+     */
+    private fun newsForSymbols(
+        symbols: List<String>,
+        topics: String?
     ): Map<String, Any> {
-        val symbols = resolveSymbols(tickers, market)
         if (symbols.isEmpty()) return emptyMap()
 
         val refreshCutoff = LocalDateTime.now().minusHours(newsProperties.refreshAfterHours)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/NewsServiceFacadeTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/NewsServiceFacadeTest.kt
@@ -72,6 +72,18 @@ internal class NewsServiceFacadeTest {
         assertThat(result).isEmpty()
     }
 
+    @Test
+    fun `market news routes to the active provider`() {
+        val (facade, alpha, eodhd) = facade(provider = "eodhd")
+        val symbols = listOf("GSPC.INDX", "XLK.US")
+        whenever(eodhd.getMarketNews(symbols, null)).thenReturn(mapOf("feed" to listOf<Any>()))
+
+        facade.getMarketNews(symbols)
+
+        verify(eodhd).getMarketNews(eq(symbols), eq(null))
+        verifyNoInteractions(alpha)
+    }
+
     private data class FacadeTriple(
         val facade: NewsServiceFacade,
         val alpha: AlphaNewsService,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsControllerTest.kt
@@ -1,0 +1,41 @@
+package com.beancounter.marketdata.providers.alpha
+
+import com.beancounter.marketdata.providers.NewsServiceFacade
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Thin-controller tests: [AlphaNewsController] only parses request params and delegates to
+ * [NewsServiceFacade]. Pins the `/news/market` symbol split and the delegation contract.
+ */
+internal class AlphaNewsControllerTest {
+    private val newsService = mock<NewsServiceFacade>()
+    private val controller = AlphaNewsController(newsService)
+
+    @Test
+    fun `getNews delegates tickers, market and topics to the facade`() {
+        val expected = mapOf<String, Any>("feed" to listOf<Any>(), "count" to 0)
+        whenever(newsService.getNewsSentiment("AAPL", "US", "earnings")).thenReturn(expected)
+
+        val result = controller.getNews("AAPL", "US", "earnings")
+
+        assertThat(result).isSameAs(expected)
+        verify(newsService).getNewsSentiment(eq("AAPL"), eq("US"), eq("earnings"))
+    }
+
+    @Test
+    fun `getMarketNews splits comma-separated proxy symbols before delegating`() {
+        val expected = mapOf<String, Any>("feed" to listOf<Any>(), "count" to 0)
+        val symbols = listOf("GSPC.INDX", "XLK.US")
+        whenever(newsService.getMarketNews(symbols, null)).thenReturn(expected)
+
+        val result = controller.getMarketNews("GSPC.INDX,XLK.US", null)
+
+        assertThat(result).isSameAs(expected)
+        verify(newsService).getMarketNews(eq(symbols), eq(null))
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsControllerTest.kt
@@ -19,12 +19,15 @@ internal class AlphaNewsControllerTest {
     @Test
     fun `getNews delegates tickers, market and topics to the facade`() {
         val expected = mapOf<String, Any>("feed" to listOf<Any>(), "count" to 0)
-        whenever(newsService.getNewsSentiment("AAPL", "US", "earnings")).thenReturn(expected)
+        val ticker = "AAPL"
+        val market = "US"
+        val topics = "earnings"
+        whenever(newsService.getNewsSentiment(ticker, market, topics)).thenReturn(expected)
 
-        val result = controller.getNews("AAPL", "US", "earnings")
+        val result = controller.getNews(ticker, market, topics)
 
         assertThat(result).isSameAs(expected)
-        verify(newsService).getNewsSentiment(eq("AAPL"), eq("US"), eq("earnings"))
+        verify(newsService).getNewsSentiment(eq(ticker), eq(market), eq(topics))
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -33,7 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger
  * Unit tests for [EodhdNewsService] with repos mocked. End-to-end persistence is covered by the
  * Spring + WireMock integration test ([EodhdNewsApiTest]); these specs pin the routing logic, the
  * refresh-gating, and the response shape.
+ *
+ * Repeated domain literals (ticker symbols, the `title`/`feed` projection keys) read clearer inline
+ * across these spec methods than hoisted into constants, so detekt's duplication rule is suppressed.
  */
+@Suppress("StringLiteralDuplication")
 internal class EodhdNewsServiceTest {
     private val proxy = mock<EodhdProxy>()
     private val marketService = mock<MarketService>()

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -70,22 +70,25 @@ internal class EodhdNewsServiceTest {
     fun `market news fetches verbatim proxy symbols without ticker-market resolution`() {
         // Index/sector proxies arrive already exchange-qualified (GSPC.INDX). They must be queried
         // verbatim — NOT re-suffixed to GSPC.INDX.US the way resolveSymbols treats held tickers.
-        whenever(fetchRepo.findById("GSPC.INDX")).thenReturn(Optional.empty())
-        whenever(fetchRepo.findById("XLK.US")).thenReturn(Optional.empty())
+        val index = "GSPC.INDX"
+        val sector = "XLK.US"
+        val headline = "Tech Wreck"
+        whenever(fetchRepo.findById(index)).thenReturn(Optional.empty())
+        whenever(fetchRepo.findById(sector)).thenReturn(Optional.empty())
         whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenReturn(listOf(eodhArticle(0.6)))
         whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
         whenever(articleRepo.findByTickersAfter(any(), any()))
-            .thenReturn(listOf(storedArticle(polarity = 0.7, title = "Tech Wreck")))
+            .thenReturn(listOf(storedArticle(polarity = 0.7, title = headline)))
 
-        val result = service.getMarketNews(listOf("GSPC.INDX", "xlk.us"), topics = null)
+        val result = service.getMarketNews(listOf(index, "xlk.us"), topics = null)
 
-        verify(proxy).getNews(eq("GSPC.INDX"), any(), anyOrNull(), any())
+        verify(proxy).getNews(eq(index), any(), anyOrNull(), any())
         // Lower-case input is normalised, not re-resolved with an exchange suffix.
-        verify(proxy).getNews(eq("XLK.US"), any(), anyOrNull(), any())
+        verify(proxy).getNews(eq(sector), any(), anyOrNull(), any())
 
         @Suppress("UNCHECKED_CAST")
         val feed = result["feed"] as List<Map<String, Any>>
-        assertThat(feed.first()["title"]).isEqualTo("Tech Wreck")
+        assertThat(feed.first()["title"]).isEqualTo(headline)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -67,6 +67,36 @@ internal class EodhdNewsServiceTest {
     }
 
     @Test
+    fun `market news fetches verbatim proxy symbols without ticker-market resolution`() {
+        // Index/sector proxies arrive already exchange-qualified (GSPC.INDX). They must be queried
+        // verbatim — NOT re-suffixed to GSPC.INDX.US the way resolveSymbols treats held tickers.
+        whenever(fetchRepo.findById("GSPC.INDX")).thenReturn(Optional.empty())
+        whenever(fetchRepo.findById("XLK.US")).thenReturn(Optional.empty())
+        whenever(proxy.getNews(any(), any(), anyOrNull(), any())).thenReturn(listOf(eodhArticle(0.6)))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any()))
+            .thenReturn(listOf(storedArticle(polarity = 0.7, title = "Tech Wreck")))
+
+        val result = service.getMarketNews(listOf("GSPC.INDX", "xlk.us"), topics = null)
+
+        verify(proxy).getNews(eq("GSPC.INDX"), any(), anyOrNull(), any())
+        // Lower-case input is normalised, not re-resolved with an exchange suffix.
+        verify(proxy).getNews(eq("XLK.US"), any(), anyOrNull(), any())
+
+        @Suppress("UNCHECKED_CAST")
+        val feed = result["feed"] as List<Map<String, Any>>
+        assertThat(feed.first()["title"]).isEqualTo("Tech Wreck")
+    }
+
+    @Test
+    fun `market news with no proxy symbols short-circuits without an upstream call`() {
+        val result = service.getMarketNews(emptyList(), topics = null)
+
+        assertThat(result).isEmpty()
+        verify(proxy, never()).getNews(any(), any(), anyOrNull(), any())
+    }
+
+    @Test
     fun `per-symbol upstream refreshes run concurrently`() {
         // A batch of N stale tickers must fan out to N concurrent EODHD calls, not N serial ones.
         // Each fetch rendezvous at a CyclicBarrier sized to the batch: the barrier only trips once


### PR DESCRIPTION
## Why

Two gaps surfaced from a live agent query:

1. **DeepSeek answered in 2025.** Nothing in the prompt bound "today" to a real date, so the model reasoned from its training-cutoff frame.
2. **Market-wide news was invisible.** A macro event (a jobs report driving a broad sell-off) moved the portfolio but wasn't tagged to any held ticker, so per-holding `getNews` looked quiet on exactly the day that mattered. Verified against EODHD: `GSPC.INDX` carried "Wall Street ends sharply lower as jobs data fuels rate hike fears" while the holdings' own ticker news did not.

## What

**Date grounding** (`svc-agent`)
- `AgentController.buildUserMessage` stamps `[Current date: YYYY-MM-DD]` on every user message, from an injected `Clock` (`TimeConfig` bean; tests use a fixed clock). Dynamic — keeps the static system prompt cache-stable.

**Market / sector news proxies**
- `svc-data`: `NewsProvider.getMarketNews(symbols, topics)` (default empty), implemented by `EodhdNewsService` as a verbatim-symbol path (no ticker→exchange resolution), reusing the existing parallel-fetch / rank / persist core. New `/news/market` endpoint (inherits the controller's scope check).
- `svc-agent`: `getMarketNews(scope)` tool maps `market` → `GSPC.INDX, DJI.INDX` and a sector name → its SPDR ETF (`technology`→`XLK.US`, etc.). Unknown scope returns the supported list; no upstream call.
- WEALTH + general prompts now instruct the model to pull macro + sector news to attribute portfolio moves.

## Tests
- `AgentControllerTest`: date stamped with/without page context (fixed clock).
- `NewsToolsTest`: market scope → indices, sector → ETF (case-insensitive), unknown scope short-circuits, empty feed → no_coverage.
- `EodhdNewsServiceTest`: verbatim proxy symbols (no exchange re-suffix), empty short-circuit.
- `NewsServiceFacadeTest`: market news routes to active provider.
- Full `:svc-agent:test` + `:svc-data:test` green; format + lint clean; semgrep clean.

Local code-review skill run pre-push.

@coderabbitai ignore