### PR TITLE
fix(fx): defer FX for forward-dated trns (DATA-51)

### DIFF
--- a/jar-client/src/main/kotlin/com/beancounter/client/ingest/FxTransactions.kt
+++ b/jar-client/src/main/kotlin/com/beancounter/client/ingest/FxTransactions.kt
@@ -7,7 +7,9 @@ import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.NumberUtils
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -17,7 +19,8 @@ import java.math.BigDecimal
  */
 @Service
 class FxTransactions(
-    private val fxClientService: FxService
+    private val fxClientService: FxService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val numberUtils = NumberUtils()
 
@@ -95,7 +98,10 @@ class FxTransactions(
                 numberUtils.isUnset(trnInput.tradeBaseRate) ||
                 numberUtils.isUnset(trnInput.tradeCashRate)
         ) &&
-            trnInput.trnType != TrnType.SPLIT
+            trnInput.trnType != TrnType.SPLIT &&
+            // Forward tradeDate (e.g. DIVI pay date 18 days out) — FX providers reject
+            // future dates. Auto-settle resolves rates when tradeDate arrives.
+            !trnInput.tradeDate.isAfter(dateUtils.date)
 
     fun setRates(
         portfolio: Portfolio,
@@ -106,5 +112,64 @@ class FxTransactions(
             val (data) = fxClientService.getRates(fxRequest)
             setRates(data, fxRequest, trnInput)
         }
+    }
+
+    /**
+     * Settle-time FX resolution. PROPOSED corporate-event trns (DIVI) are written with
+     * forward-dated tradeDate (= payDate) and their FX rates are deferred (see
+     * `needsRates(TrnInput)`). When auto-settle (or a manual settle) flips PROPOSED → SETTLED
+     * the tradeDate has now arrived, so we resolve and stamp the rates on the persisted Trn.
+     */
+    fun setRates(
+        portfolio: Portfolio,
+        trn: Trn
+    ) {
+        if (!needsRates(trn)) return
+        val fxRequest = getFxRequest(portfolio, trn)
+        val (data) = fxClientService.getRates(fxRequest)
+        // Resolve all three rates into locals first. If the provider returns an
+        // incomplete response, throw before touching the managed entity so the
+        // Trn is not left partially mutated in the JPA persistence context.
+        val pf = resolveRate(fxRequest.tradePf, trn.tradePortfolioRate, data)
+        val base = resolveRate(fxRequest.tradeBase, trn.tradeBaseRate, data)
+        val cash = resolveRate(fxRequest.tradeCash, trn.tradeCashRate, data)
+        trn.tradePortfolioRate = pf
+        trn.tradeBaseRate = base
+        trn.tradeCashRate = cash
+    }
+
+    private fun resolveRate(
+        pair: IsoCurrencyPair?,
+        current: BigDecimal,
+        data: FxPairResults
+    ): BigDecimal {
+        if (pair != null && numberUtils.isUnset(current)) {
+            return data.rates[pair]?.rate
+                ?: throw IllegalStateException("FX rate missing for $pair")
+        }
+        return if (numberUtils.isUnset(current)) BigDecimal.ONE else current
+    }
+
+    fun needsRates(trn: Trn): Boolean =
+        (
+            numberUtils.isUnset(trn.tradePortfolioRate) ||
+                numberUtils.isUnset(trn.tradeBaseRate) ||
+                numberUtils.isUnset(trn.tradeCashRate)
+        ) &&
+            trn.trnType != TrnType.SPLIT &&
+            !trn.tradeDate.isAfter(dateUtils.date)
+
+    private fun getFxRequest(
+        portfolio: Portfolio,
+        trn: Trn
+    ): FxRequest {
+        val tradeDate = trn.tradeDate.toString()
+        val fxRequest = FxRequest(tradeDate, mutableSetOf())
+        fxRequest.addTradePf(pair(trn.tradeCurrency, portfolio.currency, trn.tradePortfolioRate))
+        fxRequest.addTradeBase(pair(trn.tradeCurrency, portfolio.base, trn.tradeBaseRate))
+        trn.cashCurrency?.let { cash ->
+            fxRequest.addTradeCash(pair(trn.tradeCurrency, cash, trn.tradeCashRate))
+        }
+        return fxRequest
     }
 }

--- a/jar-client/src/test/kotlin/com/beancounter/client/TestFxTransactions.kt
+++ b/jar-client/src/test/kotlin/com/beancounter/client/TestFxTransactions.kt
@@ -10,6 +10,7 @@ import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.FxRate
 import com.beancounter.common.model.IsoCurrencyPair
+import com.beancounter.common.utils.DateUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -80,6 +81,44 @@ class TestFxTransactions {
                 "tradePortfolioRate",
                 BigDecimal.ONE
             )
