### PR TITLE
feat(svc-position): composite asset valuation strategy + CPF impl

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/AssetConfigClient.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/AssetConfigClient.kt
@@ -1,0 +1,40 @@
+package com.beancounter.position.composite
+
+import com.beancounter.auth.TokenService
+import com.beancounter.common.exception.NotFoundException
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.body
+
+/**
+ * Read-only client for svc-data's PrivateAssetConfig endpoint. Used by
+ * composite valuation to source sub-account balances that aren't held in
+ * svc-position's transaction-driven positions.
+ */
+@Service
+class AssetConfigClient(
+    @Qualifier("bcDataRestClient")
+    private val restClient: RestClient,
+    private val tokenService: TokenService
+) {
+    fun find(assetId: String): PrivateAssetConfigDto {
+        val response =
+            try {
+                restClient
+                    .get()
+                    .uri("/assets/config/{id}", assetId)
+                    .header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+                    .retrieve()
+                    .body<PrivateAssetConfigResponseDto>()
+            } catch (ex: RestClientResponseException) {
+                if (ex.statusCode.value() == 404) {
+                    throw NotFoundException("Asset config not found: $assetId")
+                }
+                throw ex
+            } ?: throw NotFoundException("Asset config not found: $assetId")
+        return response.data
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeController.kt
@@ -1,0 +1,53 @@
+package com.beancounter.position.composite
+
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.common.model.Position
+import com.beancounter.common.utils.DateUtils
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Synthesises a Position for composite assets (CPF, ILP, ...) whose balance
+ * lives in a sub-account list rather than a transaction stream. Returns
+ * data = null for non-composite assets so callers can fall back to the
+ * standard whereHeld/positions flow without a 404.
+ */
+@RestController
+@RequestMapping("/positions/composite")
+@CrossOrigin
+@PreAuthorize(
+    "hasAnyAuthority('" + AuthConstants.SCOPE_USER + "', '" + AuthConstants.SCOPE_SYSTEM + "')"
+)
+@Tag(
+    name = "Composite Position",
+    description = "Synthesised positions for composite assets (CPF, ILP, ...)"
+)
+class CompositeController(
+    private val service: CompositeValuationService
+) {
+    @GetMapping("/{assetId}")
+    @Operation(summary = "Get synthesised position for a composite asset")
+    fun byId(
+        @PathVariable assetId: String,
+        @RequestParam(name = "asAt", required = false, defaultValue = "today")
+        asAt: String
+    ): CompositePositionResponse {
+        val date = dateUtils.getDate(asAt)
+        return CompositePositionResponse(service.valueFor(assetId, date))
+    }
+
+    companion object {
+        private val dateUtils = DateUtils()
+    }
+}
+
+data class CompositePositionResponse(
+    val data: Position?
+)

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeValuation.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeValuation.kt
@@ -1,0 +1,22 @@
+package com.beancounter.position.composite
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Position
+import java.time.LocalDate
+
+/**
+ * Strategy for valuing composite assets (CPF, ILP, generic pensions) whose
+ * balance lives in sub-accounts rather than transaction history. Each impl
+ * decides whether it supports a given asset's config and, if so, synthesises
+ * a [Position] with [Position.subAccounts] populated and the rolled-up total
+ * exposed via [com.beancounter.common.model.QuantityValues.getTotal].
+ */
+interface CompositeValuation {
+    fun supports(config: PrivateAssetConfigDto): Boolean
+
+    fun value(
+        asset: Asset,
+        config: PrivateAssetConfigDto,
+        asAt: LocalDate
+    ): Position
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/CompositeValuationService.kt
@@ -1,0 +1,29 @@
+package com.beancounter.position.composite
+
+import com.beancounter.client.Assets
+import com.beancounter.common.model.Position
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Strategy registry. Looks up an asset's config, picks the first
+ * [CompositeValuation] strategy that supports it and returns the synthesised
+ * [Position]. Returns null when the asset has no composite policy so callers
+ * can fall back to the regular position lookup.
+ */
+@Service
+class CompositeValuationService(
+    private val configClient: AssetConfigClient,
+    private val assets: Assets,
+    private val strategies: List<CompositeValuation>
+) {
+    fun valueFor(
+        assetId: String,
+        asAt: LocalDate
+    ): Position? {
+        val config = configClient.find(assetId)
+        val strategy = strategies.firstOrNull { it.supports(config) } ?: return null
+        val asset = assets.find(assetId)
+        return strategy.value(asset, config, asAt)
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/CpfValuation.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/CpfValuation.kt
@@ -1,0 +1,37 @@
+package com.beancounter.position.composite
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Position
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Composite valuation for Singapore CPF policies. Sums OA/SA/MA/RA sub-account
+ * balances into a single rolled-up [Position]. SG-specific liquidity / CPF
+ * LIFE payout conversion is captured via the [SubAccountDto.liquid] flag and
+ * deferred to the projection layer; this strategy only reports current balance.
+ */
+@Component
+class CpfValuation : CompositeValuation {
+    override fun supports(config: PrivateAssetConfigDto): Boolean = config.policyType == POLICY_TYPE
+
+    override fun value(
+        asset: Asset,
+        config: PrivateAssetConfigDto,
+        asAt: LocalDate
+    ): Position {
+        val position = Position(asset)
+        var total = BigDecimal.ZERO
+        for (sub in config.subAccounts) {
+            position.subAccounts[sub.code] = sub.balance
+            total = total.add(sub.balance)
+        }
+        position.quantityValues.adjustment = total
+        return position
+    }
+
+    companion object {
+        const val POLICY_TYPE: String = "CPF"
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/PrivateAssetConfigDto.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/PrivateAssetConfigDto.kt
@@ -1,0 +1,43 @@
+package com.beancounter.position.composite
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Lean DTO mirroring svc-data's PrivateAssetConfig response for the fields
+ * needed by composite valuation. Unknown fields are ignored so svc-data can
+ * evolve its schema without breaking svc-position.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PrivateAssetConfigDto(
+    val assetId: String,
+    val policyType: String? = null,
+    val currency: String? = null,
+    val payoutAge: Int? = null,
+    val monthlyPayoutAmount: BigDecimal? = null,
+    val cpfLifePlan: String? = null,
+    val cpfPayoutStartAge: Int? = null,
+    val lockedUntilDate: LocalDate? = null,
+    val subAccounts: List<SubAccountDto> = emptyList()
+) {
+    fun isComposite(): Boolean = subAccounts.isNotEmpty()
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SubAccountDto(
+    val code: String,
+    val displayName: String? = null,
+    val balance: BigDecimal = BigDecimal.ZERO,
+    val expectedReturnRate: BigDecimal? = null,
+    val feeRate: BigDecimal? = null,
+    val liquid: Boolean = true
+)
+
+/**
+ * Wrapper for the GET /assets/config/{id} response shape.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PrivateAssetConfigResponseDto(
+    val data: PrivateAssetConfigDto
+)

--- a/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeControllerTest.kt
@@ -1,0 +1,60 @@
+package com.beancounter.position.composite
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.Position
+import com.beancounter.position.Constants.Companion.SGD
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class CompositeControllerTest {
+    @Mock
+    private lateinit var service: CompositeValuationService
+
+    private val asset =
+        Asset(
+            code = "CPF",
+            id = "cpf-asset-id",
+            name = "CPF",
+            market = Market("PRIVATE")
+        )
+
+    @Test
+    fun `byId returns synthesised position when asset is composite`() {
+        val controller = CompositeController(service)
+        val position =
+            Position(asset).apply {
+                subAccounts["OA"] = BigDecimal("145000")
+                subAccounts["SA"] = BigDecimal("78000")
+                quantityValues.adjustment = BigDecimal("223000")
+            }
+        whenever(service.valueFor(eq(asset.id), any())).thenReturn(position)
+
+        val response = controller.byId(asset.id, "today")
+
+        assertThat(response.data).isNotNull
+        assertThat(response.data!!.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal("223000"))
+    }
+
+    @Test
+    fun `byId returns null data when asset is not composite`() {
+        val controller = CompositeController(service)
+        whenever(service.valueFor(eq(asset.id), any())).thenReturn(null)
+
+        val response = controller.byId(asset.id, "today")
+
+        assertThat(response.data).isNull()
+    }
+
+    @Suppress("unused")
+    private val sgd = SGD
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeValuationServiceTest.kt
@@ -1,0 +1,76 @@
+package com.beancounter.position.composite
+
+import com.beancounter.client.Assets
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.position.Constants.Companion.SGD
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class CompositeValuationServiceTest {
+    private val asAt: LocalDate = LocalDate.of(2026, 6, 7)
+    private val cpfAsset =
+        Asset(
+            code = "CPF",
+            id = "cpf-asset-id",
+            name = "CPF",
+            market = Market("PRIVATE")
+        )
+    private val cpfConfig =
+        PrivateAssetConfigDto(
+            assetId = cpfAsset.id,
+            policyType = "CPF",
+            currency = SGD.code,
+            subAccounts =
+                listOf(
+                    SubAccountDto("OA", balance = BigDecimal("145000")),
+                    SubAccountDto("SA", balance = BigDecimal("78000"))
+                )
+        )
+
+    @Test
+    fun `valueFor returns null when asset is not composite`() {
+        val configClient = mock<AssetConfigClient>()
+        val assets = mock<Assets>()
+        whenever(configClient.find(cpfAsset.id)).thenReturn(
+            PrivateAssetConfigDto(assetId = cpfAsset.id, policyType = null)
+        )
+
+        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+
+        assertThat(service.valueFor(cpfAsset.id, asAt)).isNull()
+    }
+
+    @Test
+    fun `valueFor returns null when no strategy supports policy type`() {
+        val configClient = mock<AssetConfigClient>()
+        val assets = mock<Assets>()
+        whenever(configClient.find(cpfAsset.id)).thenReturn(
+            PrivateAssetConfigDto(assetId = cpfAsset.id, policyType = "ILP")
+        )
+
+        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+
+        assertThat(service.valueFor(cpfAsset.id, asAt)).isNull()
+    }
+
+    @Test
+    fun `valueFor delegates to matching strategy and returns synthesised position`() {
+        val configClient = mock<AssetConfigClient>()
+        val assets = mock<Assets>()
+        whenever(configClient.find(cpfAsset.id)).thenReturn(cpfConfig)
+        whenever(assets.find(cpfAsset.id)).thenReturn(cpfAsset)
+
+        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+
+        val position = service.valueFor(cpfAsset.id, asAt)
+
+        assertThat(position).isNotNull
+        assertThat(position!!.asset).isEqualTo(cpfAsset)
+        assertThat(position.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal("223000"))
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/composite/CpfValuationTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/composite/CpfValuationTest.kt
@@ -1,0 +1,96 @@
+package com.beancounter.position.composite
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.position.Constants.Companion.SGD
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.MapEntry.entry
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class CpfValuationTest {
+    private val valuation = CpfValuation()
+    private val asAt = LocalDate.of(2026, 6, 7)
+    private val cpfAsset =
+        Asset(
+            code = "CPF",
+            id = "cpf-asset-id",
+            name = "CPF",
+            market = Market("PRIVATE")
+        )
+
+    @Test
+    fun `supports returns true when policyType is CPF`() {
+        val config = config(policyType = "CPF")
+        assertThat(valuation.supports(config)).isTrue
+    }
+
+    @Test
+    fun `supports returns false when policyType is null`() {
+        val config = config(policyType = null)
+        assertThat(valuation.supports(config)).isFalse
+    }
+
+    @Test
+    fun `supports returns false when policyType is not CPF`() {
+        val config = config(policyType = "ILP")
+        assertThat(valuation.supports(config)).isFalse
+    }
+
+    @Test
+    fun `value rolls up sub-account balances into position`() {
+        val config =
+            config(
+                policyType = "CPF",
+                subAccounts =
+                    listOf(
+                        sub("OA", "145000"),
+                        sub("SA", "78000"),
+                        sub("MA", "58000", liquid = false),
+                        sub("RA", "0")
+                    )
+            )
+
+        val position = valuation.value(cpfAsset, config, asAt)
+
+        assertThat(position.asset).isEqualTo(cpfAsset)
+        assertThat(position.subAccounts).containsOnly(
+            entry("OA", BigDecimal("145000")),
+            entry("SA", BigDecimal("78000")),
+            entry("MA", BigDecimal("58000")),
+            entry("RA", BigDecimal("0"))
+        )
+        assertThat(position.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal("281000"))
+    }
+
+    @Test
+    fun `value returns zero quantity when sub-accounts empty`() {
+        val config = config(policyType = "CPF", subAccounts = emptyList())
+
+        val position = valuation.value(cpfAsset, config, asAt)
+
+        assertThat(position.subAccounts).isEmpty()
+        assertThat(position.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    private fun config(
+        policyType: String?,
+        subAccounts: List<SubAccountDto> = emptyList()
+    ) = PrivateAssetConfigDto(
+        assetId = cpfAsset.id,
+        policyType = policyType,
+        currency = SGD.code,
+        subAccounts = subAccounts
+    )
+
+    private fun sub(
+        code: String,
+        balance: String,
+        liquid: Boolean = true
+    ) = SubAccountDto(
+        code = code,
+        balance = BigDecimal(balance),
+        liquid = liquid
+    )
+}


### PR DESCRIPTION
## Summary

- Adds `CompositeValuation` strategy + `CpfValuation` impl in `svc-position`. Sums OA/SA/MA/RA sub-account balances into a single synthesised `Position` (`Position.subAccounts` + `quantityValues.adjustment` rolled-up total).
- New `GET /positions/composite/{assetId}` endpoint exposes the synthesised position; returns `data: null` for non-composite assets so callers fall back to the standard whereHeld flow.
- `AssetConfigClient` reads svc-data `GET /assets/config/{id}` via the existing `bcDataRestClient` + `tokenService.bearerToken` pattern.

## Why

Composite policies (CPF today; ILP / Generic to follow) store balance in `PrivateAssetConfig.subAccounts` on svc-data, not as svc-position positions. Existing `/positions/{portfolio}` returns nothing for them, so the Plan "Policies Need Balances" warning fires, Plan Total Assets misses 281k of CPF, and Onboarding/Review tiles show `-`. This puts valuation behind a single composite-aware endpoint so Plan + Review + Onboarding + Net Worth converge on one source.

Companion bc-view PR: monowai/bc-view#feat/composite-valuation

## Test plan

- [x] `./gradlew :svc-position:testSmart`
- [x] `./gradlew :svc-position:formatKotlin :svc-position:lintKotlin`
- [x] `./gradlew :svc-position:check`
- [ ] Deploy to kauri, verify Mary's CPF 281k surfaces in Plan + "Policies Need Balances" warning disappears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoint to retrieve composite position data for assets with multiple sub-accounts.
  * Introduced support for Singapore CPF (Central Provident Fund) policy valuation, aggregating sub-account balances into a single rolled-up position view.

* **Tests**
  * Added comprehensive test coverage for composite position valuation and endpoint functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->