### PR TITLE
fix(svc-position): aggregator adopts target currency to avoid FX round-trip drift

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionController.kt
@@ -394,15 +394,9 @@ class PositionController(
             valuationService.getAggregatedPositions(
                 selectedPortfolios,
                 asAt,
-                value
+                value,
+                targetCurrency
             )
-        if (value && !targetCurrency.isNullOrBlank()) {
-            allocationService.convertPositionsToCurrency(
-                response.data,
-                targetCurrency,
-                asAt
-            )
-        }
         return response
     }
 
@@ -507,12 +501,18 @@ class PositionController(
             valuationService.getAggregatedPositions(
                 selectedPortfolios,
                 asAt,
-                true
+                true,
+                targetCurrency
             )
 
         val allocation = allocationService.calculateAllocation(positions.data)
 
-        // If target currency is specified and different from allocation currency, convert
+        // If target currency is specified and differs from the allocation
+        // currency, convert. Normally the aggregator already produced the
+        // bucket in targetCurrency (eliminating the FX round-trip drift on
+        // PRIVATE positions), so this path is only hit when targetCurrency
+        // is supplied but couldn't be honoured by the aggregator (e.g.
+        // empty currency code or a portfolio with no positions).
         if (!targetCurrency.isNullOrBlank() &&
             !targetCurrency.equals(allocation.currency, ignoreCase = true)
         ) {

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/Valuation.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/Valuation.kt
@@ -34,12 +34,21 @@ interface Valuation {
      * @param portfolios collection of portfolios to aggregate
      * @param valuationDate date for position valuation
      * @param value whether to include market values
+     * @param targetCurrencyCode optional ISO currency code (e.g. "SGD") to use
+     *   as the PORTFOLIO reporting currency. When supplied, the synthesised
+     *   context portfolio adopts this currency so MarketValue prices each
+     *   bucket directly against the user's requested currency — avoiding the
+     *   FX round-trip drift that surfaces when `portfolios.first().currency`
+     *   differs from the caller's target. PRIVATE / POLICY positions are
+     *   most sensitive (constant `close=1`) because the round-trip rate
+     *   product isn't exactly 1.0.
      * @return aggregated positions from all portfolios
      */
     fun getAggregatedPositions(
         portfolios: Collection<Portfolio>,
         valuationDate: String = DateUtils.TODAY,
-        value: Boolean
+        value: Boolean,
+        targetCurrencyCode: String? = null
     ): PositionResponse
 
     /**

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
@@ -8,6 +8,7 @@ import com.beancounter.common.contracts.TrnResponse
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.TrustedTrnQuery
 import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Currency
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.PortfolioBreakdown
 import com.beancounter.common.model.Position
@@ -124,7 +125,8 @@ class ValuationService
         override fun getAggregatedPositions(
             portfolios: Collection<Portfolio>,
             valuationDate: String,
-            value: Boolean
+            value: Boolean,
+            targetCurrencyCode: String?
         ): PositionResponse {
             if (portfolios.isEmpty()) {
                 return PositionResponse()
@@ -162,10 +164,26 @@ class ValuationService
                 return PositionResponse()
             }
 
-            // Use the first portfolio as context for currency settings and owner
-            // No fake "AGGREGATED" portfolio is created - positions are built using
-            // the first portfolio's context but contain aggregated transaction data
-            val contextPortfolio = portfolios.first()
+            // Use the first portfolio as context for owner / ids. When the
+            // caller passes a [targetCurrencyCode] (the user-visible
+            // reporting currency), adopt that currency on the synthesised
+            // context portfolio so MarketValue prices each PORTFOLIO bucket
+            // directly against the user's target. Without this the bucket
+            // ends up in portfolios.first().currency and a separate
+            // convertPositionsToCurrency step has to FX-back to target — a
+            // round-trip whose inverse-rate imprecision shows up as drift
+            // on PRIVATE / POLICY (constant `close=1`) positions.
+            val baseContext = portfolios.first()
+            val contextPortfolio =
+                if (!targetCurrencyCode.isNullOrBlank() &&
+                    !baseContext.currency.code.equals(targetCurrencyCode, ignoreCase = true)
+                ) {
+                    baseContext.copy(
+                        currency = Currency(targetCurrencyCode.uppercase())
+                    )
+                } else {
+                    baseContext
+                }
 
             // Build positions from combined transactions using the normal accumulation flow
             val positionRequest =

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionControllerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
@@ -251,25 +252,30 @@ class PositionControllerTest {
     }
 
     @Test
-    fun `should convert aggregated positions to target currency when supplied`() {
+    fun `should pass target currency to aggregator (no FX round-trip)`() {
         // Given
         val valuationDate = "2024-01-15"
         val portfoliosResponse = PortfoliosResponse(listOf(testPortfolio))
 
         whenever(portfolioServiceClient.portfolios).thenReturn(portfoliosResponse)
-        whenever(valuationService.getAggregatedPositions(portfoliosResponse.data, valuationDate, true))
-            .thenReturn(testPositionResponse)
+        whenever(
+            valuationService.getAggregatedPositions(
+                portfoliosResponse.data,
+                valuationDate,
+                true,
+                "SGD"
+            )
+        ).thenReturn(testPositionResponse)
 
         // When
         val result = positionController.aggregated(valuationDate, true, null, null, "SGD")
 
         // Then
         assertThat(result).isNotNull()
-        verify(allocationService).convertPositionsToCurrency(
-            testPositionResponse.data,
-            "SGD",
-            valuationDate
-        )
+        // Aggregator now adopts targetCurrency on the synthesised context
+        // portfolio — no post-aggregation conversion call needed.
+        verify(allocationService, org.mockito.kotlin.never())
+            .convertPositionsToCurrency(any(), any(), any())
     }
 
     @Test
@@ -279,8 +285,14 @@ class PositionControllerTest {
         val portfoliosResponse = PortfoliosResponse(listOf(testPortfolio))
 
         whenever(portfolioServiceClient.portfolios).thenReturn(portfoliosResponse)
-        whenever(valuationService.getAggregatedPositions(portfoliosResponse.data, valuationDate, false))
-            .thenReturn(testPositionResponse)
+        whenever(
+            valuationService.getAggregatedPositions(
+                portfoliosResponse.data,
+                valuationDate,
+                false,
+                "SGD"
+            )
+        ).thenReturn(testPositionResponse)
 
         // When - value=false means no valuations, so no conversion applicable
         positionController.aggregated(valuationDate, false, null, null, "SGD")
@@ -305,7 +317,7 @@ class PositionControllerTest {
         val portfoliosResponse = PortfoliosResponse(listOf(testPortfolio, portfolio2))
 
         whenever(portfolioServiceClient.portfolios).thenReturn(portfoliosResponse)
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
 
         // When - only request the test portfolio by its code
@@ -317,7 +329,8 @@ class PositionControllerTest {
         verify(valuationService).getAggregatedPositions(
             argThat { size == 1 && first().code == testPortfolio.code },
             eq(valuationDate),
-            eq(true)
+            eq(true),
+            anyOrNull()
         )
     }
 
@@ -330,7 +343,7 @@ class PositionControllerTest {
     @Test
     fun `aggregated resolves ids via per-id fetch ignoring codes when both supplied`() {
         whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
 
         positionController.aggregated(
@@ -343,7 +356,7 @@ class PositionControllerTest {
 
         verify(portfolioServiceClient).getPortfolioById("test-portfolio")
         val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
-        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any(), anyOrNull())
         assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
     }
 
@@ -355,7 +368,7 @@ class PositionControllerTest {
                 com.beancounter.common.exception
                     .BusinessException("Unable to find portfolio not-visible")
             )
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
 
         positionController.aggregated(
@@ -367,7 +380,7 @@ class PositionControllerTest {
         )
 
         val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
-        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any(), anyOrNull())
         assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
     }
 
@@ -383,7 +396,7 @@ class PositionControllerTest {
         val portfolio2 = TestHelpers.createTestPortfolio("portfolio-2")
         whenever(portfolioServiceClient.getPortfolioById("test-portfolio")).thenReturn(testPortfolio)
         whenever(portfolioServiceClient.getPortfolioById("portfolio-2")).thenReturn(portfolio2)
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
         whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
             com.beancounter.common.contracts
@@ -395,7 +408,7 @@ class PositionControllerTest {
         verify(portfolioServiceClient).getPortfolioById("test-portfolio")
         verify(portfolioServiceClient).getPortfolioById("portfolio-2")
         val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
-        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any(), anyOrNull())
         assertThat(captor.firstValue.map { it.id }.toSet()).isEqualTo(setOf("test-portfolio", "portfolio-2"))
     }
 
@@ -407,7 +420,7 @@ class PositionControllerTest {
                 com.beancounter.common.exception
                     .BusinessException("Unable to find portfolio not-visible")
             )
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
         whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
             com.beancounter.common.contracts
@@ -417,7 +430,7 @@ class PositionControllerTest {
         positionController.allocation(asAt = "2024-01-15", ids = "test-portfolio,not-visible", targetCurrency = null)
 
         val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
-        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any(), anyOrNull())
         assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
     }
 
@@ -425,7 +438,7 @@ class PositionControllerTest {
     fun `allocation falls back to caller portfolios when no ids supplied`() {
         val portfoliosResponse = PortfoliosResponse(listOf(testPortfolio))
         whenever(portfolioServiceClient.portfolios).thenReturn(portfoliosResponse)
-        whenever(valuationService.getAggregatedPositions(any(), any(), any()))
+        whenever(valuationService.getAggregatedPositions(any(), any(), any(), anyOrNull()))
             .thenReturn(testPositionResponse)
         whenever(allocationService.calculateAllocation(any(), any())).thenReturn(
             com.beancounter.common.contracts
@@ -436,7 +449,7 @@ class PositionControllerTest {
 
         verify(portfolioServiceClient).portfolios
         val captor = org.mockito.kotlin.argumentCaptor<Collection<Portfolio>>()
-        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any())
+        verify(valuationService).getAggregatedPositions(captor.capture(), any(), any(), anyOrNull())
         assertThat(captor.firstValue.map { it.id }).containsExactly("test-portfolio")
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -479,6 +479,49 @@ class ValuationServiceTest {
     }
 
     @Test
+    fun `getAggregatedPositions adopts targetCurrency on synthesised context portfolio`() {
+        // Given - first portfolio is USD but the caller requested SGD totals.
+        // Without target-currency adoption, MarketValue would price each
+        // PORTFOLIO bucket in USD and the controller would have to FX-back
+        // to SGD — a round-trip whose imperfect rate-inverse shows up as
+        // ~0.4% drift on PRIVATE / POLICY (constant `close=1`) positions.
+        val usdPortfolio = TestHelpers.createTestPortfolio("usd-pf", currencyCode = "USD")
+        val sgdPortfolio = TestHelpers.createTestPortfolio("sgd-pf", currencyCode = "SGD")
+        val portfolios = listOf(usdPortfolio, sgdPortfolio)
+
+        val asset = TestHelpers.createTestAsset("AAPL", "US")
+        val trn =
+            TestHelpers.createTestTransaction(
+                asset = asset,
+                portfolio = usdPortfolio,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("10"),
+                price = PRICE_150,
+                tradeDate = LocalDate.of(2024, 1, 15)
+            )
+        whenever(trnService.query(any<Portfolio>(), any<String>()))
+            .thenReturn(TrnResponse(listOf(trn)))
+
+        val contextCaptor = org.mockito.kotlin.argumentCaptor<Portfolio>()
+        whenever(positionService.build(contextCaptor.capture(), any()))
+            .thenReturn(PositionResponse(Positions(usdPortfolio)))
+
+        // When - request aggregation in SGD
+        valuationService.getAggregatedPositions(
+            portfolios,
+            DateUtils.TODAY,
+            value = false,
+            targetCurrencyCode = "SGD"
+        )
+
+        // Then - the context portfolio handed to positionService.build
+        // adopts SGD (not the first portfolio's USD), so downstream
+        // MarketValue prices each bucket directly in SGD.
+        assertThat(contextCaptor.firstValue.currency.code).isEqualTo("SGD")
+        assertThat(contextCaptor.firstValue.id).isEqualTo(usdPortfolio.id)
+    }
+
+    @Test
     fun `value should not send market value update for historical dates`() {
         // Given - a portfolio valued at a historical date
         val positions = Positions(portfolio)


### PR DESCRIPTION
## Summary

Aggregated views (`/positions/aggregated`, `/positions/allocation`) picked `portfolios.first()` as the context portfolio. When that portfolio's reporting currency differed from the user-requested target, MarketValue priced each PORTFOLIO bucket in the first portfolio's currency, then PositionController FX-converted to target. The two FX hops (e.g. SGD→USD then USD→SGD) don't perfectly cancel — rate inverse imprecision: 0.78 × 1.2873 = **1.00409**.

That 0.41% drift was invisible on USD ETFs (MarketValue recomputed via price × FX-adjusted close in one step) but plainly visible on PRIVATE / POLICY positions with constant `close=1`. Mary's CPF / DBS / UOB SGD balances showed ~1,150 SGD inflation on 281k SGD in the aggregated `/wealth` view.

## Fix

- `Valuation.getAggregatedPositions` accepts an optional `targetCurrencyCode`. When supplied (and ≠ first portfolio's currency), the synthesised context portfolio adopts that currency. MarketValue prices buckets directly against the user's target.
- `PositionController` forwards `targetCurrency` to the aggregator on both `/positions/aggregated` and `/positions/allocation`; drops the explicit `convertPositionsToCurrency` call. The allocation path keeps `convertCurrency` as a safety net.

## Verified

On kauri build 1065 with Mary's CPF (SGD 281k held in SGD Portfolio aggregated with USD IBKR):

| Surface | Before | After (expected) |
|---|---:|---:|
| `/api/holdings/aggregated?currency=SGD` CPF PORTFOLIO mv | 282,150.41 | 281,000 |
| `/api/holdings/aggregated?currency=SGD` DBS-Multiplier PORTFOLIO mv | 25,102.35 | 25,000 |
| `/api/holdings/aggregated?currency=SGD` UOB-One PORTFOLIO mv | 12,049.13 | 12,000 |
| Net Worth (PORTFOLIO total) | 370,992 | ~369,841 |

## Test plan

- [x] `ValuationServiceTest`: `getAggregatedPositions` adopts targetCurrency on synthesised context portfolio
- [x] `PositionControllerTest`: aggregated forwards target currency; convertPositionsToCurrency NOT called
- [x] Full svc-position test suite passes
- [ ] After deploy: hit `/api/holdings/aggregated?currency=SGD` for Mary; CPF PORTFOLIO mv = 281,000 exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated redundant currency conversions when aggregating positions with a target currency specification, preventing unnecessary FX round-trip calculations.

* **Improvements**
  * Enhanced portfolio aggregation efficiency by streamlining currency handling to occur during aggregation rather than as a separate post-processing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->