### PR TITLE
feat(trns): bound proposed review by asAt date (default today)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -564,8 +564,13 @@ class TrnController(
         ]
     )
     fun findProposed(
-        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope
-    ): TrnResponse = TrnResponse(trnService.findProposedForUser(scope))
+        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope,
+        @Parameter(description = "Show proposed transactions due on or before this date (default today)")
+        @RequestParam(value = "asAt", required = false) asAt: String?
+    ): TrnResponse =
+        TrnResponse(
+            trnService.findProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today()))
+        )
 
     @GetMapping(
         value = ["/proposed/count"],
@@ -591,8 +596,11 @@ class TrnController(
         ]
     )
     fun countProposed(
-        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope
-    ): Map<String, Long> = mapOf("count" to trnService.countProposedForUser(scope))
+        @RequestParam(value = "scope", required = false, defaultValue = "ALL") scope: ProposedScope,
+        @Parameter(description = "Count proposed transactions due on or before this date (default today)")
+        @RequestParam(value = "asAt", required = false) asAt: String?
+    ): Map<String, Long> =
+        mapOf("count" to trnService.countProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today())))
 
     @GetMapping(
         value = ["/settled"],

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -192,8 +192,10 @@ interface TrnRepository :
     ): Collection<Trn>
 
     /**
-     * Find all transactions with a specific status for portfolios owned by the given user.
-     * Used for cross-portfolio proposed transaction views.
+     * Find transactions with a specific status for portfolios owned by the given user, bounded to
+     * those whose tradeDate is on or before [asAt]. Used for the cross-portfolio proposed-review
+     * view — `asAt` defaults to today at the controller, so not-yet-due (future-dated) proposed
+     * transactions stay hidden until their date arrives.
      */
     @Query(
         "select t from Trn t " +
@@ -204,24 +206,29 @@ interface TrnRepository :
             "left join fetch t.cashCurrency " +
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
+            "and t.tradeDate <= ?3 " +
             "order by t.tradeDate desc"
     )
     fun findByStatusAndPortfolioOwner(
         status: TrnStatus,
-        owner: SystemUser
+        owner: SystemUser,
+        asAt: LocalDate
     ): Collection<Trn>
 
     /**
-     * Count all transactions with a specific status for portfolios owned by the given user.
+     * Count transactions with a specific status for portfolios owned by the given user, bounded to
+     * those whose tradeDate is on or before [asAt].
      */
     @Query(
         "select count(t) from Trn t " +
             "where t.status = ?1 " +
-            "and t.portfolio.owner = ?2"
+            "and t.portfolio.owner = ?2 " +
+            "and t.tradeDate <= ?3"
     )
     fun countByStatusAndPortfolioOwner(
         status: TrnStatus,
-        owner: SystemUser
+        owner: SystemUser,
+        asAt: LocalDate
     ): Long
 
     @Query(
@@ -233,21 +240,25 @@ interface TrnRepository :
             "left join fetch t.cashCurrency " +
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
+            "and t.tradeDate <= ?3 " +
             "order by t.tradeDate desc"
     )
     fun findByStatusAndPortfolioIdIn(
         status: TrnStatus,
-        portfolioIds: Collection<String>
+        portfolioIds: Collection<String>,
+        asAt: LocalDate
     ): Collection<Trn>
 
     @Query(
         "select count(t) from Trn t " +
             "where t.status = ?1 " +
-            "and t.portfolio.id in ?2"
+            "and t.portfolio.id in ?2 " +
+            "and t.tradeDate <= ?3"
     )
     fun countByStatusAndPortfolioIdIn(
         status: TrnStatus,
-        portfolioIds: Collection<String>
+        portfolioIds: Collection<String>,
+        asAt: LocalDate
     ): Long
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -154,19 +154,25 @@ class TrnService(
     }
 
     /**
-     * Find PROPOSED transactions for the current user.
+     * Find PROPOSED transactions for the current user, bounded to those due on or before [asAt]
+     * (defaults to today). Future-dated proposed transactions — e.g. dividends with a forward pay
+     * date — are excluded until [asAt] reaches their tradeDate, so the review list only shows
+     * actionable rows. Widen [asAt] to preview upcoming proposed transactions.
      *
      * - OWNED: portfolios where current user is the owner (default historical behaviour).
      * - MANAGED: portfolios shared with the current user via an ACTIVE PortfolioShare.
      * - ALL: union of both.
      */
-    fun findProposedForUser(scope: ProposedScope = ProposedScope.ALL): Collection<Trn> {
+    fun findProposedForUser(
+        scope: ProposedScope = ProposedScope.ALL,
+        asAt: LocalDate = dateUtils.date
+    ): Collection<Trn> {
         val user = systemUserService.getOrThrow()
         val results = mutableMapOf<String, Trn>()
 
         if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
             trnRepository
-                .findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
+                .findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
                 .forEach { results[it.id] = it }
         }
 
@@ -174,34 +180,38 @@ class TrnService(
             val managedPortfolioIds = managedPortfolioIdsFor(user)
             if (managedPortfolioIds.isNotEmpty()) {
                 trnRepository
-                    .findByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds)
+                    .findByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
                     .forEach { results[it.id] = it }
             }
         }
 
