### PR TITLE
fix(svc-data): admin asset DELETE returns 204 instead of empty 200

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetController.kt
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
@@ -499,10 +501,8 @@ class AssetController(
         @RequestBody assetInput: AssetInput
     ): AssetResponse = AssetResponse(ownedAssetService.updateOwnedAsset(assetId, assetInput))
 
-    @DeleteMapping(
-        value = ["/admin/{assetId}"],
-        produces = [MediaType.APPLICATION_JSON_VALUE]
-    )
+    @DeleteMapping(value = ["/admin/{assetId}"])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAuthority('${AuthConstants.SCOPE_ADMIN}')")
     @Operation(
         summary = "Admin: delete any asset that is not held in any transaction",
@@ -521,7 +521,7 @@ class AssetController(
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Asset deleted successfully"),
+            ApiResponse(responseCode = "204", description = "Asset deleted successfully"),
             ApiResponse(
                 responseCode = "400",
                 description = "Asset is referenced by one or more transactions"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AdminAssetDeleteTest.kt
@@ -108,7 +108,7 @@ internal class AdminAssetDeleteTest {
                     .delete(ADMIN_ASSET_PATH, assetId)
                     .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(adminHelper.token))
                     .with(csrf())
-            ).andExpect(status().isOk)
+            ).andExpect(status().isNoContent)
 
         mockMvc
             .perform(


### PR DESCRIPTION
## Summary
Follow-up to #920. The new admin asset DELETE returned HTTP 200 with an empty body (Kotlin `Unit`), which broke bc-view's proxy: `handleResponse` calls `response.json()` for any non-204 success and threw "Unexpected end of JSON input" on a successful delete (reproduced on kauri).

Annotate the controller with `@ResponseStatus(HttpStatus.NO_CONTENT)` so the response is 204 — matches the existing pattern on `PrivateAssetConfigController.deleteConfig`. bc-view's `handleResponse` short-circuits on 204 with `res.status(204).end()`.

## Test plan
- [x] `AdminAssetDeleteTest` happy path now asserts `status().isNoContent`; full svc-data suite green
- [x] `formatKotlin` + `lintKotlin` clean
- [ ] Verify on kauri: admin delete completes without "Unexpected end of JSON input"; the deleted asset re-resolves cleanly via lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only endpoint to delete assets. Includes role-based authorization controls with HTTP 204 on success and proper error handling for asset references, insufficient permissions, and missing assets.

* **Tests**
  * Updated asset deletion tests to verify correct HTTP status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->