### PR TITLE
fix(trn,position): POLICY tradeCurrency = accountingType currency

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
@@ -101,14 +101,7 @@ class TrnInputMapper(
                 tradeAmount
             )
         val asset = getAsset(trnInput, existing)
-        val tradeCurrency =
-            if (trnInput.tradeCurrency.isEmpty()) {
-                asset.accountingType?.currency ?: asset.market.currency
-            } else {
-                currencyService.getCode(
-                    trnInput.tradeCurrency
-                )
-            }
+        val tradeCurrency = resolveTradeCurrency(asset, trnInput.tradeCurrency)
         val broker = getBroker(trnInput, existing)
         return Trn(
             id = existing?.id ?: keyGenUtils.id,
@@ -157,5 +150,33 @@ class TrnInputMapper(
     ): Asset {
         val asset = existing?.asset ?: assetFinder.find(trnInput.assetId!!)
         return asset
+    }
+
+    /**
+     * Composite policy assets (CPF today, ILP later) are denominated in a
+     * statutory currency carried on the asset's accountingType. The market
+     * is "PRIVATE" with a placeholder currency that must NOT leak into the
+     * trn — otherwise svc-position multiplies by the wrong FX rate when
+     * synthesising the PORTFOLIO / BASE buckets. Server-side override is
+     * the defense for any caller (CSV import, retry of an old payload, a
+     * client that forgot to set tradeCurrency correctly).
+     *
+     * For non-POLICY assets the historical behaviour stands: honour the
+     * caller's tradeCurrency when supplied, fall back to the asset's
+     * accounting/market currency otherwise.
+     */
+    private fun resolveTradeCurrency(
+        asset: Asset,
+        requestedCode: String
+    ): com.beancounter.common.model.Currency {
+        val accountingCurrency = asset.accountingType?.currency
+        if (asset.assetCategory.id == "POLICY" && accountingCurrency != null) {
+            return accountingCurrency
+        }
+        return if (requestedCode.isEmpty()) {
+            accountingCurrency ?: asset.market.currency
+        } else {
+            currencyService.getCode(requestedCode)
+        }
     }
 }

