### PR TITLE
fix(svc-position): check assetCategory.id for POLICY gain zero

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
@@ -111,7 +111,7 @@ class MarketValue(
             moneyValues.unrealisedGain = BigDecimal.ZERO // moneyValues.marketValue.subtract(moneyValues.costBasis)
             moneyValues.totalGain = BigDecimal.ZERO
             // moneyValues.realisedGain.add(moneyValues.unrealisedGain) // moneyValues.marketValue
-        } else if (mktData.asset.category == "POLICY") {
+        } else if (mktData.asset.assetCategory.id == "POLICY") {
             // Composite / pension assets (CPF, ILP, life policies) are balance
             // snapshots, not traded positions. Book = current market by
             // construction so per-pool FX rate drift on the snapshot DEPOSIT

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
@@ -338,15 +338,24 @@ internal class MarketValueTest {
         // composite valuation feeds the runtime balance. Per-pool FX drift
         // on the snapshot rate would otherwise show as Your Loss on the
         // holdings page (kauri bug: -955.40 on Mary's 281,000 SGD CPF).
+        // Reproduce the deserialized-Asset shape from a cross-service call:
+        // the @JsonIgnore `category` field stays at its default ("Equity"),
+        // but `assetCategory.id` survives JSON → that is the canonical
+        // category source MarketValue must consult.
         val policyAsset =
             Asset(
                 code = "CPF",
                 id = "CPF",
                 name = "CPF",
                 market = NASDAQ,
-                category = "POLICY",
                 status = com.beancounter.common.model.Status.Active
-            )
+            ).apply {
+                assetCategory =
+                    com.beancounter.common.model
+                        .AssetCategory("POLICY", "Retirement Fund")
+            }
+        assertThat(policyAsset.category).isEqualTo("Equity") // @JsonIgnore default survives
+        assertThat(policyAsset.assetCategory.id).isEqualTo("POLICY")
         val positions = Positions(portfolio)
         val position = positions.getOrCreate(policyAsset)
         position.quantityValues.purchased = BigDecimal("281000")


### PR DESCRIPTION
## Summary
- Follow-up to #930. That PR keyed the gain-zero short-circuit off `mktData.asset.category`, which is `@JsonIgnore` on the `Asset` model — cross-service callers always deserialise to the default `"Equity"`, so the POLICY branch never fired on kauri.
- Live diagnostic confirmed: Mary's CPF asset returns `assetCategory: { id: "POLICY", name: "Retirement Fund" }` from the API, but `moneyValues.PORTFOLIO.totalGain = -955.40` (and `BASE` matches) post-#930 deploy. TRADE pool was already zero because `MarketValue` hard-codes `rate=ONE` there.
- Switch the check to `mktData.asset.assetCategory.id`, the canonical field that survives JSON.
- Added a regression assertion: the test asset now reproduces the deserialised shape (`category == "Equity"` default, `assetCategory.id == "POLICY"`), so the #930 pattern would fail this test.

## Test plan
- [x] `./gradlew :svc-position:test --tests "com.beancounter.position.valuation.MarketValueTest"` — green
- [x] `./gradlew :svc-position:lintKotlin` — green
- [ ] Re-deploy bc-position, hit `/api/holdings/SGD` on Mary persona, assert `moneyValues.PORTFOLIO.totalGain == 0` and `Your Loss` is gone from the CPF holdings row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how POLICY assets are identified during market valuation calculations. These assets will continue to accurately report zero gain, even when market values differ from original cost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->