### PR TITLE
feat(svc-data): admin DELETE /assets/admin/{id} guarded by transaction refs

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
@@ -499,6 +499,42 @@ class AssetController(
         @RequestBody assetInput: AssetInput
     ): AssetResponse = AssetResponse(ownedAssetService.updateOwnedAsset(assetId, assetInput))
 
+    @DeleteMapping(
+        value = ["/admin/{assetId}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @PreAuthorize("hasAuthority('${AuthConstants.SCOPE_ADMIN}')")
+    @Operation(
+        summary = "Admin: delete any asset that is not held in any transaction",
+        description = """
+            Admin-only deletion of an arbitrary asset (public-market or
+            user-owned). The asset must not be referenced by any transaction
+            (neither as the trade asset nor as a cash settlement asset). Use
+            for reseeding a stale market asset whose code or market mapping
+            has been corrected upstream and needs re-resolution via the
+            normal lookup flow.
+
+            Cascades the remaining dependents (market data, classifications,
+            exposures, holdings, broker settlement accounts, private asset
+            config) before deleting the asset itself.
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Asset deleted successfully"),
+            ApiResponse(
+                responseCode = "400",
+                description = "Asset is referenced by one or more transactions"
+            ),
+            ApiResponse(responseCode = "403", description = "Caller lacks the admin role"),
+            ApiResponse(responseCode = "404", description = "Asset not found")
+        ]
+    )
+    fun deleteAnyAsset(
+        @Parameter(description = "Asset ID to delete", example = "abc123")
+        @PathVariable assetId: String
+    ) = assetService.deleteAsset(assetId)
+
     @PatchMapping(
         value = ["/admin/{assetId}"],
         produces = [MediaType.APPLICATION_JSON_VALUE]

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -13,6 +13,7 @@ import com.beancounter.common.model.Status
 import com.beancounter.common.utils.KeyGenUtils
 import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.MarketDataService
+import com.beancounter.marketdata.trn.TrnRepository
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Import
@@ -39,6 +40,8 @@ class AssetService(
     private val assetFinder: AssetFinder,
     private val assetCategoryConfig: AssetCategoryConfig,
     private val accountingTypeService: AccountingTypeService,
+    private val trnRepository: TrnRepository,
+    private val assetCascadeDeleter: AssetCascadeDeleter,
     transactionManager: PlatformTransactionManager
 ) : Assets {
     // New transaction template for recovery lookups after constraint violations
@@ -249,6 +252,41 @@ class AssetService(
         // saveAndFlush — AssetEntityListener (@PostUpdate) needs an immediate
         // flush to rehydrate transient fields on the managed instance.
         return assetRepository.saveAndFlush(asset)
+    }
+
+    /**
+     * Admin-only delete of an arbitrary asset (public-market or user-owned).
+     *
+     * Refuses to delete when the asset is still referenced by any transaction
+     * (either as the trade asset or the cash settlement asset). The caller is
+     * expected to confirm the asset isn't held in any portfolio before
+     * issuing the request — this guard is the server-side enforcement of
+     * that invariant.
+     *
+     * Cascades deletion of remaining dependents (market data, classifications,
+     * exposures, holdings, broker settlement accounts, private asset config).
+     *
+     * @throws NotFoundException if asset not found
+     * @throws BusinessException if asset is referenced by transactions
+     */
+    fun deleteAsset(assetId: String) {
+        val asset =
+            assetRepository.findById(assetId).orElseThrow {
+                NotFoundException("Asset not found: $assetId")
+            }
+        if (trnRepository.existsByAssetId(assetId)) {
+            throw BusinessException(
+                "Cannot delete asset $assetId — held in one or more transactions"
+            )
+        }
+        if (trnRepository.existsByCashAssetId(assetId)) {
+            throw BusinessException(
+                "Cannot delete asset $assetId — referenced as cash settlement on transactions"
+            )
+        }
+        assetCascadeDeleter.deleteDependents(assetId)
+        assetRepository.delete(asset)
+        log.info("Admin deleted asset {} ({}.{})", assetId, asset.market.code, asset.code)
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -285,7 +285,28 @@ class AssetService(
             )
         }
         assetCascadeDeleter.deleteDependents(assetId)
-        assetRepository.delete(asset)
+        // Force the delete to flush inside this try block so any FK race —
+        // a parallel writer adding a referencing row between the
+        // existsBy* checks above and the actual delete — surfaces here as
+        // DataIntegrityViolationException instead of leaking up at
+        // transaction commit time. Translate to BusinessException so the
+        // caller gets a 400 with the same "held in transactions" message
+        // they'd see from the pre-flight guard.
+        try {
+            assetRepository.delete(asset)
+            assetRepository.flush()
+        } catch (e: DataIntegrityViolationException) {
+            log.warn(
+                "FK race deleting asset {} ({}.{}): {}",
+                assetId,
+                asset.market.code,
+                asset.code,
+                e.mostSpecificCause.message
+            )
+            throw BusinessException(
+                "Cannot delete asset $assetId — held in one or more transactions"
+            )
+        }
         log.info("Admin deleted asset {} ({}.{})", assetId, asset.market.code, asset.code)
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -49,6 +49,20 @@ interface TrnRepository :
 
     fun deleteByAssetId(assetId: String): Long
 
+    /**
+     * True if any transaction holds the asset as its trade asset.
+     * Used by admin asset-delete to refuse deletion when the asset is
+     * referenced by trades.
+     */
+    fun existsByAssetId(assetId: String): Boolean
+
+    /**
+     * True if any transaction uses the asset as its cash settlement asset.
+     * Cash-asset references survive `deleteByAssetId` (they reference a
+     * different column) and must be checked separately before delete.
+     */
+    fun existsByCashAssetId(assetId: String): Boolean
+
     @Modifying
     @Query("UPDATE Trn t SET t.cashAsset = null WHERE t.cashAsset.id = :assetId")
     fun clearCashAssetReferences(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
@@ -39,6 +39,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.math.BigDecimal
 
+private const val ADMIN_ASSET_PATH = "$ASSET_ROOT/admin/{assetId}"
+
 /**
  * Verifies the admin DELETE /assets/admin/{assetId} endpoint introduced for
  * the Asset Lookup "delete + reload" flow on bc-view. The endpoint refuses
@@ -103,7 +105,7 @@ internal class AdminAssetDeleteTest {
         mockMvc
             .perform(
                 MockMvcRequestBuilders
-                    .delete("$ASSET_ROOT/admin/{assetId}", assetId)
+                    .delete(ADMIN_ASSET_PATH, assetId)
                     .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
                     .with(csrf())
             ).andExpect(status().isOk)
@@ -143,7 +145,7 @@ internal class AdminAssetDeleteTest {
         mockMvc
             .perform(
                 MockMvcRequestBuilders
-                    .delete("$ASSET_ROOT/admin/{assetId}", assetId)
+                    .delete(ADMIN_ASSET_PATH, assetId)
                     .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
                     .with(csrf())
             ).andExpect(status().isBadRequest)
@@ -162,7 +164,7 @@ internal class AdminAssetDeleteTest {
         mockMvc
             .perform(
                 MockMvcRequestBuilders
-                    .delete("$ASSET_ROOT/admin/{assetId}", "any-id")
+                    .delete(ADMIN_ASSET_PATH, "any-id")
                     .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(noRoles))
                     .with(csrf())
             ).andExpect(status().isForbidden)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
@@ -1,0 +1,170 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.contracts.AssetUpdateResponse
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.AssetKeyUtils.Companion.toKey
+import com.beancounter.common.utils.AssetUtils.Companion.getAssetInput
+import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
+import com.beancounter.common.utils.BcJson.Companion.objectMapper
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.utils.ASSET_ROOT
+import com.beancounter.marketdata.utils.BcMvcHelper
+import com.beancounter.marketdata.utils.RegistrationUtils.registerUser
+import com.beancounter.marketdata.utils.TRADE_DATE
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+
+/**
+ * Verifies the admin DELETE /assets/admin/{assetId} endpoint introduced for
+ * the Asset Lookup "delete + reload" flow on bc-view. The endpoint refuses
+ * to delete an asset that is still referenced by any transaction (either as
+ * the trade asset or as cash settlement) and requires SCOPE_ADMIN.
+ */
+@SpringMvcDbTest
+internal class AdminAssetDeleteTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean
+    private lateinit var fxTransactions: FxTransactions
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @Autowired
+    private lateinit var dateUtils: DateUtils
+
+    private lateinit var adminHelper: BcMvcHelper
+
+    @BeforeEach
+    fun setup() {
+        val token =
+            registerUser(
+                mockMvc,
+                mockAuthConfig.getUserToken(
+                    SystemUser(id = "adminAssetDelete", email = "admin@assetdelete.test", auth0 = "adminAssetDelete")
+                )
+            )
+        adminHelper = BcMvcHelper(mockMvc, token)
+    }
+
+    private fun createPublicAsset(code: String): String {
+        val asset = getTestAsset(market = NASDAQ, code = code)
+        val createMap = mapOf(toKey(asset) to getAssetInput(NASDAQ.code, asset.code))
+        val mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post(ASSET_ROOT)
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(AssetRequest(createMap)))
+                        .contentType(APPLICATION_JSON)
+                ).andExpect(status().isOk)
+                .andReturn()
+        return objectMapper
+            .readValue<AssetUpdateResponse>(mvcResult.response.contentAsString)
+            .data[toKey(asset)]!!
+            .id
+    }
+
+    @Test
+    fun `admin can delete asset not held in any transaction`() {
+        val assetId = createPublicAsset("ADMINDEL.A")
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .delete("$ASSET_ROOT/admin/{assetId}", assetId)
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
+                    .with(csrf())
+            ).andExpect(status().isOk)
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("$ASSET_ROOT/{assetId}", assetId)
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `admin cannot delete asset that is held in a transaction`() {
+        val assetId = createPublicAsset("ADMINDEL.HELD")
+        val portfolio =
+            adminHelper.portfolio(
+                PortfolioInput("ADMDEL", "ADMDEL", currency = Constants.NZD.code)
+            )
+        adminHelper.postTrn(
+            TrnRequest(
+                portfolio.id,
+                listOf(
+                    TrnInput(
+                        CallerRef(batch = "0", callerId = "held-1"),
+                        assetId,
+                        trnType = TrnType.BUY,
+                        quantity = BigDecimal.TEN,
+                        tradeDate = dateUtils.getFormattedDate(TRADE_DATE),
+                        price = BigDecimal.TEN,
+                        status = TrnStatus.SETTLED
+                    )
+                )
+            )
+        )
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .delete("$ASSET_ROOT/admin/{assetId}", assetId)
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
+                    .with(csrf())
+            ).andExpect(status().isBadRequest)
+            .andExpect(
+                jsonPath("$.detail").value(org.hamcrest.Matchers.containsString("held in one or more transactions"))
+            )
+    }
+
+    @Test
+    fun `non-admin cannot delete via admin endpoint`() {
+        val noRoles =
+            mockAuthConfig.tokenUtils.getNoRolesToken(
+                SystemUser(email = "noroles@assetdelete.test")
+            )
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .delete("$ASSET_ROOT/admin/{assetId}", "any-id")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(noRoles))
+                    .with(csrf())
+            ).andExpect(status().isForbidden)
+    }
+}


### PR DESCRIPTION
## Summary
- New admin-scoped delete for any asset, guarded server-side: refuses (400) when the asset is referenced by any transaction (trade asset OR cash settlement asset). Cascades remaining dependents (market_data, classifications, exposures, holdings, broker settlement accounts, private_asset_config) on success.
- Backs the new Delete button on bc-view's Asset Lookup page so an admin can clear stale market assets before re-resolving them.

## Test plan
- [x] `admin can delete asset not held in any transaction` — full happy path, asset returned 404 after delete
- [x] `admin cannot delete asset that is held in a transaction` — 400 with explanatory `detail`
- [x] `non-admin cannot delete via admin endpoint` — 403 from `@PreAuthorize`
- [x] `./gradlew :svc-data:test` green, `formatKotlin` + `lintKotlin` clean
- [ ] Verify on kauri after deploy: admin can delete then reload an asset whose code/market mapping changed upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can delete assets via a dedicated admin endpoint.
* **Behavior / Safety**
  * Deletion is blocked when an asset is referenced by existing transactions; a clear error is returned.
  * Non-admin users cannot access the admin deletion endpoint.
* **Tests**
  * Integration tests added for successful admin deletion, rejection when referenced, and non-admin denial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->