### PR TITLE
fix(svc-data): admit self-register without SCOPE_USER

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/RegistrationController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/RegistrationController.kt
@@ -56,8 +56,14 @@ class RegistrationController internal constructor(
         return RegistrationResponse(user, preferences)
     }
 
+    // Authenticated, but not yet role-bound: a freshly-signed-up Auth0 user
+    // arrives without SCOPE_USER (role assignment happens via the post-login
+    // Action, which may not fire on every signup path). Allowing any
+    // authenticated principal unblocks the self-registration chicken-and-egg.
+    // SystemUserService.register() still rejects M2M tokens and requires the
+    // email claim, so the only callers it admits are real human users.
     @PostMapping(value = ["/register"])
-    @PreAuthorize("hasAuthority('" + AuthConstants.SCOPE_USER + "')")
+    @PreAuthorize("isAuthenticated()")
     fun register(
         @RequestBody(required = false) registrationRequest: RegistrationRequest
     ): RegistrationResponse {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/RegistrationControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/RegistrationControllerTest.kt
@@ -87,6 +87,74 @@ class RegistrationControllerTest {
     }
 
     @Test
+    fun `authenticated user without SCOPE_USER can self-register`() {
+        // Mirrors a real Auth0 signup before the post-login Action assigns the
+        // 'user' role: the token is valid and carries an email claim, but
+        // permissions[] is empty. /register must still admit them, otherwise
+        // the user is stuck in a 403 chicken-and-egg loop.
+        val freshSignup =
+            SystemUser(
+                email = "fresh-signup@testing.com",
+                auth0 = "auth0|fresh-signup"
+            )
+        // getAuth0Token emits the bare minimum a real Auth0 user token
+        // carries (auth0 sub + email claim) with no role authorities — the
+        // scope shape Mary's token had on kauri.
+        val auth0LikeToken = mockAuthConfig.tokenUtils.getAuth0Token(freshSignup)
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/register")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(auth0LikeToken))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(RegistrationRequest()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().is2xxSuccessful)
+
+        // Belt-and-braces: a token literally stripped of every role/scope
+        // (the pathological pre-Action state) should also be admitted.
+        val stillFresh =
+            SystemUser(
+                email = "another-fresh@testing.com",
+                auth0 = "auth0|another-fresh"
+            )
+        // getNoRolesToken doesn't emit an email claim; the registration body
+        // will fail at the email-claim check below — that's the correct
+        // 4xx (BusinessException), NOT the 403 the old PreAuthorize threw.
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/register")
+                    .with(
+                        SecurityMockMvcRequestPostProcessors.jwt().jwt(
+                            mockAuthConfig.tokenUtils.getNoRolesToken(stillFresh)
+                        )
+                    ).with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(RegistrationRequest()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().is4xxClientError)
+    }
+
+    @Test
+    fun `M2M token cannot self-register`() {
+        // Service tokens are admitted by isAuthenticated() at the
+        // @PreAuthorize layer, but SystemUserService.register() rejects them
+        // explicitly — otherwise a service caller could mint SystemUser rows
+        // keyed to the M2M client_id.
+        val m2m = mockAuthConfig.tokenUtils.getSystemToken(Constants.systemUser)
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/register")
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(m2m))
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .content(objectMapper.writeValueAsString(RegistrationRequest()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().is4xxClientError)
+    }
+
+    @Test
     fun `should return forbidden when accessing me endpoint as unregistered user`() {
         val user =
             SystemUser(


### PR DESCRIPTION
## Summary

- `/register` previously required `SCOPE_USER`; a freshly-signed-up Auth0 user has empty `permissions[]` until the post-login Action assigns the `user` role. They 403'd on the very call that's supposed to provision them.
- Loosened to `@PreAuthorize(\"isAuthenticated()\")`. `SystemUserService.register()` still rejects service tokens (line 42-44) and requires the email claim (line 46-50), so the only callers actually let through are real human Auth0 users.

## Repro that motivated this

Brand-new Auth0 user signs in via bc-view → `/api/register` returns 403 → cascading 403s on `/api/me`, `/api/portfolios`, etc. Token decoded:

```
scope: openid profile email offline_access
permissions: []
```

No `SystemUser` row gets created; user is stuck.

## Tests

- `authenticated user without SCOPE_USER can self-register` — token shaped like a fresh-signup Auth0 token (sub + email, no role) registers cleanly.
- `M2M token cannot self-register` — verifies the in-body guard still rejects service tokens.
- Existing happy-path + 401/403/400 tests unchanged.

## Out of scope (raise separately)

Even after `/register` succeeds, the user still has no `user` role in Auth0 — so subsequent `SCOPE_USER`-gated endpoints (`/me`, `/portfolios`, …) keep returning 403 until a downstream process assigns the role. Two viable follow-ups:

1. The post-login Action should auto-assign `user` on every new signup (current behaviour: inconsistent).
2. Or, after a successful `/register`, write the role to the user's Auth0 metadata via the Management API (analogous to how `writeSystemUserId` already runs).

## Test plan

- [ ] `./gradlew :svc-data:test --tests com.beancounter.marketdata.registration.RegistrationControllerTest` green locally
- [ ] After deploy: a fresh Auth0 signup hits `/api/register` and gets a 2xx (instead of 403)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication requirements for self-registration, explaining how authenticated users can complete signup even before receiving full authorization scopes.

* **Tests**
  * Added test coverage for self-registration authentication scenarios, including verification that service tokens are properly rejected during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->