### PR TITLE
fix(svc-position): zero gain for POLICY assets

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
@@ -111,6 +111,16 @@ class MarketValue(
             moneyValues.unrealisedGain = BigDecimal.ZERO // moneyValues.marketValue.subtract(moneyValues.costBasis)
             moneyValues.totalGain = BigDecimal.ZERO
             // moneyValues.realisedGain.add(moneyValues.unrealisedGain) // moneyValues.marketValue
+        } else if (mktData.asset.category == "POLICY") {
+            // Composite / pension assets (CPF, ILP, life policies) are balance
+            // snapshots, not traded positions. Book = current market by
+            // construction so per-pool FX rate drift on the snapshot DEPOSIT
+            // can't surface as a phantom gain/loss.
+            moneyValues.costBasis = moneyValues.marketValue
+            moneyValues.costValue = moneyValues.marketValue
+            moneyValues.realisedGain = BigDecimal.ZERO
+            moneyValues.unrealisedGain = BigDecimal.ZERO
+            moneyValues.totalGain = BigDecimal.ZERO
         } else {
             gains.value(
                 total,

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
@@ -333,6 +333,48 @@ internal class MarketValueTest {
     }
 
     @Test
+    fun `POLICY assets report zero gain even when snapshot cost drifts from market value`() {
+        // Mirror the CPF/pension flow: snapshot DEPOSIT seeds cost basis, then
+        // composite valuation feeds the runtime balance. Per-pool FX drift
+        // on the snapshot rate would otherwise show as Your Loss on the
+        // holdings page (kauri bug: -955.40 on Mary's 281,000 SGD CPF).
+        val policyAsset =
+            Asset(
+                code = "CPF",
+                id = "CPF",
+                name = "CPF",
+                market = NASDAQ,
+                category = "POLICY",
+                status = com.beancounter.common.model.Status.Active
+            )
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(policyAsset)
+        position.quantityValues.purchased = BigDecimal("281000")
+
+        // Snapshot cost recorded at trn time (slightly off the runtime price)
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { pool ->
+            val moneyValues = position.getMoneyValues(pool, policyAsset.market.currency)
+            moneyValues.costBasis = BigDecimal("360635.40")
+            moneyValues.costValue = BigDecimal("360635.40")
+            moneyValues.purchases = BigDecimal("360635.40")
+        }
+
+        val marketData = MarketData(policyAsset, close = BigDecimal("1.28"))
+        val fxRateMap = getRates(portfolio, policyAsset, BigDecimal.ONE)
+
+        MarketValue(Gains()).value(positions, marketData, fxRateMap)
+
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { pool ->
+            val moneyValues = position.getMoneyValues(pool, policyAsset.market.currency)
+            assertThat(moneyValues.totalGain).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(moneyValues.unrealisedGain).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(moneyValues.realisedGain).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(moneyValues.costValue).isEqualByComparingTo(moneyValues.marketValue)
+            assertThat(moneyValues.costBasis).isEqualByComparingTo(moneyValues.marketValue)
+        }
+    }
+
+    @Test
     fun `should preserve position values when price returns zero`() {
         // Scenario: Position was valued at $100/share, now bc-data returns no price (close=0)
         // The position should still be usable and not crash


### PR DESCRIPTION
## Summary
- Composite / pension snapshots (CPF, ILP, life policies) surfaced a phantom **Your Loss** on the holdings card whenever the snapshot DEPOSIT's per-pool FX rate drifted from the runtime composite valuation (which always uses rate=1.0 + balance-table totals).
- Symptom on Mary demo persona (SGD CPF, SGD portfolio): `-955.40 Your Loss` in Portfolio view, zero in Trade view. Same currency on both sides — the loss is pure rate-application drift, not real P&L.
- Treat `POLICY` assets like cash for gain calc: force `costBasis = costValue = marketValue` and zero the gain buckets so book == actual by construction in every pool (TRADE / BASE / PORTFOLIO).

## Test plan
- [x] `./gradlew :svc-position:test` — green, includes new `POLICY assets report zero gain even when snapshot cost drifts from market value`
- [x] `./gradlew :svc-position:lintKotlin` — green
- [ ] Verify on kauri after deploy: CPF row in `/holdings/SGD` shows `0.00 Your Profit` instead of `-955.40 Your Loss`
- [ ] Verify totals strip (`total profit` at top of holdings page) drops the spurious loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy assets now correctly report zero gains and losses, with cost basis aligned to current market value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->