### PR TITLE
feat(allocation): emit composite liquid/non-liquid split

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/AllocationContracts.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/AllocationContracts.kt
@@ -19,7 +19,22 @@ data class AllocationData(
      * pensions linked into a portfolio via a BALANCE trn) so a single
      * holding doesn't get counted twice in plan totals.
      */
-    val heldAssetIds: Set<String> = emptySet()
+    val heldAssetIds: Set<String> = emptySet(),
+    /**
+     * Sum of composite-policy sub-account balances flagged liquid (CPF
+     * OA / SA / RA pre-55), in [currency]. Allows the projection engine
+     * to keep these balances in the spendable bucket while treating the
+     * locked portion as non-liquid — without re-running the per-asset
+     * sub-account rollup itself.
+     */
+    val compositeLiquid: BigDecimal = BigDecimal.ZERO,
+    /**
+     * Sum of composite-policy sub-account balances flagged non-liquid
+     * (CPF MA, future RA-post-55), in [currency]. The projection moves
+     * this amount from the spendable pot to the non-spendable bucket so
+     * the locked CPF balances are not drawn down alongside cash + ETFs.
+     */
+    val compositeNonLiquid: BigDecimal = BigDecimal.ZERO
 )
 
 /**

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
@@ -5,12 +5,16 @@ import com.beancounter.client.FxService
 import com.beancounter.common.contracts.AllocationData
 import com.beancounter.common.contracts.CategoryAllocation
 import com.beancounter.common.contracts.FxRequest
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
+import com.beancounter.position.composite.AssetConfigClient
+import com.beancounter.position.composite.PrivateAssetConfigDto
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -23,7 +27,8 @@ import java.math.RoundingMode
 @Service
 class AllocationService(
     private val tokenService: TokenService,
-    private val fxService: FxService
+    private val fxService: FxService,
+    private val assetConfigClient: AssetConfigClient
 ) {
     /**
      * Calculate allocation breakdown from positions.
@@ -86,6 +91,8 @@ class AllocationService(
                 .map { it.asset.id }
                 .toSet()
 
+        val (compositeLiquid, compositeNonLiquid) = compositeSplit(positions, valueIn)
+
         return AllocationData(
             cashAllocation = cashAllocation,
             equityAllocation = equityAllocation,
@@ -93,8 +100,78 @@ class AllocationService(
             totalValue = totalValue.setScale(2, RoundingMode.HALF_UP),
             currency = currency,
             categoryBreakdown = categoryBreakdown,
-            heldAssetIds = heldAssetIds
+            heldAssetIds = heldAssetIds,
+            compositeLiquid = compositeLiquid.setScale(2, RoundingMode.HALF_UP),
+            compositeNonLiquid = compositeNonLiquid.setScale(2, RoundingMode.HALF_UP)
         )
+    }
+
+    /**
+     * Splits the value of any composite-policy position (currently CPF —
+     * any position whose [Position.subAccounts] map is non-empty) into a
+     * liquid and non-liquid portion, in the requested valuation bucket's
+     * currency. The split is driven by the sub-account [liquid] flag on
+     * [com.beancounter.position.composite.SubAccountDto] — the same flag
+     * jar-common's [com.beancounter.common.composite.CompositeValuation]
+     * uses, so svc-position and svc-retire stay in lock-step.
+     *
+     * The position's bucket [MoneyValues.marketValue] is the truth for
+     * what the user sees; we apply the liquid/total ratio (derived from
+     * the asset config sub-account balances) to that figure. That keeps
+     * the FX conversion path identical to the rest of the allocation
+     * math — there is no second currency hop.
+     */
+    private fun compositeSplit(
+        positions: Positions,
+        valueIn: Position.In
+    ): Pair<BigDecimal, BigDecimal> {
+        var liquid = BigDecimal.ZERO
+        var nonLiquid = BigDecimal.ZERO
+        for (position in positions.positions.values) {
+            if (position.subAccounts.isEmpty()) continue
+            val marketValue = position.moneyValues[valueIn]?.marketValue ?: BigDecimal.ZERO
+            if (marketValue.signum() <= 0) continue
+            val config =
+                try {
+                    assetConfigClient.find(position.asset.id)
+                } catch (_: NotFoundException) {
+                    // Position has sub-accounts but no config — degrade
+                    // gracefully (treat all as liquid via the default
+                    // bucket logic upstream).
+                    continue
+                } catch (ex: BusinessException) {
+                    log.warn(
+                        "Composite split skipped for {}: {}",
+                        position.asset.id,
+                        ex.message
+                    )
+                    continue
+                }
+            val (liquidShare, nonLiquidShare) = splitMarketValue(config, marketValue)
+            liquid = liquid.add(liquidShare)
+            nonLiquid = nonLiquid.add(nonLiquidShare)
+        }
+        return liquid to nonLiquid
+    }
+
+    private fun splitMarketValue(
+        config: PrivateAssetConfigDto,
+        marketValue: BigDecimal
+    ): Pair<BigDecimal, BigDecimal> {
+        val total =
+            config.subAccounts
+                .fold(BigDecimal.ZERO) { acc, sa -> acc.add(sa.balance) }
+        if (total.signum() <= 0) return BigDecimal.ZERO to BigDecimal.ZERO
+        val liquidBalance =
+            config.subAccounts
+                .filter { it.liquid }
+                .fold(BigDecimal.ZERO) { acc, sa -> acc.add(sa.balance) }
+        val liquidShare =
+            marketValue
+                .multiply(liquidBalance)
+                .divide(total, 4, RoundingMode.HALF_UP)
+        val nonLiquidShare = marketValue.subtract(liquidShare)
+        return liquidShare to nonLiquidShare
     }
 
     private fun sumCategoryPercentage(

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/AllocationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/AllocationServiceTest.kt
@@ -5,12 +5,16 @@ import com.beancounter.client.FxService
 import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.FxRequest
 import com.beancounter.common.contracts.FxResponse
+import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.FxRate
 import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Totals
+import com.beancounter.position.composite.AssetConfigClient
+import com.beancounter.position.composite.PrivateAssetConfigDto
+import com.beancounter.position.composite.SubAccountDto
 import com.beancounter.position.utils.TestHelpers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -35,11 +39,14 @@ class AllocationServiceTest {
     @Mock
     private lateinit var fxService: FxService
 
+    @Mock
+    private lateinit var assetConfigClient: AssetConfigClient
+
     private lateinit var allocationService: AllocationService
 
     @BeforeEach
     fun setUp() {
-        allocationService = AllocationService(tokenService, fxService)
+        allocationService = AllocationService(tokenService, fxService, assetConfigClient)
     }
 
     @Test
@@ -139,5 +146,68 @@ class AllocationServiceTest {
                 .currency.code
         ).isEqualTo("USD")
         assertThat(result.totals[Position.In.PORTFOLIO]!!.marketValue).isEqualByComparingTo("1000")
+    }
+
+    @Test
+    fun `calculateAllocation splits composite position into liquid and non-liquid via subaccount flags`() {
+        val sgd = Currency("SGD")
+        val portfolio = TestHelpers.createTestPortfolio(currencyCode = "SGD", baseCurrency = "SGD")
+
+        val cpfAsset =
+            TestHelpers.createTestAsset(code = "userA.CPF", marketCode = "PRIVATE").apply {
+                assetCategory = AssetCategory(id = "POLICY", name = "Retirement Fund")
+            }
+        val cpf = Position(cpfAsset, portfolio)
+        cpf.subAccounts["OA"] = BigDecimal("145000")
+        cpf.subAccounts["SA"] = BigDecimal("78000")
+        cpf.subAccounts["MA"] = BigDecimal("58000")
+        cpf.moneyValues[Position.In.PORTFOLIO] =
+            MoneyValues(sgd).apply { marketValue = BigDecimal("281000") }
+
+        val positions = TestHelpers.createTestPositions(portfolio, listOf(cpf))
+        positions.totals[Position.In.PORTFOLIO] =
+            Totals(currency = sgd, marketValue = BigDecimal("281000"))
+
+        whenever(assetConfigClient.find(cpfAsset.id)).thenReturn(
+            PrivateAssetConfigDto(
+                assetId = cpfAsset.id,
+                policyType = "CPF",
+                currency = "SGD",
+                subAccounts =
+                    listOf(
+                        SubAccountDto(code = "OA", balance = BigDecimal("145000"), liquid = true),
+                        SubAccountDto(code = "SA", balance = BigDecimal("78000"), liquid = true),
+                        SubAccountDto(code = "MA", balance = BigDecimal("58000"), liquid = false)
+                    )
+            )
+        )
+
+        val data = allocationService.calculateAllocation(positions)
+
+        // 145k OA + 78k SA = 223k liquid; 58k MA non-liquid.
+        assertThat(data.compositeLiquid).isEqualByComparingTo("223000")
+        assertThat(data.compositeNonLiquid).isEqualByComparingTo("58000")
+        // Total unchanged — split is a refinement, not a re-count.
+        assertThat(data.totalValue).isEqualByComparingTo("281000")
+    }
+
+    @Test
+    fun `calculateAllocation skips composite lookup when position has no subAccounts`() {
+        val sgd = Currency("SGD")
+        val portfolio = TestHelpers.createTestPortfolio(currencyCode = "SGD", baseCurrency = "SGD")
+        val asset = TestHelpers.createTestAsset(code = "VOO", marketCode = "US")
+        val position = Position(asset, portfolio)
+        position.moneyValues[Position.In.PORTFOLIO] =
+            MoneyValues(sgd).apply { marketValue = BigDecimal("10000") }
+
+        val positions = TestHelpers.createTestPositions(portfolio, listOf(position))
+        positions.totals[Position.In.PORTFOLIO] =
+            Totals(currency = sgd, marketValue = BigDecimal("10000"))
+
+        val data = allocationService.calculateAllocation(positions)
+
+        assertThat(data.compositeLiquid).isEqualByComparingTo("0")
+        assertThat(data.compositeNonLiquid).isEqualByComparingTo("0")
+        verify(assetConfigClient, org.mockito.kotlin.never()).find(any())
     }
 }