-        log.trace("proposed trns: ${results.size} (scope=$scope)")
+        log.trace("proposed trns: ${results.size} (scope=$scope, asAt=$asAt)")
         return postProcess(results.values.toList())
     }
 
     /**
-     * Count PROPOSED transactions for the current user under the given scope.
+     * Count PROPOSED transactions for the current user under the given scope, bounded to those due
+     * on or before [asAt] (defaults to today) so the badge tracks the same set as the review list.
      */
-    fun countProposedForUser(scope: ProposedScope = ProposedScope.ALL): Long {
+    fun countProposedForUser(
+        scope: ProposedScope = ProposedScope.ALL,
+        asAt: LocalDate = dateUtils.date
+    ): Long {
         val user = systemUserService.getOrThrow()
         var count = 0L
 
         if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
-            count += trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user)
+            count += trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
         }
 
         if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
             val managedPortfolioIds = managedPortfolioIdsFor(user)
             if (managedPortfolioIds.isNotEmpty()) {
-                count += trnRepository.countByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds)
+                count += trnRepository.countByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
             }
         }
 
-        log.trace("proposed count: $count (scope=$scope)")
+        log.trace("proposed count: $count (scope=$scope, asAt=$asAt)")
         return count
     }
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
@@ -339,6 +339,71 @@ class ProposedTransactionsTest {
     }
 
     @Test
+    fun `proposed list bounds by asAt date — future-dated trns hidden by default, shown when asAt covers them`() {
+        val msft = bcMvcHelper.asset(AssetRequest(msftInput))
+        val portfolio =
+            bcMvcHelper.portfolio(
+                PortfolioInput("PROPOSED-FUTURE", "Future-dated proposed", currency = USD.code)
+            )
+        // A DIVI whose pay date (tradeDate) is in the future — not yet due for review.
+        val futureDate = dateUtils.date.plusDays(8)
+        val futureTrn =
+            TrnInput(
+                CallerRef(batch = "FUTURE-PROPOSED", callerId = "1"),
+                msft.id,
+                trnType = TrnType.DIVI,
+                quantity = BigDecimal.TEN,
+                tradeCurrency = USD.code,
+                tradeDate = futureDate,
+                price = BigDecimal("1.50"),
+                status = TrnStatus.PROPOSED
+            )
+        trnService.save(portfolio, TrnRequest(portfolio.id, listOf(futureTrn)))
+
+        // Default (asAt = today) excludes the future-dated trn.
+        val defaultTrns = proposedFor(portfolio.id, asAt = null)
+        assertThat(defaultTrns).isEmpty()
+
+        // asAt on/after the trade date includes it.
+        val futureTrns = proposedFor(portfolio.id, asAt = futureDate.toString())
+        assertThat(futureTrns).hasSize(1)
+
+        // The count badge tracks the same default-today bound.
+        val defaultCount = proposedCount(asAt = null)
+        val futureCount = proposedCount(asAt = futureDate.toString())
+        assertThat(futureCount).isGreaterThan(defaultCount)
+    }
+
+    private fun proposedFor(
+        portfolioId: String,
+        asAt: String?
+    ): List<com.beancounter.common.model.Trn> {
+        val url = "$TRNS_ROOT/proposed" + (asAt?.let { "?asAt=$it" } ?: "")
+        val body =
+            mockMvc
+                .perform(get(url).with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token)))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper
+            .readValue(body, TrnResponse::class.java)
+            .data
+            .toTrns()
+            .filter { it.portfolio.id == portfolioId }
+    }
+
+    private fun proposedCount(asAt: String?): Int {
+        val url = "$TRNS_ROOT/proposed/count" + (asAt?.let { "?asAt=$it" } ?: "")
+        val body =
+            mockMvc
+                .perform(get(url).with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token)))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body).get("count").asInt()
+    }
+
+    @Test
     fun `should not include SETTLED transactions in proposed list`() {
         // Given: A portfolio with both PROPOSED and SETTLED transactions
         val msft = bcMvcHelper.asset(AssetRequest(msftInput))


### PR DESCRIPTION
## Why

The Proposed Transactions review showed every PROPOSED row regardless of date, including future-dated dividends (e.g. pay date 14–15/06 when today is 06/06). Those rows aren't actionable — the manual-settle guard blocks settling future tradeDates — so they clutter the review with rows the user can't act on.

## What

`/trns/proposed` and `/trns/proposed/count` now accept an optional `asAt` date (defaults to today) and filter `tradeDate <= asAt`. Future-dated proposed rows stay hidden until their date arrives; widening `asAt` previews upcoming ones. Auto-settle (`tradeDate <= today`) still promotes them on their pay date — unchanged.

- `TrnRepository`: `findByStatusAndPortfolioOwner` / `…IdIn` + count variants gain `and t.tradeDate <= :asAt`.
- `TrnService.findProposedForUser` / `countProposedForUser` take `asAt: LocalDate = today`.
- `TrnController`: `asAt` query param, parsed via `dateUtils`, default today.

Backward-compatible: omitting `asAt` behaves as `today`. Existing callers/tests (which use past-dated trns) are unaffected.

bc-view counterpart (date control + param) is a separate PR.

## Tests

`ProposedTransactionsTest`: new case — a future-dated proposed trn is excluded by default and appears when `asAt` covers its date; count badge tracks the same bound. Full `:svc-data:test` green; format + lint + semgrep clean.

Local code-review skill run pre-push.

@coderabbitai ignore