--- a/svc-data/src/main/resources/db/migration/V28__fix_policy_balance_trade_currency.sql
+++ b/svc-data/src/main/resources/db/migration/V28__fix_policy_balance_trade_currency.sql
@@ -1,0 +1,50 @@
+-- Backfill for the POLICY BALANCE tradeCurrency leak.
+--
+-- bc-view's link-composite flow hardcoded `currency = "USD"` as a placeholder
+-- on every standalone composite config. That value rode the BALANCE trn into
+-- svc-data, baking USD into `trn.trade_currency_code` for SGD-denominated CPF
+-- positions. svc-position then computed the PORTFOLIO and BASE buckets by
+-- multiplying the TRADE amount by an unintended FX rate (~1.28 USD->SGD for
+-- Mary's CPF), inflating market value by ~28% across /wealth and the plan
+-- projection's liquidAssets.
+--
+-- Server-side defense (TrnInputMapper) now overrides tradeCurrency from the
+-- asset's accountingType for POLICY assets, so no new wrong rows can land.
+-- This migration repairs any pre-existing rows by:
+--   1. Replacing trade_currency_code with the asset's accounting_type currency
+--      for POLICY BALANCE trns where the two diverge.
+--   2. Resetting trade_portfolio_rate / trade_base_rate to 1 when the now-
+--      corrected trade currency matches the portfolio currency / base. Cross-
+--      currency POLICY (none today, but ILP later) keeps its existing rates;
+--      operators recompute manually if a future case appears.
+
+WITH bad_trns AS (
+    SELECT t.id,
+           at.currency_code AS correct_currency,
+           p.currency_code  AS portfolio_currency,
+           p.base_code      AS portfolio_base
+    FROM trn t
+    JOIN asset a              ON a.id = t.asset_id
+    JOIN accounting_type at   ON at.id = a.accounting_type_id
+    JOIN portfolio p          ON p.id = t.portfolio_id
+    WHERE t.trn_type = 'BALANCE'
+      AND a.category = 'POLICY'
+      AND t.trade_currency_code <> at.currency_code
+)
+UPDATE trn t
+SET trade_currency_code  = bt.correct_currency,
+    trade_portfolio_rate = CASE WHEN bt.correct_currency = bt.portfolio_currency
+                                THEN 1
+                                ELSE t.trade_portfolio_rate END,
+    trade_base_rate      = CASE WHEN bt.correct_currency = bt.portfolio_base
+                                THEN 1
+                                ELSE t.trade_base_rate END,
+    trade_cash_rate      = CASE WHEN bt.correct_currency = bt.portfolio_currency
+                                THEN 1
+                                ELSE t.trade_cash_rate END,
+    cash_currency_code   = CASE WHEN t.cash_currency_code IS NOT NULL
+                                  AND t.cash_currency_code <> bt.correct_currency
+                                THEN bt.correct_currency
+                                ELSE t.cash_currency_code END
+FROM bad_trns bt
+WHERE t.id = bt.id;

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
@@ -4,7 +4,11 @@ import com.beancounter.client.FxService
 import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.AccountingType
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.Market
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.AssetKeyUtils.Companion.toKey
@@ -14,6 +18,7 @@ import com.beancounter.common.utils.PortfolioUtils.Companion.getPortfolio
 import com.beancounter.common.utils.TradeCalculator
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.NZD
+import com.beancounter.marketdata.Constants.Companion.SGD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.Constants.Companion.usdCashBalance
 import com.beancounter.marketdata.assets.AssetFinder
@@ -385,5 +390,58 @@ internal class TrnInputMapperTest {
                 commentsProp,
                 trnInput.comments
             )
+    }
+
+    @Test
+    fun `POLICY balance overrides client-supplied tradeCurrency with accountingType currency`() {
+        // CPF (POLICY) is statutory SGD. A buggy client sending tradeCurrency=USD
+        // for a SGD-denominated CPF asset must NOT bake USD into the trn —
+        // svc-position would otherwise multiply by USD->SGD on the PORTFOLIO
+        // bucket, inflating CPF balance by ~28% in net worth and projections.
+        val cpfAsset =
+            Asset(
+                code = "userId.CPF",
+                id = "asset-cpf",
+                name = "CPF",
+                market = Market("PRIVATE"),
+                category = "POLICY",
+                assetCategory =
+                    AssetCategory(
+                        id = "POLICY",
+                        name = "Retirement Fund"
+                    ),
+                accountingType =
+                    AccountingType(
+                        id = "policy-sgd",
+                        category = "POLICY",
+                        currency = SGD
+                    )
+            )
+        Mockito.`when`(assetFinder.find(cpfAsset.id)).thenReturn(cpfAsset)
+        Mockito.`when`(currencyService.getCode(SGD.code)).thenReturn(SGD)
+
+        val trnInput =
+            TrnInput(
+                CallerRef(portfolioId.uppercase(Locale.getDefault()), one, one),
+                assetId = cpfAsset.id,
+                trnType = TrnType.BALANCE,
+                tradeCurrency = USD.code, // wrong — client bug
+                quantity = BigDecimal("281000"),
+                price = ONE,
+                tradeAmount = BigDecimal("281000"),
+                tradeBaseRate = ONE,
+                tradeCashRate = ZERO,
+                tradePortfolioRate = ONE
+            )
+
+        val trnResponse =
+            trnInputMapper.convert(
+                portfolioService.find(portfolioId),
+                TrnRequest(portfolioId, listOf(trnInput))
+            )
+
+        assertThat(trnResponse).hasSize(1)
+        assertThat(trnResponse.first())
+            .hasFieldOrPropertyWithValue("tradeCurrency", SGD)
     }
 }

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
@@ -167,7 +167,12 @@ class PositionValuationService(
             val refMoneyValues =
                 position.getMoneyValues(
                     Position.In.PORTFOLIO,
-                    position.asset.market.currency
+                    // PORTFOLIO bucket denominates value in the portfolio's
+                    // reporting currency (mirrors MarketValue.value()). Using
+                    // asset.market.currency leaked the PRIVATE market's
+                    // placeholder USD into composite POLICY positions whose
+                    // accountingType is SGD, double-counting the FX rate.
+                    positions.portfolio.currency
                 )
             val tradeMoneyValues =
                 position.getMoneyValues(


### PR DESCRIPTION
## Summary

bc-view's link-composite flow hardcoded `currency: "USD"` as a placeholder. That value rode the BALANCE trn into svc-data, baking USD into `trn.trade_currency_code` for SGD-denominated CPF assets. svc-position then multiplied the TRADE amount by USD→SGD (~1.28) on the PORTFOLIO and BASE buckets, inflating CPF position market value by ~28% in `/wealth` and the plan projection's `liquidAssets`.

## Changes

- **svc-data `TrnInputMapper`** — extract `resolveTradeCurrency`. For POLICY assets, server-side override the client `tradeCurrency` to `asset.accountingType.currency`. Defense-in-depth against any caller (CSV import, retries, future clients).
- **svc-position `PositionValuationService`** — PORTFOLIO bucket fallback now uses `portfolio.currency` (matches `MarketValue.value()`) rather than `asset.market.currency`, which leaked the PRIVATE market's USD placeholder when the accumulator path skipped the regular FX rebuild.
- **Flyway V28** — backfill existing POLICY BALANCE trns whose `trade_currency_code` diverges from the asset's accountingType currency. Resets `trade_portfolio_rate` / `trade_base_rate` / `trade_cash_rate` to 1 when the corrected currency matches the portfolio's reporting / base currency (SGD CPF in an SGD portfolio is the common case).

## Companion PR

bc-view monowai/bc-view#800 — fixes the placeholder at the source so new trns land correct.

## Test plan

- [x] `TrnInputMapperTest`: POLICY BALANCE overrides client USD with accountingType SGD
- [x] All existing svc-data + svc-position tests still pass
- [ ] After deploy: run `V28` on kauri, verify `/wealth` shows CPF total at the accountingType currency (no FX inflation)
- [ ] After deploy: link a fresh CPF via the banner, verify trn payload has `tradeCurrency: "SGD"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed currency calculation for POLICY-type investments to use correct accounting currency.
  * Corrected historical data for POLICY balance transactions with incorrect currency codes.
  * Improved portfolio valuation accuracy by properly referencing portfolio currency instead of asset market currency.

* **Tests**
  * Added test coverage for POLICY asset currency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->