### PR TITLE
feat(agent): getBenchmark tool for market/sector performance context

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -27,6 +27,22 @@ object DomainSystemPrompts {
         page of the Holdsworth UI the user is currently viewing. Use it to
         infer intent — never ask "which portfolio?" when context names one.
 
+        ## Current date
+
+        Each message also carries `[Current date: YYYY-MM-DD]` — the real
+        today. Trust it over any date in your training data. Resolve every
+        relative date expression against it before calling a tool, and pass
+        concrete `YYYY-MM-DD`:
+        - "this year" / "year to date" → `<year>-01-01` … today.
+        - "last month", "past 30 days", "past 6 months", "last 12 months" →
+          subtract from today.
+        - "last year" → the prior calendar year (Jan 1 … Dec 31).
+        - "since <date>" / "since I bought it" → that date … today.
+        Use these for any tool taking a date (`getPositions(asAt)`,
+        `getFxRate(rateDate)`, `getCurrentPrice`, `loadPortfolioEvents(asAt)`,
+        `backfillPortfolioEvents(fromDate, toDate)`). Pass `today` only when the
+        user literally means now. Never invent or assume the year.
+
         ## Output
 
         - GitHub-flavored markdown.
@@ -53,7 +69,8 @@ object DomainSystemPrompts {
 
         - **Portfolios**: short user-facing codes (`TYLER`, `NZD`). Never ask
           for UUIDs.
-        - **Assets**: tickers (`AAPL`). **Dates**: `YYYY-MM-DD` or `today`.
+        - **Assets**: tickers (`AAPL`). **Dates**: `YYYY-MM-DD` or `today` —
+          resolve relative phrases against the current date (see above).
         - **Currencies**: ISO 4217. Pass `displayCurrency` to tools for FX
           conversion — never do FX arithmetic yourself.
 

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -189,6 +189,24 @@ object DomainSystemPrompts {
         `"market"`. A `{status: "no_coverage"}` means nothing live; say so
         briefly rather than inventing.
 
+        ### Benchmarking performance
+
+        `getMarketNews` explains *why* in words; `getBenchmark(scope)` quantifies
+        it. It returns today's `changePercent` for the broad indices
+        (`getBenchmark("market")` → S&P 500 / Nasdaq / Dow) or a sector
+        (`getBenchmark("technology")` → the sector proxy).
+
+        Use it whenever the user asks how a holding or the portfolio is doing
+        **versus the market**, or whether a move is **stock-specific or
+        market-wide**:
+        - Compare a holding's `changePercent` (from positions) against the
+          benchmark's. "NVDA −4.1% vs Nasdaq −2.6% — underperformed the index
+          by ~1.5pts" says more than the raw number.
+        - For a whole-portfolio view, benchmark against `"market"`; for a
+          concentrated book, also benchmark the dominant sector.
+        Same status contract as the news tools: `unknown_scope` lists valid
+        scopes; `no_coverage` means no live price — say so, don't invent.
+
         ### Closed positions
 
         Closed (zero-quantity) positions are filtered out before the tool
@@ -496,6 +514,9 @@ object DomainSystemPrompts {
         - `getCurrentPrice(market, code)` — current close, prior close,
           intraday change %. Required for grounding any forward-looking
           framing such as analyst price targets.
+        - `getBenchmark(scope)` — today's change for the broad market
+          (`"market"`) or a sector. Use it to frame the asset's own move
+          against its sector / the market.
         - `listMarkets`, `listCurrencies`, `getFxRate(from, to, date?)` —
           market metadata for context.
         - `getPortfolio(code)`, `getPositions(code)` — only if the user
@@ -513,7 +534,11 @@ object DomainSystemPrompts {
            current close so the implied growth `(target − close) / close`
            is visible. Attribute the target to the article — it is the
            analyst's claim, not BC's.
-        4. Synthesise: company + sector summary, what's happening now,
+        4. To judge whether the asset's move is its own story or just the
+           tape, call `getBenchmark("market")` (and the asset's sector when
+           known) and compare its change against the asset's — say "moved
+           with / against / ahead of the market", not just the raw number.
+        5. Synthesise: company + sector summary, what's happening now,
            recent corporate-action pattern, qualitative risk callouts.
 
         ### Output
@@ -560,6 +585,8 @@ object DomainSystemPrompts {
         - News / sentiment / "what's happening with X" → `getNews`.
         - Why the market / portfolio moved, "what happened today", macro or
           sector conditions → `getMarketNews(scope)` ('market' or a sector).
+        - Performance vs the market, "is this drop market-wide or
+          stock-specific" → `getBenchmark(scope)` for the index/sector change.
 
         Closed positions (quantity = 0) are excluded by default unless the
         user explicitly asks about historical / sold / closed holdings.

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/MarketTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/MarketTools.kt
@@ -76,6 +76,58 @@ class MarketTools(
         )
     }
 
+    @Tool(description = BENCHMARK_DESC)
+    fun getBenchmark(
+        @ToolParam(description = BENCHMARK_SCOPE_DESC) scope: String
+    ): Map<String, Any> {
+        val key = scope.trim().lowercase()
+        val proxies = if (key.isBlank() || key in MARKET_ALIASES) INDEX_PROXIES else SECTOR_PROXIES[key]
+        if (proxies == null) {
+            return mapOf(
+                "status" to "unknown_scope",
+                "scope" to scope,
+                "message" to BENCHMARK_UNKNOWN_SCOPE_MESSAGE,
+                "supportedScopes" to (listOf("market") + SECTOR_PROXIES.keys.sorted())
+            )
+        }
+        val response =
+            priceService.getPrices(
+                PriceRequest(
+                    date = "today",
+                    assets = proxies.map { PriceAsset(market = it.market, code = it.code) },
+                    currentMode = true
+                ),
+                tokenService.bearerToken
+            )
+        val byCode = response.data.associateBy { it.asset.code.uppercase() }
+        val benchmarks =
+            proxies.mapNotNull { proxy ->
+                byCode[proxy.code.uppercase()]?.let { md ->
+                    mapOf(
+                        "name" to proxy.label,
+                        "market" to md.asset.market.code,
+                        "code" to md.asset.code,
+                        "priceClose" to md.close,
+                        "previousClose" to md.previousClose,
+                        "changePercent" to md.changePercent,
+                        "priceDate" to md.priceDate.toString()
+                    )
+                }
+            }
+        return if (benchmarks.isEmpty()) {
+            mapOf("status" to "no_coverage", "scope" to scope, "message" to BENCHMARK_NO_COVERAGE_MESSAGE)
+        } else {
+            mapOf("benchmarks" to benchmarks, "count" to benchmarks.size)
+        }
+    }
+
+    /** Market/sector proxy whose price change stands in for that segment's performance. */
+    private data class BenchmarkProxy(
+        val market: String,
+        val code: String,
+        val label: String
+    )
+
     companion object {
         const val MARKETS_DESC =
             "List every market Beancounter knows about (NASDAQ, NYSE, ASX, NZX, etc.) " +
@@ -90,6 +142,51 @@ class MarketTools(
                 "call this to retrieve the current close so you can frame the implied " +
                 "growth percentage relative to today's price. Never quote a price target " +
                 "without also stating the current close."
+        const val BENCHMARK_DESC =
+            "Get current market or sector benchmark performance (today's price change of a broad " +
+                "index or a sector proxy). Use this to contextualise a portfolio's or holding's " +
+                "move against the market — e.g. when the user asks how their portfolio is doing " +
+                "'versus the market', whether a drop is stock-specific or market-wide, or how a " +
+                "sector is performing. Pair the benchmark's changePercent with a holding's " +
+                "changePercent to say whether it out- or under-performed. Returns name, close, " +
+                "previousClose and changePercent (decimal; -0.026 = -2.6%) per benchmark. NEVER " +
+                "mention the underlying data provider."
+        const val BENCHMARK_SCOPE_DESC =
+            "What to benchmark: 'market' for the broad indices (S&P 500, Nasdaq, Dow), or a sector " +
+                "name. Supported sectors: technology, financials, energy, healthcare, " +
+                "consumer_discretionary, consumer_staples, industrials, materials, utilities, " +
+                "real_estate, communication. One scope per call."
+        const val BENCHMARK_UNKNOWN_SCOPE_MESSAGE =
+            "Unrecognised scope. Use 'market' for the broad indices or one of the listed sector names."
+        const val BENCHMARK_NO_COVERAGE_MESSAGE =
+            "No benchmark price available right now for this scope."
+
+        // Broad-market index proxies (priced on the synthetic INDEX market → EODHD `.INDX`).
+        private val INDEX_PROXIES =
+            listOf(
+                BenchmarkProxy("INDEX", "GSPC", "S&P 500"),
+                BenchmarkProxy("INDEX", "IXIC", "Nasdaq Composite"),
+                BenchmarkProxy("INDEX", "DJI", "Dow Jones Industrial Average")
+            )
+
+        // Sector → SPDR sector ETF proxy (priced on the US market). Keys are the scope vocabulary
+        // in BENCHMARK_SCOPE_DESC; the ETF's daily move stands in for sector-wide performance.
+        private val SECTOR_PROXIES =
+            mapOf(
+                "technology" to listOf(BenchmarkProxy("US", "XLK", "Technology (XLK)")),
+                "financials" to listOf(BenchmarkProxy("US", "XLF", "Financials (XLF)")),
+                "energy" to listOf(BenchmarkProxy("US", "XLE", "Energy (XLE)")),
+                "healthcare" to listOf(BenchmarkProxy("US", "XLV", "Health Care (XLV)")),
+                "consumer_discretionary" to listOf(BenchmarkProxy("US", "XLY", "Consumer Discretionary (XLY)")),
+                "consumer_staples" to listOf(BenchmarkProxy("US", "XLP", "Consumer Staples (XLP)")),
+                "industrials" to listOf(BenchmarkProxy("US", "XLI", "Industrials (XLI)")),
+                "materials" to listOf(BenchmarkProxy("US", "XLB", "Materials (XLB)")),
+                "utilities" to listOf(BenchmarkProxy("US", "XLU", "Utilities (XLU)")),
+                "real_estate" to listOf(BenchmarkProxy("US", "XLRE", "Real Estate (XLRE)")),
+                "communication" to listOf(BenchmarkProxy("US", "XLC", "Communication Services (XLC)"))
+            )
+
+        private val MARKET_ALIASES = setOf("market", "markets", "macro", "broad", "overall", "index")
     }
 }
 

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/tools/MarketToolsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/tools/MarketToolsTest.kt
@@ -78,4 +78,70 @@ class MarketToolsTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("GHOST")
     }
+
+    private fun priceOf(
+        code: String,
+        market: String,
+        changePercent: String
+    ): MarketData =
+        MarketData(
+            asset = Asset(code = code, id = "$code-id", market = Market(market)),
+            priceDate = LocalDate.of(2026, 6, 7),
+            close = BigDecimal("100.00"),
+            previousClose = BigDecimal("103.00"),
+            change = BigDecimal("-3.00"),
+            changePercent = BigDecimal(changePercent)
+        )
+
+    @Test
+    fun `getBenchmark market scope returns the broad index changes`() {
+        whenever(priceService.getPrices(any(), any())).thenReturn(
+            PriceResponse(
+                listOf(
+                    priceOf("GSPC", "INDEX", "-0.0264"),
+                    priceOf("IXIC", "INDEX", "-0.0410"),
+                    priceOf("DJI", "INDEX", "-0.0180")
+                )
+            )
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val benchmarks = marketTools.getBenchmark("market")["benchmarks"] as List<Map<String, Any>>
+
+        assertThat(benchmarks).hasSize(3)
+        assertThat(benchmarks.map { it["name"] })
+            .containsExactly("S&P 500", "Nasdaq Composite", "Dow Jones Industrial Average")
+        assertThat(benchmarks.first()["changePercent"]).isEqualTo(BigDecimal("-0.0264"))
+    }
+
+    @Test
+    fun `getBenchmark sector scope maps to its SPDR ETF`() {
+        whenever(priceService.getPrices(any(), any()))
+            .thenReturn(PriceResponse(listOf(priceOf("XLK", "US", "-0.031"))))
+
+        @Suppress("UNCHECKED_CAST")
+        val benchmarks = marketTools.getBenchmark("Technology")["benchmarks"] as List<Map<String, Any>>
+
+        assertThat(benchmarks).hasSize(1)
+        assertThat(benchmarks.first()["code"]).isEqualTo("XLK")
+        assertThat(benchmarks.first()["name"]).isEqualTo("Technology (XLK)")
+    }
+
+    @Test
+    fun `getBenchmark unknown scope returns supported list without pricing`() {
+        val result = marketTools.getBenchmark("crypto")
+
+        assertThat(result["status"]).isEqualTo("unknown_scope")
+        @Suppress("UNCHECKED_CAST")
+        val supported = result["supportedScopes"] as List<String>
+        assertThat(supported).contains("market", "technology", "energy")
+        org.mockito.kotlin.verifyNoInteractions(priceService)
+    }
+
+    @Test
+    fun `getBenchmark returns no_coverage when no prices come back`() {
+        whenever(priceService.getPrices(any(), any())).thenReturn(PriceResponse(emptyList()))
+
+        assertThat(marketTools.getBenchmark("market")["status"]).isEqualTo("no_coverage")
+    }
 }


### PR DESCRIPTION
## Why

`getMarketNews` gave the agent macro *news*; there was no macro *performance* context. So "how's my portfolio doing **vs the market**?" or "is this drop **stock-specific or market-wide**?" couldn't be answered with numbers — the capability to price an index existed but was unexposed.

## What

New `getBenchmark(scope)` tool on `MarketTools`, mirroring `getMarketNews`:
- `"market"` → broad indices (S&P 500 `GSPC.INDX`, Nasdaq `IXIC.INDX`, Dow `DJI.INDX`)
- sector name → SPDR sector ETF proxy (`technology`→`XLK`, `energy`→`XLE`, …)
- Returns name + close + previousClose + `changePercent` per benchmark; `unknown_scope` lists valid scopes; `no_coverage` when no live price.

Reuses the existing `PriceService` path (`INDEX` market for indices, `US` market for ETFs — both EODHD-backed; verified S&P −2.6% live). Available wherever `MarketTools` already ships (Wealth, Asset Review, News). Prompts updated (WEALTH "Benchmarking", Asset Review workflow, general routing) to call it for vs-market / stock-vs-tape framing.

## Tests

`MarketToolsTest`: market scope → 3 indices; sector → SPDR ETF (case-insensitive); unknown scope short-circuits (no pricing); empty → `no_coverage`. Full `:svc-agent:test` green; format + lint + semgrep clean.

Local code-review skill run pre-push.

@coderabbitai ignore