+    }
+
+    @Test
+    fun `needsRates is false when tradeDate is in the future`() {
+        // Corporate-event TRNs (DIVI) are created with tradeDate = payDate, which can be
+        // up to ~18 days in the future. FX providers (Frankfurter, ECB) reject forward
+        // dates — calling them logs "Both FX providers failed". Defer FX resolution to
+        // auto-settle when the date actually arrives. (Sentry DATA-51)
+        val fxTransactions =
+            FxTransactions(
+                Mockito.mock(FxService::class.java)
+            )
+        val tomorrow = DateUtils().date.plusDays(1)
+        val trnInput =
+            TrnInput(
+                CallerRef(),
+                "ABC",
+                tradeCurrency = "NZD",
+                tradeDate = tomorrow
+            )
+        assertThat(fxTransactions.needsRates(trnInput)).isFalse()
+    }
+
+    @Test
+    fun `needsRates is true when tradeDate is today and rates are unset`() {
+        val fxTransactions =
+            FxTransactions(
+                Mockito.mock(FxService::class.java)
+            )
+        val today = DateUtils().date
+        val trnInput =
+            TrnInput(
+                CallerRef(),
+                "ABC",
+                tradeCurrency = "NZD",
+                tradeDate = today
+            )
+        assertThat(fxTransactions.needsRates(trnInput)).isTrue()
     }
 
     @Test

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
@@ -24,7 +25,8 @@ import org.springframework.stereotype.Service
 class AutoSettleService(
     private val trnRepository: TrnRepository,
     private val dateUtils: DateUtils,
-    private val userPreferencesService: UserPreferencesService
+    private val userPreferencesService: UserPreferencesService,
+    private val fxTransactions: FxTransactions
 ) {
     private val log = LoggerFactory.getLogger(AutoSettleService::class.java)
 
@@ -71,6 +73,19 @@ class AutoSettleService(
                     "Skipping auto-settle for {} — owner {} has autoSettle disabled",
                     trn.id,
                     owner.id
+                )
+                continue
+            }
+            // Resolve FX rates now that tradeDate has arrived. Ingest of PROPOSED
+            // event trns defers FX (forward payDate; providers reject future dates).
+            try {
+                fxTransactions.setRates(trn.portfolio, trn)
+            } catch (ex: RuntimeException) {
+                log.warn(
+                    "FX resolution failed for {} on {} — leaving PROPOSED for retry: {}",
+                    trn.id,
+                    trn.tradeDate,
+                    ex.message
                 )
                 continue
             }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.contracts.TrnDeleteResponse
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.contracts.TrnResponse
@@ -12,6 +13,7 @@ import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.ShareStatus
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.cash.CashAutoSettleService
@@ -41,7 +43,9 @@ class TrnService(
     private val systemUserService: SystemUserService,
     private val cacheInvalidationProducer: CacheInvalidationProducer,
     private val portfolioShareRepository: PortfolioShareRepository,
-    private val cashAutoSettleService: CashAutoSettleService
+    private val cashAutoSettleService: CashAutoSettleService,
+    private val fxTransactions: FxTransactions,
+    private val dateUtils: DateUtils
 ) {
     private val log = LoggerFactory.getLogger(TrnService::class.java)
 
@@ -251,6 +255,27 @@ class TrnService(
             if (trnOptional.isPresent) {
                 val trn = trnOptional.get()
                 if (trn.status == TrnStatus.PROPOSED) {
+                    if (trn.tradeDate.isAfter(dateUtils.date)) {
+                        log.warn(
+                            "Cannot settle transaction {} - tradeDate {} is in the future",
+                            trnId,
+                            trn.tradeDate
+                        )
+                        continue
+                    }
+                    // Resolve FX rates now that user has confirmed settlement.
+                    // Ingest of forward-dated event trns (DIVI payDate) defers FX.
+                    try {
+                        fxTransactions.setRates(portfolio, trn)
+                    } catch (ex: RuntimeException) {
+                        log.warn(
+                            "FX resolution failed for {} on {} — leaving PROPOSED: {}",
+                            trnId,
+                            trn.tradeDate,
+                            ex.message
+                        )
+                        continue
+                    }
                     trn.status = TrnStatus.SETTLED
                     val saved = trnRepository.save(trn)
                     settled.add(saved)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
@@ -32,6 +33,7 @@ class AutoSettleServiceTest {
     private lateinit var autoSettleService: AutoSettleService
     private lateinit var dateUtils: DateUtils
     private lateinit var userPreferencesService: UserPreferencesService
+    private lateinit var fxTransactions: FxTransactions
     private val today = LocalDate.now()
 
     private val testOwner = SystemUser("test-user", "test@example.com")
@@ -54,6 +56,7 @@ class AutoSettleServiceTest {
         trnRepository = mock(TrnRepository::class.java)
         dateUtils = mock(DateUtils::class.java)
         userPreferencesService = mock(UserPreferencesService::class.java)
+        fxTransactions = mock(FxTransactions::class.java)
         `when`(dateUtils.date).thenReturn(today)
         // Default: every owner opted in.
         `when`(userPreferencesService.getOrCreate(kAny<SystemUser>()))
@@ -61,7 +64,7 @@ class AutoSettleServiceTest {
                 UserPreferences(owner = invocation.getArgument(0))
             }
         autoSettleService =
-            AutoSettleService(trnRepository, dateUtils, userPreferencesService)
+            AutoSettleService(trnRepository, dateUtils, userPreferencesService, fxTransactions)
     }
 
     @Test
@@ -159,6 +162,48 @@ class AutoSettleServiceTest {
         assertThat(result).isEqualTo(0)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.PROPOSED)
         verify(trnRepository, never()).save(any(Trn::class.java))
+    }
+
+    @Test
+    fun `should resolve FX rates before flipping status to SETTLED`() {
+        // Given: A PROPOSED dividend with tradeDate = today and unset FX rates
+        // (rates were skipped at ingest because tradeDate was a future pay date)
+        val proposedTrn = createProposedTransaction("trn-1", today, TrnType.DIVI)
+        proposedTrn.tradeBaseRate = BigDecimal.ZERO
+        proposedTrn.tradePortfolioRate = BigDecimal.ZERO
+        proposedTrn.tradeCashRate = BigDecimal.ZERO
+        `when`(trnRepository.findDueEventTransactions(TrnStatus.PROPOSED, EVENT_TYPES, today))
+            .thenReturn(listOf(proposedTrn))
+
+        // When: Auto-settle is triggered
+        autoSettleService.autoSettleDueTransactions()
+
+        // Then: FxTransactions.setRates was called with the trn's portfolio + the trn,
+        // and the status flip happened after.
+        val inOrder = org.mockito.Mockito.inOrder(fxTransactions, trnRepository)
+        inOrder.verify(fxTransactions).setRates(testPortfolio, proposedTrn)
+        inOrder.verify(trnRepository).save(proposedTrn)
+        assertThat(proposedTrn.status).isEqualTo(TrnStatus.SETTLED)
+    }
+
+    @Test
+    fun `FX failure on one trn does not stop the batch`() {
+        // Given: two due DIVI trns. The first one's FX resolution throws; the second succeeds.
+        val failing = createProposedTransaction("trn-fail", today, TrnType.DIVI)
+        val succeeding = createProposedTransaction("trn-ok", today, TrnType.DIVI)
+        `when`(trnRepository.findDueEventTransactions(TrnStatus.PROPOSED, EVENT_TYPES, today))
+            .thenReturn(listOf(failing, succeeding))
+        `when`(fxTransactions.setRates(testPortfolio, failing))
+            .thenThrow(IllegalStateException("FX rate missing for USD/EUR"))
+
+        val result = autoSettleService.autoSettleDueTransactions()
+
+        // Then: failing trn stays PROPOSED and is never saved; the other one settles.
+        assertThat(result).isEqualTo(1)
+        assertThat(failing.status).isEqualTo(TrnStatus.PROPOSED)
+        assertThat(succeeding.status).isEqualTo(TrnStatus.SETTLED)
+        verify(trnRepository, never()).save(failing)
+        verify(trnRepository).save(succeeding)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/PositionMoveServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/PositionMoveServiceTest.kt
@@ -4,6 +4,7 @@ import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.contracts.PositionMoveRequest
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.Portfolio
@@ -328,7 +329,7 @@ class PositionMoveServiceTest {
             )
         )
 
-        verify(fxTransactions).setRates(eq(nzdTargetPortfolio), any())
+        verify(fxTransactions).setRates(eq(nzdTargetPortfolio), any<TrnInput>())
         assertThat(trn.portfolio).isEqualTo(nzdTargetPortfolio)
     }
 
@@ -346,7 +347,7 @@ class PositionMoveServiceTest {
             )
         )
 
-        verify(fxTransactions, never()).setRates(any(), any())
+        verify(fxTransactions, never()).setRates(any(), any<TrnInput>())
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -1,0 +1,131 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
+import com.beancounter.marketdata.cash.CashAutoSettleService
+import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
+import com.beancounter.marketdata.registration.SystemUserService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+/**
+ * Focused unit tests for TrnService.settleTransactions covering settlement preconditions
+ * (forward-dated trns must not flip to SETTLED) and FX deferral on settle.
+ */
+class TrnSettleTest {
+    private lateinit var trnRepository: TrnRepository
+    private lateinit var portfolioService: PortfolioService
+    private lateinit var fxTransactions: FxTransactions
+    private lateinit var trnMigrator: TrnMigrator
+    private lateinit var cacheInvalidationProducer: CacheInvalidationProducer
+    private lateinit var systemUserService: SystemUserService
+    private lateinit var trnService: TrnService
+    private lateinit var dateUtils: DateUtils
+
+    private val today: LocalDate = LocalDate.of(2026, 6, 6)
+
+    private val owner = SystemUser("test-user", "test@example.com")
+    private val portfolio =
+        Portfolio(
+            id = "pf-1",
+            code = "TEST",
+            name = "Test Portfolio",
+            currency = USD,
+            base = USD,
+            owner = owner
+        )
+
+    @BeforeEach
+    fun setUp() {
+        trnRepository = mock()
+        portfolioService = mock()
+        fxTransactions = mock()
+        trnMigrator = mock()
+        cacheInvalidationProducer = mock()
+        systemUserService = mock()
+        dateUtils = mock()
+        whenever(dateUtils.date).thenReturn(today)
+        whenever(portfolioService.find("pf-1")).thenReturn(portfolio)
+        whenever(trnMigrator.upgrade(any())).thenAnswer { it.arguments[0] as Trn }
+        whenever(systemUserService.getOrThrow()).thenReturn(owner)
+        trnService =
+            TrnService(
+                trnRepository = trnRepository,
+                trnInputMapper = mock(),
+                portfolioService = portfolioService,
+                trnMigrator = trnMigrator,
+                assetFinder = mock<AssetFinder>(),
+                systemUserService = systemUserService,
+                cacheInvalidationProducer = cacheInvalidationProducer,
+                portfolioShareRepository = mock<PortfolioShareRepository>(),
+                cashAutoSettleService = mock<CashAutoSettleService>(),
+                fxTransactions = fxTransactions,
+                dateUtils = dateUtils
+            )
+    }
+
+    @Test
+    fun `refuses to settle a trn whose tradeDate is in the future`() {
+        val forwardTrn = proposed("trn-future", today.plusDays(5))
+        whenever(trnRepository.findByPortfolioIdAndId(portfolio.id, "trn-future"))
+            .thenReturn(Optional.of(forwardTrn))
+
+        val result = trnService.settleTransactions("pf-1", listOf("trn-future"))
+
+        assertThat(result).isEmpty()
+        assertThat(forwardTrn.status).isEqualTo(TrnStatus.PROPOSED)
+        verify(trnRepository, never()).save(forwardTrn)
+        verify(fxTransactions, never()).setRates(any(), any<Trn>())
+    }
+
+    @Test
+    fun `settles a trn whose tradeDate is today and resolves FX`() {
+        val dueTrn = proposed("trn-today", today)
+        whenever(trnRepository.findByPortfolioIdAndId(portfolio.id, "trn-today"))
+            .thenReturn(Optional.of(dueTrn))
+        whenever(trnRepository.save(dueTrn)).thenReturn(dueTrn)
+
+        val result = trnService.settleTransactions("pf-1", listOf("trn-today"))
+
+        assertThat(result).hasSize(1)
+        assertThat(dueTrn.status).isEqualTo(TrnStatus.SETTLED)
+        verify(fxTransactions).setRates(portfolio, dueTrn)
+        verify(trnRepository).save(dueTrn)
+    }
+
+    private fun proposed(
+        id: String,
+        tradeDate: LocalDate
+    ): Trn =
+        Trn(
+            id = id,
+            portfolio = portfolio,
+            asset = MSFT,
+            trnType = TrnType.DIVI,
+            tradeDate = tradeDate,
+            quantity = BigDecimal("100"),
+            price = BigDecimal("0.50"),
+            tradeAmount = BigDecimal("50.00"),
+            tradeCurrency = USD,
+            status = TrnStatus.PROPOSED
+        )
+}


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- Sentry DATA-51: `Both FX providers failed for date <future>` — corporate-event DIVI ingested with `tradeDate = payDate` (recordDate + 18d). Frankfurter / ECB reject forward dates.
- `FxTransactions.needsRates` now short-circuits when `tradeDate > today`. PROPOSED rows are stored with rates unset and resolved later.
- `AutoSettleService` and `TrnService.settleTransactions` call `fxTransactions.setRates(portfolio, trn)` before flipping to SETTLED. Resolution is atomic (rates computed into locals, then assigned) so a partial provider response can't leave the JPA entity dirty.
- Manual settle (`POST /portfolio/{id}/settle`) refuses forward-dated trns (skip + warn) so users can't settle trades that haven't occurred yet.

## Test plan

- [x] `./gradlew testSmart` — all green.
- [x] `./gradlew formatKotlin && ./gradlew lintKotlin` — clean.
- [x] CodeRabbit CLI review on branch — 0 findings.
- [x] Semgrep scan on modified files — 0 findings.

Closes DATA-51.