### PR TITLE
feat(jar-common): shared CompositeValuation support class

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
@@ -1,0 +1,83 @@
+package com.beancounter.common.composite
+
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+/**
+ * Single source of truth for composite-asset (CPF / ILP / generic pension)
+ * balance roll-ups. Both `svc-position` (synthesising a `Position` for the
+ * `/positions/composite/{assetId}` endpoint) and `svc-retire` (adjusting a
+ * Plan's `totalAssets` / `liquidAssets` when projecting) delegate here so
+ * the math lives in exactly one place.
+ *
+ * Inputs are deliberately primitive (`policyType` + sub-account list) so
+ * the support class is decoupled from any service's DTO shape. Callers
+ * adapt their own DTO (svc-position's `PrivateAssetConfigDto`, svc-retire's
+ * `PrivateAssetConfigDto`, etc.) into the lean [SubAccountBalance] list.
+ *
+ * Returns null when the policy type isn't composite-aware so callers can
+ * fall back to the default per-asset balance lookup without special-casing.
+ */
+@Component
+class CompositeValuation {
+    fun value(
+        policyType: String?,
+        subAccounts: List<SubAccountBalance>
+    ): CompositeBalance? {
+        if (policyType !in supportedPolicyTypes) return null
+
+        var total = BigDecimal.ZERO
+        var liquid = BigDecimal.ZERO
+        var nonLiquid = BigDecimal.ZERO
+        val byCode = linkedMapOf<String, BigDecimal>()
+
+        for (sub in subAccounts) {
+            total = total.add(sub.balance)
+            if (sub.liquid) {
+                liquid = liquid.add(sub.balance)
+            } else {
+                nonLiquid = nonLiquid.add(sub.balance)
+            }
+            byCode[sub.code] = sub.balance
+        }
+
+        return CompositeBalance(
+            total = total,
+            liquid = liquid,
+            nonLiquid = nonLiquid,
+            byCode = byCode
+        )
+    }
+
+    companion object {
+        /** Policy types this support class knows how to roll up. */
+        val supportedPolicyTypes: Set<String> = setOf("CPF")
+    }
+}
+
+/**
+ * Lean per-sub-account input. Callers map their own DTO into this list.
+ *
+ * @property liquid `true` when the sub-account contributes to spendable wealth
+ * today (CPF OA / SA / RA). `false` for locked buckets (CPF MA pre-55).
+ */
+data class SubAccountBalance(
+    val code: String,
+    val balance: BigDecimal,
+    val liquid: Boolean = true
+)
+
+/**
+ * Rolled-up balance for one composite asset.
+ *
+ * @property total sum of all sub-account balances
+ * @property liquid sum of sub-account balances with `liquid = true`
+ * @property nonLiquid sum of sub-account balances with `liquid = false`
+ * @property byCode per-sub-account balance map (preserves caller's order)
+ */
+data class CompositeBalance(
+    val total: BigDecimal,
+    val liquid: BigDecimal,
+    val nonLiquid: BigDecimal,
+    val byCode: Map<String, BigDecimal>
+)

--- a/jar-common/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
@@ -38,7 +38,7 @@ class CompositeValuation {
             } else {
                 nonLiquid = nonLiquid.add(sub.balance)
             }
