### PR TITLE
fix(data): map EODHD search exchange to BC market code

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -73,12 +73,27 @@ class AssetSearchService(
             return AssetSearchResponse(emptyList())
         }
 
-        return when {
-            market.equals("PRIVATE", ignoreCase = true) -> searchPrivateAssets(keyword)
-            market.equals("FIGI", ignoreCase = true) -> searchFigiGlobal(keyword)
-            market.isNullOrBlank() -> searchLocalAssets(keyword)
-            else -> searchMarketAssets(keyword, market)
-        }
+        val response =
+            when {
+                market.equals("PRIVATE", ignoreCase = true) -> searchPrivateAssets(keyword)
+                market.equals("FIGI", ignoreCase = true) -> searchFigiGlobal(keyword)
+                market.isNullOrBlank() -> searchLocalAssets(keyword)
+                else -> searchMarketAssets(keyword, market)
+            }
+        return AssetSearchResponse(response.data.filter { onSupportedMarket(it) })
+    }
+
+    /**
+     * Final guard: only surface results that sit on a resolvable Beancounter market. The lookup UI
+     * posts a result's `market` to `/api/assets`, which rejects unknown codes with a 404 — so a
+     * result the system can't place on a BC market is unusable noise. Per-provider mapping (EODHD,
+     * FIGI) already emits BC codes; this is the central net that catches anything slipping past them,
+     * including future providers that return their own venue codes.
+     */
+    private fun onSupportedMarket(result: AssetSearchResult): Boolean {
+        val code = result.market
+        if (code.isNullOrBlank()) return false
+        return runCatching { marketService.getMarket(code) }.isSuccess
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -11,6 +11,7 @@ import com.beancounter.marketdata.providers.MarketDataPriceProvider
 import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
 import com.beancounter.marketdata.providers.eodhd.model.EodhdBulkPrice
+import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -186,16 +187,7 @@ class EodhdPriceService(
         return try {
             eodhdProxy
                 .searchAssets(keyword, eodhdConfig.apiKey)
-                .map { row ->
-                    AssetSearchResult(
-                        symbol = row.code,
-                        name = row.name,
-                        type = row.type ?: "Equity",
-                        region = row.exchange,
-                        currency = row.currency,
-                        market = row.exchange
-                    )
-                }
+                .mapNotNull { row -> toSearchResult(row) }
         } catch (
             @Suppress("TooGenericExceptionCaught")
             e: Exception
@@ -203,6 +195,32 @@ class EodhdPriceService(
             log.warn("EODHD search for '{}' failed: {}", keyword, e.message)
             emptyList()
         }
+    }
+
+    /**
+     * Project an EODHD search row onto an [AssetSearchResult], mapping EODHD's exchange code back to
+     * the owning BC market code.
+     *
+     * EODHD reports its own exchange (e.g. `LSE`), but the UI posts the result's `market` to
+     * `/api/assets`, which only accepts BC market codes — posting the raw exchange trips "Unable to
+     * resolve market code" → 404 (asset creation disables alias resolution). [MarketService.getMarket]
+     * resolves the exchange via the alias map (`LSE` → `LON`); rows whose exchange maps to no BC
+     * market are dropped rather than surfaced with an un-postable code — mirroring the FIGI path.
+     */
+    private fun toSearchResult(row: EodhdSearchResult): AssetSearchResult? {
+        val market = runCatching { eodhdConfig.marketService.getMarket(row.exchange) }.getOrNull()
+        if (market == null) {
+            log.debug("Dropping EODHD result {} — exchange {} maps to no BC market", row.code, row.exchange)
+            return null
+        }
+        return AssetSearchResult(
+            symbol = row.code,
+            name = row.name,
+            type = row.type ?: "Equity",
+            region = market.code,
+            currency = row.currency,
+            market = market.code
+        )
     }
 
     companion object {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -119,14 +119,15 @@ class AssetSearchPublicFallbackTest {
     fun `excludes results that sit on no supported BC market`() {
         // A provider surfaced a result on a venue BC doesn't model (XETRA). The UI would post that
         // market to /api/assets and 404 — the central guard must drop it before it ever surfaces.
+        val unsupported = "XETRA"
         val onXetra =
             AssetSearchResult(
                 symbol = "XYZ",
                 name = "Some Frankfurt Listing",
                 type = "ETF",
-                region = "XETRA",
+                region = unsupported,
                 currency = "EUR",
-                market = "XETRA"
+                market = unsupported
             )
         val provider =
             mock<MarketDataPriceProvider> {
@@ -135,7 +136,7 @@ class AssetSearchPublicFallbackTest {
         val strictMarkets =
             mock<MarketService> {
                 on { getMarket("US") } doReturn usMarket
-                on { getMarket("XETRA") } doThrow NotFoundException("Unable to resolve market code XETRA")
+                on { getMarket(unsupported) } doThrow NotFoundException("Unable to resolve market code $unsupported")
             }
         val (service, _) = buildService(marketProvider = provider, marketService = strictMarkets)
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -1,6 +1,7 @@
 package com.beancounter.marketdata.assets
 
 import com.beancounter.common.contracts.AssetSearchResult
+import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.Market
 import com.beancounter.common.utils.BcJson
@@ -56,7 +57,8 @@ class AssetSearchPublicFallbackTest {
         marketProvider: MarketDataPriceProvider =
             mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
         allProviders: Collection<MarketDataPriceProvider> = listOf(marketProvider),
-        dbAssets: List<com.beancounter.common.model.Asset> = emptyList()
+        dbAssets: List<com.beancounter.common.model.Asset> = emptyList(),
+        marketService: MarketService = mock { on { getMarket(any()) } doReturn usMarket }
     ): Pair<AssetSearchService, AlphaProxy> {
         val alphaConfig =
             mock<AlphaConfig> {
@@ -94,8 +96,7 @@ class AssetSearchPublicFallbackTest {
                     },
                 figiGateway = figiGateway,
                 figiConfig = figiConfig,
-                marketService =
-                    mock<MarketService> { on { getMarket(any()) } doReturn usMarket },
+                marketService = marketService,
                 systemUserService = mock<SystemUserService>(),
                 mdFactory = mdFactory
             )
@@ -112,6 +113,35 @@ class AssetSearchPublicFallbackTest {
             .extracting<String> { it.symbol }
             .containsExactly("COWZ")
         verify(alphaProxy).search(any(), any())
+    }
+
+    @Test
+    fun `excludes results that sit on no supported BC market`() {
+        // A provider surfaced a result on a venue BC doesn't model (XETRA). The UI would post that
+        // market to /api/assets and 404 — the central guard must drop it before it ever surfaces.
+        val onXetra =
+            AssetSearchResult(
+                symbol = "XYZ",
+                name = "Some Frankfurt Listing",
+                type = "ETF",
+                region = "XETRA",
+                currency = "EUR",
+                market = "XETRA"
+            )
+        val provider =
+            mock<MarketDataPriceProvider> {
+                on { searchAssets(any(), anyOrNull()) } doReturn listOf(onXetra)
+            }
+        val strictMarkets =
+            mock<MarketService> {
+                on { getMarket("US") } doReturn usMarket
+                on { getMarket("XETRA") } doThrow NotFoundException("Unable to resolve market code XETRA")
+            }
+        val (service, _) = buildService(marketProvider = provider, marketService = strictMarkets)
+
+        val results = service.search("XYZ", "US")
+
+        assertThat(results.data).isEmpty()
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
@@ -1,12 +1,13 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.model.Market
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -33,6 +34,7 @@ internal class EodhdPriceServiceSearchTest {
     @Test
     fun `searchAssets returns mapped results from EODHD search`() {
         val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(marketService.getMarket("US")).thenReturn(Market("US"))
         whenever(proxy.searchAssets(any(), any())).thenReturn(
             listOf(
                 EodhdSearchResult(
@@ -59,6 +61,59 @@ internal class EodhdPriceServiceSearchTest {
     }
 
     @Test
+    fun `searchAssets maps the EODHD exchange to its BC market code`() {
+        // EODHD returns its own exchange ("LSE"); the result must carry the owning BC market code
+        // ("LON") so the UI can POST it to /api/assets without tripping "Unable to resolve market".
+        val service = EodhdPriceService(configWithMarkets("LON"), proxy, adapter, dateUtils)
+        whenever(marketService.getMarket("LSE")).thenReturn(Market(code = "LON", currencyId = "USD"))
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(
+                EodhdSearchResult(
+                    code = "MOTU",
+                    exchange = "LSE",
+                    name = MOTU_NAME,
+                    type = "ETF",
+                    country = "UK",
+                    currency = "USD",
+                    isin = null
+                )
+            )
+        )
+
+        val results = service.searchAssets("MOTU", "LON")
+
+        assertThat(results).hasSize(1)
+        assertThat(results.first().market).isEqualTo("LON")
+        assertThat(results.first().symbol).isEqualTo("MOTU")
+        assertThat(results.first().currency).isEqualTo("USD")
+    }
+
+    @Test
+    fun `searchAssets drops rows whose exchange maps to no BC market`() {
+        // An EODHD exchange with no BC market (e.g. XETRA) must be dropped, not surfaced with a raw
+        // code the UI would post and 404 on.
+        val service = EodhdPriceService(configWithMarkets("LON"), proxy, adapter, dateUtils)
+        whenever(marketService.getMarket("XETRA")).thenThrow(NotFoundException("Unable to resolve market code XETRA"))
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(
+                EodhdSearchResult(
+                    code = "XYZ",
+                    exchange = "XETRA",
+                    name = "Some Frankfurt Listing",
+                    type = "ETF",
+                    country = "DE",
+                    currency = "EUR",
+                    isin = null
+                )
+            )
+        )
+
+        val results = service.searchAssets("XYZ", "LON")
+
+        assertThat(results).isEmpty()
+    }
+
+    @Test
     fun `searchAssets returns empty when EODHD markets allowlist is empty`() {
         val service = EodhdPriceService(configWithMarkets(""), proxy, adapter, dateUtils)
 
@@ -71,6 +126,7 @@ internal class EodhdPriceServiceSearchTest {
     @Test
     fun `searchAssets with null market still queries EODHD when provider is enabled`() {
         val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(marketService.getMarket("US")).thenReturn(Market("US"))
         whenever(proxy.searchAssets(any(), any())).thenReturn(
             listOf(
                 EodhdSearchResult(
@@ -93,6 +149,7 @@ internal class EodhdPriceServiceSearchTest {
 
     companion object {
         private const val HYSA_NAME = "Pacer International HY Corp Bond ETF"
+        private const val MOTU_NAME = "VanEck Morningstar US Wide Moat UCITS ETF A"
     }
 
     @Test


### PR DESCRIPTION
## Symptom

Asset Lookup → search an LSE-listed asset (e.g. MOTU, VanEck Morningstar US Wide Moat UCITS ETF, priced USD) → request Price Chart → **"Could not resolve asset (404)"**.

## Root cause

`EodhdPriceService.searchAssets` set the result's `market` to EODHD's own exchange code:

```kotlin
market = row.exchange   // "LSE"
```

The Asset Lookup UI posts the selected result's `market` to `POST /api/assets` to persist + enrich the asset before charting. `AssetService.create` resolves the market with `getMarket(code, orByAlias = false)` — alias resolution **off** — so the raw EODHD exchange `LSE` (not a BC market code; `LON` is, with `eodhd` alias `LSE`) throws `NotFoundException("Unable to resolve market code LSE")` → 404.

The FIGI search paths already guard against exactly this (they map exchange → BC code and drop unmapped rows); EODHD search didn't.

## Fix

Map each EODHD result's exchange back to the owning BC market code via the alias map (`LSE` → `LON`), and drop rows whose exchange maps to no BC market — so the UI always receives a postable BC code.

## Tests

`EodhdPriceServiceSearchTest`:
- new: `LSE` → result market `LON`
- new: unmappable exchange (`XETRA`) → row dropped
- existing `US` cases updated to stub `marketService.getMarket`

Full `:svc-data:test` green; format + lint clean; semgrep clean.

Local code-review skill run pre-push.

@coderabbitai ignore