### PR TITLE
feat(svc-position): BALANCE captures subAccounts + AllocationData.heldAssetIds

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/AllocationContracts.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/AllocationContracts.kt
@@ -12,7 +12,14 @@ data class AllocationData(
     val housingAllocation: BigDecimal = BigDecimal.ZERO,
     val totalValue: BigDecimal = BigDecimal.ZERO,
     val currency: String = "USD",
-    val categoryBreakdown: Map<String, CategoryAllocation> = emptyMap()
+    val categoryBreakdown: Map<String, CategoryAllocation> = emptyMap(),
+    /**
+     * Asset ids represented in the underlying portfolio positions. Lets
+     * callers deduplicate against config-driven rollups (e.g. composite
+     * pensions linked into a portfolio via a BALANCE trn) so a single
+     * holding doesn't get counted twice in plan totals.
+     */
+    val heldAssetIds: Set<String> = emptySet()
 )
 
 /**

--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
@@ -31,6 +31,14 @@ class BalanceBehaviour(
         position: Position
     ): Position {
         position.quantityValues.purchased = trn.tradeAmount
+        // Composite policies (CPF / ILP / generic pension) carry a per-bucket
+        // map on the BALANCE trn. Snapshot semantics: overwrite (not add) so
+        // re-running with a fresh balance replaces the previous snapshot,
+        // mirroring `quantityValues.purchased` above.
+        if (!trn.subAccounts.isNullOrEmpty()) {
+            position.subAccounts.clear()
+            position.subAccounts.putAll(trn.subAccounts!!)
+        }
         val isCash = cashUtils.isCash(position.asset)
         applyMoneyValues(
             Position.In.BASE,

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
@@ -81,13 +81,19 @@ class AllocationService(
         val equityAllocation = sumCategoryPercentage(categoryBreakdown, EQUITY_CATEGORIES)
         val housingAllocation = sumCategoryPercentage(categoryBreakdown, HOUSING_CATEGORIES)
 
+        val heldAssetIds =
+            positions.positions.values
+                .map { it.asset.id }
+                .toSet()
+
         return AllocationData(
             cashAllocation = cashAllocation,
             equityAllocation = equityAllocation,
             housingAllocation = housingAllocation,
             totalValue = totalValue.setScale(2, RoundingMode.HALF_UP),
             currency = currency,
-            categoryBreakdown = categoryBreakdown
+            categoryBreakdown = categoryBreakdown,
+            heldAssetIds = heldAssetIds
         )
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -152,4 +152,52 @@ class BalanceBehaviourTest {
             balance
         )
     }
+
+    @Test
+    fun `BALANCE with subAccounts captures per-bucket snapshot on position`() {
+        // Composite-policy BALANCE (CPF, ILP, generic pension) carries a
+        // sub-account map alongside the total. The accumulator must surface
+        // it on Position.subAccounts so the holdings UI can render OA / SA /
+        // MA / RA breakdown alongside the rolled-up MV.
+        val portfolio =
+            Portfolio(
+                Constants.TEST,
+                currency = SGD,
+                base = SGD
+            )
+        val cpfAsset =
+            Asset(
+                code = RUBY_CPF,
+                id = RUBY_CPF,
+                name = "Ruby CPF",
+                market = Market("PRIVATE"),
+                priceSymbol = RUBY_CPF,
+                category = AssetCategory.POLICY
+            )
+        val subAccounts =
+            mapOf(
+                "OA" to BigDecimal("145000"),
+                "SA" to BigDecimal("78000"),
+                "MA" to BigDecimal("58000"),
+                "RA" to BigDecimal("0")
+            )
+        val trn =
+            Trn(
+                trnType = TrnType.BALANCE,
+                asset = cpfAsset,
+                quantity = BigDecimal("281000"),
+                tradeAmount = BigDecimal("281000"),
+                cashCurrency = SGD,
+                tradeCurrency = SGD,
+                tradeCashRate = BigDecimal.ONE,
+                tradeBaseRate = BigDecimal.ONE,
+                tradePortfolioRate = BigDecimal.ONE,
+                portfolio = portfolio,
+                subAccounts = subAccounts
+            )
+
+        val position = accumulator.accumulate(trn, Positions(portfolio))
+
+        assertThat(position.subAccounts).containsExactlyInAnyOrderEntriesOf(subAccounts)
+    }
 }


### PR DESCRIPTION
## Summary

- `BalanceBehaviour` now snapshots `trn.subAccounts` onto `Position.subAccounts` (overwrite semantics, matching `quantityValues.purchased`). Composite policies linked into a portfolio via a BALANCE trn surface the per-bucket breakdown.
- `AllocationData` gains `heldAssetIds: Set<String>` populated from the underlying positions. Callers (svc-retire) can deduplicate against config-driven composite rollups.

## Why

User feedback on Mary's demo: "CPF should be visible in her SGD portfolio — if it's not in a portfolio it can't be considered as part of her wealth." Linking via a BALANCE trn (term-deposit-like semantic — transaction IS the balance, no cash impact, MV = cost so no phantom gain) was the right primitive. This PR wires sub-accounts through the BALANCE path so the existing UI surfaces in svc-position pick up the composite breakdown.

Companion PRs:
- monowai/svc-retire — `feat/composite-rollup-skip-held` (deduplicate)
- monowai/bc-view — `feat/link-composite-banner` (UI to fire the BALANCE trn)

## Test plan

- [x] `./gradlew :svc-position:test --tests 'com.beancounter.position.accumulation.BalanceBehaviourTest'`
- [x] `./gradlew :svc-position:test :svc-position:formatKotlin :svc-position:lintKotlin`
- [x] `./gradlew :jar-common:test :jar-common:formatKotlin :jar-common:lintKotlin`
- [ ] Deploy + verify CPF position appears in SGD portfolio after Link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Allocation data now includes asset ID tracking to enable deduplication of holdings across composite and rollup portfolio configurations
  * Sub-account handling improved to treat balance updates as per-bucket snapshots, replacing previous state instead of accumulating entries

* **Tests**
  * Added test coverage for sub-account snapshot behavior during balance accumulation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->