### PR TITLE
feat(svc-data): add AMS (Euronext Amsterdam) market with EODHD alias

### DIFF
--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -492,6 +492,16 @@ beancounter:
           FIGI: "LN"
           eodhd: "LSE"
 
+      - code: "AMS"
+        name: "Euronext Amsterdam"
+        currencyId: "EUR"
+        timezoneId: "Europe/Amsterdam"
+        aliases:
+          FIGI: "NA"
+          # EODHD codes Euronext Amsterdam as "AS" (verified via /api/exchanges-list).
+          # Useful for cross-listed ETFs (e.g. IGSG also trades on LSE in GBX).
+          eodhd: "AS"
+
       - code: "MUTF"
         name: "Mutual Funds"
         currencyId: "GBP"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
@@ -6,6 +6,7 @@ import com.beancounter.marketdata.Constants
 import com.beancounter.marketdata.Constants.Companion.AUD
 import com.beancounter.marketdata.Constants.Companion.CAD
 import com.beancounter.marketdata.Constants.Companion.CASH_MARKET
+import com.beancounter.marketdata.Constants.Companion.EUR
 import com.beancounter.marketdata.Constants.Companion.GBP
 import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.SGD
@@ -54,6 +55,21 @@ class MarketServiceTest {
         `when`(currencyService.getCode(SGD.code)).thenReturn(SGD)
         `when`(currencyService.getCode(GBP.code)).thenReturn(GBP)
         `when`(currencyService.getCode(CAD.code)).thenReturn(CAD)
+        `when`(currencyService.getCode(EUR.code)).thenReturn(EUR)
+    }
+
+    @Test
+    fun `should resolve AMS market and its EODHD alias`() {
+        val ams = marketService.getMarket("AMS")
+        assertThat(ams)
+            .isNotNull
+            .hasFieldOrPropertyWithValue("currency.code", EUR.code)
+            .hasFieldOrPropertyWithValue("timezone", TimeZone.getTimeZone("Europe/Amsterdam"))
+        assertThat(ams.getAlias("eodhd")).isEqualTo("AS")
+        // `aliases` map preserves the YAML key casing; FIGI is read by direct
+        // lookup (see FigiProxy.kt:101). `getAlias` lowercases its input and
+        // only matches lowercase-stored keys (e.g. mstack/eodhd).
+        assertThat(ams.aliases["FIGI"]).isEqualTo("NA")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- New `AMS` market entry — EUR, Europe/Amsterdam tz. EODHD alias `AS` (verified via /api/exchanges-list), FIGI alias `NA`.
- Unlocks cross-listed European ETFs (e.g. iShares `IGSG` — Ireland-domiciled, dual-listed `IGSG.LSE` in GBX and `IGSG.AS` in EUR — useful for non-US-resident investors taking Euro exposure without GBP→EUR FX on every dividend).
- Routing onto the EODHD provider is opt-in via `BEANCOUNTER_MARKET_PROVIDERS_EODHD_MARKETS`. Paired bc-deploy change adds `AMS` to that allowlist on kauri.

## Test plan
- [x] New unit test: `getMarket("AMS")` resolves with EUR/Europe-Amsterdam and aliases `eodhd=AS` / `FIGI=NA`
- [x] Full `:svc-data:test` green, `formatKotlin` + `lintKotlin` clean
- [ ] Verify on kauri after deploy: Asset Lookup with market `AMS` + symbol `IGSG` resolves via EODHD; price history populated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the AMS (Euronext Amsterdam) exchange with EUR currency and Europe/Amsterdam timezone, including alias configurations for FIGI and EODHD identifiers to support cross-referenced listings.

* **Tests**
  * Added test coverage verifying AMS market resolution, currency configuration, timezone, and alias preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->