### PR DESCRIPTION
## Summary

`AllocationData` now surfaces the composite-policy sub-account split: `compositeLiquid` (CPF OA / SA / RA pre-55) and `compositeNonLiquid` (CPF MA today, future RA-post-55). svc-position derives the split from the sub-account `liquid` flag on `AssetConfigClient` and applies the ratio to the position's bucket `marketValue`. `totalValue` is unchanged — the split is a refinement, not a re-count.

## Why

svc-position previously folded the entire composite balance (281k for Mary's CPF) into the liquid pool via `housingAllocation = 0`. svc-retire's `PlanAllocationService.fetch` then treated all 281k as spendable, so the projection grew CPF MA (locked-for-medical) and SA (annuitizes into CPF LIFE) for 15 years and drew them down during retirement — alongside the CPF LIFE annuity stream from the same balance.

## Consumer change (svc-retire)

[svc-retire PR](https://github.com/monowai/svc-retire/pull/...) — `PlanAllocationService.fetch` subtracts `compositeNonLiquid` from `liquidValue` and adds it to `housingValue`. The CPF MA 58k for Mary stops being spendable.

## Test plan

- [x] `AllocationServiceTest`: CPF position with OA/SA liquid + MA non-liquid → `compositeLiquid=223k`, `compositeNonLiquid=58k`
- [x] `AllocationServiceTest`: positions without sub-accounts skip the config lookup entirely
- [x] Full svc-position + svc-data + jar-common test suites pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Allocation calculations now separately track liquid (spendable) and non-liquid (non-spendable) portions of composite policy positions, providing enhanced visibility into available funds.

* **Tests**
  * Updated allocation tests to validate liquid vs non-liquid position splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->