### PR TITLE
fix(allocation): FX-scale composite split fields in convertCurrency

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/AllocationService.kt
@@ -233,7 +233,19 @@ class AllocationService(
         return allocation.copy(
             totalValue = convertedTotalValue,
             currency = targetCurrency,
-            categoryBreakdown = convertedBreakdown
+            categoryBreakdown = convertedBreakdown,
+            // FX-scale the composite-split fields too — otherwise a SGD-
+            // labelled response carries USD-magnitude composite values
+            // (USD 173,940 → 45,240 on Mary's CPF), undercounting the
+            // PORTFOLIO bucket by the SGD/USD ratio downstream.
+            compositeLiquid =
+                allocation.compositeLiquid
+                    .multiply(rate)
+                    .setScale(2, RoundingMode.HALF_UP),
+            compositeNonLiquid =
+                allocation.compositeNonLiquid
+                    .multiply(rate)
+                    .setScale(2, RoundingMode.HALF_UP)
         )
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/AllocationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/AllocationServiceTest.kt
@@ -2,6 +2,7 @@ package com.beancounter.position.service
 
 import com.beancounter.auth.TokenService
 import com.beancounter.client.FxService
+import com.beancounter.common.contracts.AllocationData
 import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.FxRequest
 import com.beancounter.common.contracts.FxResponse
@@ -209,5 +210,37 @@ class AllocationServiceTest {
         assertThat(data.compositeLiquid).isEqualByComparingTo("0")
         assertThat(data.compositeNonLiquid).isEqualByComparingTo("0")
         verify(assetConfigClient, org.mockito.kotlin.never()).find(any())
+    }
+
+    @Test
+    fun `convertCurrency FX-scales compositeLiquid and compositeNonLiquid`() {
+        // Allocation originally USD; user requests SGD. The composite-split
+        // fields must FX-scale along with totalValue / categoryBreakdown —
+        // otherwise downstream displays a SGD-labelled response with USD-
+        // magnitude composite numbers, surfacing a ~22% understatement of
+        // the CPF buckets on Mary's wealth tile.
+        val usdAllocation =
+            AllocationData(
+                totalValue = BigDecimal("288194.11"),
+                currency = "USD",
+                compositeLiquid = BigDecimal("173940.00"),
+                compositeNonLiquid = BigDecimal("45240.00")
+            )
+
+        val pair = IsoCurrencyPair(from = "USD", to = "SGD")
+        val rate = BigDecimal("1.2873")
+        whenever(tokenService.bearerToken).thenReturn("bearer")
+        whenever(fxService.getRates(any<FxRequest>(), eq("bearer"))).thenReturn(
+            FxResponse(
+                FxPairResults(rates = mapOf(pair to FxRate(from = Currency("USD"), to = Currency("SGD"), rate = rate)))
+            )
+        )
+
+        val result = allocationService.convertCurrency(usdAllocation, "SGD", fxService, "2024-01-15")
+
+        assertThat(result.currency).isEqualTo("SGD")
+        assertThat(result.totalValue).isEqualByComparingTo(BigDecimal("370992.28"))
+        assertThat(result.compositeLiquid).isEqualByComparingTo(BigDecimal("223912.96"))
+        assertThat(result.compositeNonLiquid).isEqualByComparingTo(BigDecimal("58237.45"))
     }
 }


### PR DESCRIPTION
## Summary

`AllocationService.convertCurrency` built the FX-converted response via a partial data-class `copy()` listing `totalValue`, `currency` and `categoryBreakdown`. `compositeLiquid` / `compositeNonLiquid` (added in #933) fell through Kotlin's default-copy semantics — preserving source-currency magnitudes while the bucket was relabelled with the target currency.

Result: a SGD-labelled allocation response carried USD-magnitude composite figures. Mary's case: `compositeLiquid: 173,940`, `compositeNonLiquid: 45,240` (USD-magnitude), should have been `~223,913` and `~58,237` after SGD conversion. ~22% undercount.

## Fix

Multiply both composite-split fields by the FX rate in `convertCurrency`, alongside the existing `totalValue` and category-marketValue conversions.

## Test plan

- [x] `AllocationServiceTest`: convertCurrency on AllocationData with composite fields → FX-scaled correctly
- [x] Existing convertCurrency consumers unaffected (no test regressions)
- [ ] After deploy: `/api/holdings/allocation?currency=SGD` for Mary echoes `currency: "SGD"` with compositeLiquid/compositeNonLiquid in SGD magnitude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced currency conversion to include all composite monetary fields, ensuring complete consistency when converting allocations between different currencies.

* **Tests**
  * Added test coverage verifying currency conversion accuracy for composite monetary fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->