-            byCode[sub.code] = sub.balance
+            byCode.merge(sub.code, sub.balance, BigDecimal::add)
         }
 
         return CompositeBalance(

--- a/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
@@ -1,0 +1,76 @@
+package com.beancounter.common.composite
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.MapEntry.entry
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * jar-common is the single source of truth for composite (CPF / ILP / generic)
+ * balance roll-ups. Both svc-position (synthesising a Position for the
+ * /positions/composite endpoint) and svc-retire (adjusting Plan total / liquid
+ * assets) call the same class so neither re-implements the math.
+ */
+class CompositeValuationTest {
+    private val valuation = CompositeValuation()
+
+    @Test
+    fun `returns null when policy type is null`() {
+        val result =
+            valuation.value(
+                policyType = null,
+                subAccounts =
+                    listOf(SubAccountBalance(code = "OA", balance = BigDecimal("145000")))
+            )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when policy type is unknown`() {
+        val result =
+            valuation.value(
+                policyType = "UNHANDLED",
+                subAccounts = listOf(SubAccountBalance(code = "X", balance = BigDecimal.ONE))
+            )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `CPF rolls up total liquid and non-liquid`() {
+        val result =
+            valuation.value(
+                policyType = "CPF",
+                subAccounts =
+                    listOf(
+                        SubAccountBalance(code = "OA", balance = BigDecimal("145000"), liquid = true),
+                        SubAccountBalance(code = "SA", balance = BigDecimal("78000"), liquid = true),
+                        SubAccountBalance(code = "MA", balance = BigDecimal("58000"), liquid = false),
+                        SubAccountBalance(code = "RA", balance = BigDecimal("0"), liquid = true)
+                    )
+            )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.total).isEqualByComparingTo(BigDecimal("281000"))
+        assertThat(result.liquid).isEqualByComparingTo(BigDecimal("223000"))
+        assertThat(result.nonLiquid).isEqualByComparingTo(BigDecimal("58000"))
+        assertThat(result.byCode).containsOnly(
+            entry("OA", BigDecimal("145000")),
+            entry("SA", BigDecimal("78000")),
+            entry("MA", BigDecimal("58000")),
+            entry("RA", BigDecimal("0"))
+        )
+    }
+
+    @Test
+    fun `CPF with empty sub-accounts is zero`() {
+        val result = valuation.value(policyType = "CPF", subAccounts = emptyList())
+
+        assertThat(result).isNotNull
+        assertThat(result!!.total).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.liquid).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.nonLiquid).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.byCode).isEmpty()
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
@@ -61,6 +61,25 @@ class CompositeValuationTest {
             entry("MA", BigDecimal("58000")),
             entry("RA", BigDecimal("0"))
         )
+        assertThat(result.byCode.keys).containsExactly("OA", "SA", "MA", "RA")
+    }
+
+    @Test
+    fun `duplicate sub-account codes accumulate in byCode`() {
+        val result =
+            valuation.value(
+                policyType = "CPF",
+                subAccounts =
+                    listOf(
+                        SubAccountBalance(code = "OA", balance = BigDecimal("100"), liquid = true),
+                        SubAccountBalance(code = "OA", balance = BigDecimal("50"), liquid = true)
+                    )
+            )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.total).isEqualByComparingTo(BigDecimal("150"))
+        assertThat(result.liquid).isEqualByComparingTo(BigDecimal("150"))
+        assertThat(result.byCode).containsOnly(entry("OA", BigDecimal("150")))
     }
 
     @Test

--- a/svc-position/src/main/kotlin/com/beancounter/position/PositionBoot.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/PositionBoot.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.runApplication
     scanBasePackages = [
         "com.beancounter.position",
         "com.beancounter.auth",
+        "com.beancounter.common.composite",
         "com.beancounter.common.utils",
         "com.beancounter.common.telemetry",
         "com.beancounter.common.exception"

--- a/svc-position/src/main/kotlin/com/beancounter/position/composite/CpfValuation.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/composite/CpfValuation.kt
@@ -1,19 +1,26 @@
 package com.beancounter.position.composite
 
+import com.beancounter.common.composite.SubAccountBalance
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Position
 import org.springframework.stereotype.Component
-import java.math.BigDecimal
 import java.time.LocalDate
+import com.beancounter.common.composite.CompositeValuation as SharedCompositeValuation
 
 /**
- * Composite valuation for Singapore CPF policies. Sums OA/SA/MA/RA sub-account
- * balances into a single rolled-up [Position]. SG-specific liquidity / CPF
- * LIFE payout conversion is captured via the [SubAccountDto.liquid] flag and
- * deferred to the projection layer; this strategy only reports current balance.
+ * Composite valuation for Singapore CPF policies. Delegates the sub-account
+ * roll-up math to jar-common's [SharedCompositeValuation] so svc-position and
+ * svc-retire stay in lock-step. This class adapts svc-position's
+ * [PrivateAssetConfigDto] into the shared [SubAccountBalance] shape and
+ * packages the result as a [Position] for the `/positions/composite` endpoint.
+ *
+ * CPF LIFE payout conversion is left to the projection layer in svc-retire;
+ * this strategy reports current balance only.
  */
 @Component
-class CpfValuation : CompositeValuation {
+class CpfValuation(
+    private val shared: SharedCompositeValuation
+) : CompositeValuation {
     override fun supports(config: PrivateAssetConfigDto): Boolean = config.policyType == POLICY_TYPE
 
     override fun value(
@@ -21,13 +28,22 @@ class CpfValuation : CompositeValuation {
         config: PrivateAssetConfigDto,
         asAt: LocalDate
     ): Position {
+        val balance =
+            shared.value(
+                policyType = config.policyType,
+                subAccounts =
+                    config.subAccounts.map {
+                        SubAccountBalance(
+                            code = it.code,
+                            balance = it.balance,
+                            liquid = it.liquid
+                        )
+                    }
+            ) ?: error("Composite roll-up unavailable for policy ${config.policyType}")
+
         val position = Position(asset)
-        var total = BigDecimal.ZERO
-        for (sub in config.subAccounts) {
-            position.subAccounts[sub.code] = sub.balance
-            total = total.add(sub.balance)
-        }
-        position.quantityValues.adjustment = total
+        balance.byCode.forEach { (code, value) -> position.subAccounts[code] = value }
+        position.quantityValues.adjustment = balance.total
         return position
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/composite/CompositeValuationServiceTest.kt
@@ -40,7 +40,17 @@ class CompositeValuationServiceTest {
             PrivateAssetConfigDto(assetId = cpfAsset.id, policyType = null)
         )
 
-        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+        val service =
+            CompositeValuationService(
+                configClient,
+                assets,
+                listOf(
+                    CpfValuation(
+                        com.beancounter.common.composite
+                            .CompositeValuation()
+                    )
+                )
+            )
 
         assertThat(service.valueFor(cpfAsset.id, asAt)).isNull()
     }
@@ -53,7 +63,17 @@ class CompositeValuationServiceTest {
             PrivateAssetConfigDto(assetId = cpfAsset.id, policyType = "ILP")
         )
 
-        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+        val service =
+            CompositeValuationService(
+                configClient,
+                assets,
+                listOf(
+                    CpfValuation(
+                        com.beancounter.common.composite
+                            .CompositeValuation()
+                    )
+                )
+            )
 
         assertThat(service.valueFor(cpfAsset.id, asAt)).isNull()
     }
@@ -65,7 +85,17 @@ class CompositeValuationServiceTest {
         whenever(configClient.find(cpfAsset.id)).thenReturn(cpfConfig)
         whenever(assets.find(cpfAsset.id)).thenReturn(cpfAsset)
 
-        val service = CompositeValuationService(configClient, assets, listOf(CpfValuation()))
+        val service =
+            CompositeValuationService(
+                configClient,
+                assets,
+                listOf(
+                    CpfValuation(
+                        com.beancounter.common.composite
+                            .CompositeValuation()
+                    )
+                )
+            )
 
         val position = service.valueFor(cpfAsset.id, asAt)
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/composite/CpfValuationTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/composite/CpfValuationTest.kt
@@ -10,7 +10,11 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 class CpfValuationTest {
-    private val valuation = CpfValuation()
+    private val valuation =
+        CpfValuation(
+            com.beancounter.common.composite
+                .CompositeValuation()
+        )
     private val asAt = LocalDate.of(2026, 6, 7)
     private val cpfAsset =
         Asset(


### PR DESCRIPTION
## Summary

- Adds `com.beancounter.common.composite.CompositeValuation` to jar-common: single source of truth for sub-account roll-ups (total / liquid / nonLiquid / byCode). Both svc-position and svc-retire delegate to it so neither re-implements the math.
- Refactors svc-position's `CpfValuation` to delegate to the shared class. Existing svc-position composite tests still pass with zero behaviour change.
- Sets up the second PR (svc-retire `feat/composite-valuation-shared`) where `AllocationResolver` post-processes `getAllocation` with the same shared class so Plan `totalAssets` / `liquidAssets` include composite balances.

## Why

User direction: "Don't distribute calculation logic. Either the code goes into jar-common or svc-retire obtains the value from svc-position." Putting valuation in jar-common matches the existing pattern for `InterestAccrual` and `DayCountConvention`.

Base branch: `feat/composite-valuation` (depends on #927). Will retarget to `main` once #927 lands.

Companion PR: monowai/svc-retire#feat/composite-valuation-shared

## Test plan

- [x] `./gradlew :jar-common:test --tests 'com.beancounter.common.composite.*'`
- [x] `./gradlew :svc-position:test --tests 'com.beancounter.position.composite.*'`
- [x] `./gradlew :svc-position:testSmart :svc-position:formatKotlin :svc-position:lintKotlin`
- [ ] Deploy + verify Mary's CPF 281k surfaces in Plan via the svc-retire companion PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized composite asset valuation that aggregates sub-account balances into rolled-up totals (total, liquid, non-liquid) with per-account breakdown.
  * Added explicit support for CPF policy-type composite valuations.

* **Chores**
  * Application startup updated to include the new composite valuation component.

* **Tests**
  * New and updated tests validating aggregation behavior, duplicate account accumulation, empty inputs, and wiring changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->