### PR TITLE
feat(prefs): add targetIndependenceAge to UserPreferences

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
@@ -22,5 +22,6 @@ data class UserPreferencesRequest(
     val autoSettle: Boolean? = null,
     val yearOfBirth: Int? = null,
     val monthOfBirth: Int? = null,
+    val targetIndependenceAge: Int? = null,
     val lifeExpectancy: Int? = null
 )

--- a/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
@@ -42,15 +42,16 @@ data class UserPreferences(
     var milestoneMode: MilestoneMode = MilestoneMode.ACTIVE,
     @Column(name = "auto_settle")
     var autoSettle: Boolean = true,
-    // Profile demographics — mirrored from svc-retire's UserIndependenceSettings
-    // so screens that live in the svc-data scope (Edit Asset, holdings views)
-    // can resolve the user's current age without a runtime dependency on
-    // svc-retire. svc-retire still owns the write of these fields; this is
-    // a denormalised read copy.
+    // Profile demographics. svc-data is the master record — onboarding writes
+    // these directly here (PATCH /api/me), and svc-retire reads them as the
+    // user's account-wide default when its own per-plan profile has no
+    // override yet. See bc-claude/USER_PROFILE.md.
     @Column(name = "year_of_birth")
     var yearOfBirth: Int? = null,
     @Column(name = "month_of_birth")
     var monthOfBirth: Int? = null,
+    @Column(name = "target_independence_age")
+    var targetIndependenceAge: Int? = null,
     @Column(name = "life_expectancy")
     var lifeExpectancy: Int? = null
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
@@ -53,6 +53,7 @@ class UserPreferencesService(
         request.autoSettle?.let { preferences.autoSettle = it }
         request.yearOfBirth?.let { preferences.yearOfBirth = it }
         request.monthOfBirth?.let { preferences.monthOfBirth = it }
+        request.targetIndependenceAge?.let { preferences.targetIndependenceAge = it }
         request.lifeExpectancy?.let { preferences.lifeExpectancy = it }
         return userPreferencesRepository.save(preferences)
     }

--- a/svc-data/src/main/resources/db/migration/V27__add_user_preferences_target_independence_age.sql
+++ b/svc-data/src/main/resources/db/migration/V27__add_user_preferences_target_independence_age.sql
@@ -1,0 +1,10 @@
+-- Move svc-data UserPreferences toward being the master for user demographics
+-- (currently svc-retire's UserIndependenceSettings writes and mirrors back
+-- through DemographicsBackfillRunner). Target-independence age lived only
+-- in svc-retire; add it here so the onboarding flow can persist it
+-- against the user account and svc-retire can read it back as the user's
+-- account-wide default. See bc-claude/USER_PROFILE.md.
+ALTER TABLE user_preferences
+    ADD COLUMN target_independence_age INT,
+    ADD CONSTRAINT chk_user_preferences_target_independence_age
+        CHECK (target_independence_age IS NULL OR target_independence_age BETWEEN 18 AND 100);

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
@@ -268,6 +268,44 @@ class UserPreferencesServiceTest {
         assertThat(updated.defaultHoldingsView).isEqualTo(defaultView)
     }
 
+    @Test
+    fun `should persist demographic fields and surface them on subsequent reads`() {
+        val user = createAndAuthenticateUser("prefs-test-demographics@email.com")
+
+        // Default: all three demographic fields null
+        val initial = userPreferencesService.getOrCreate(user)
+        assertThat(initial.yearOfBirth).isNull()
+        assertThat(initial.monthOfBirth).isNull()
+        assertThat(initial.targetIndependenceAge).isNull()
+        assertThat(initial.lifeExpectancy).isNull()
+
+        // Onboarding writes all four — including targetIndependenceAge which
+        // didn't exist on the entity before. Without that field, the wizard's
+        // target age (the only place it's collected) had nowhere to land,
+        // and svc-retire's /settings GET fell back to its defaults.
+        val updated =
+            userPreferencesService.update(
+                user,
+                UserPreferencesRequest(
+                    yearOfBirth = 1981,
+                    monthOfBirth = 1,
+                    targetIndependenceAge = 60,
+                    lifeExpectancy = 90
+                )
+            )
+
+        assertThat(updated.yearOfBirth).isEqualTo(1981)
+        assertThat(updated.monthOfBirth).isEqualTo(1)
+        assertThat(updated.targetIndependenceAge).isEqualTo(60)
+        assertThat(updated.lifeExpectancy).isEqualTo(90)
+
+        // Re-reading goes through the persisted store, not the in-memory
+        // return value of update() — guards against the entity field
+        // being added but the column missing.
+        val reread = userPreferencesService.getOrCreate(user)
+        assertThat(reread.targetIndependenceAge).isEqualTo(60)
+    }
+
     private fun createAndAuthenticateUser(email: String): SystemUser {
         val user = SystemUser(email = email, auth0 = "auth0-$email")
         authUtilService.authenticate(user, AuthUtilService.AuthProvider.AUTH0)


### PR DESCRIPTION
## Summary

- svc-data `UserPreferences` becomes the master record for user demographics. Adds the missing `targetIndependenceAge` column (V27) + entity field + `UserPreferencesRequest` field + service mapping.
- Comment on `UserPreferences` flipped from "denormalised read copy" to "master record" — see [bc-claude/USER_PROFILE.md](https://github.com/monowai/bc-claude/blob/main/USER_PROFILE.md).
- Foundational PR. svc-retire fallback read + bc-view onboarding wiring land separately.

Resolves the underlying gap from [DEMO-ISSUES #14](https://github.com/monowai/bc-claude/blob/main/DEMO-ISSUES.md) — onboarding had nowhere to store the target age the wizard collects, so the Plan Profile UI read defaults until the user manually re-saved.

## Test plan

- [x] `./gradlew :svc-data:test --tests *UserPreferencesServiceTest` — new test plus 16 existing pass.
- [x] `./gradlew formatKotlin lintKotlin` — clean.
- [x] semgrep_scan — no findings.
- [ ] After merge: svc-retire PR reads this field as fallback when its per-plan profile is null.

@coderabbitai ignore