### PR TITLE
fix(svc-position): BALANCE cost pinned at first snapshot so gain emerges

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
@@ -78,6 +78,10 @@ class BalanceBehaviour(
                 trn.portfolio,
                 position
             )
+        // Capture the prior cost basis before CashCost.value resets it; a
+        // non-zero prior means a previous BALANCE already pinned cost and
+        // subsequent snapshots must leave it alone so gain can emerge.
+        val priorCostBasis = moneyValues.costBasis
         cashCost.value(
             moneyValues,
             position,
@@ -88,22 +92,29 @@ class BalanceBehaviour(
             setSnapshotCost(
                 moneyValues,
                 trn.tradeAmount,
-                rate
+                rate,
+                priorCostBasis
             )
         }
     }
 
     /**
-     * Non-cash BALANCE = snapshot of accumulated contributions. Cost basis
-     * tracks the snapshot amount so MV - cost = 0 by construction; this
-     * stops pension/CPF positions reporting a phantom 100% gain (the prior
-     * code reused CashCost which keeps cost at zero for cash semantics).
+     * Non-cash BALANCE: pin cost basis at the first snapshot ("principal")
+     * and leave it alone on subsequent snapshots so MV - cost surfaces real
+     * unrealised gain. First snapshot still sets cost = MV (gain = 0) so a
+     * freshly linked CPF/policy position doesn't report a phantom 100% gain.
      */
     private fun setSnapshotCost(
         moneyValues: MoneyValues,
         tradeAmount: BigDecimal,
-        rate: BigDecimal
+        rate: BigDecimal,
+        priorCostBasis: BigDecimal
     ) {
+        if (priorCostBasis.signum() != 0) {
+            moneyValues.costBasis = priorCostBasis
+            moneyValues.costValue = priorCostBasis
+            return
+        }
         val amount = MathUtils.multiply(tradeAmount, rate) ?: return
         moneyValues.costBasis = amount.abs()
         moneyValues.costValue = amount.abs()

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -154,6 +154,57 @@ class BalanceBehaviourTest {
     }
 
     @Test
+    fun `second BALANCE leaves cost pinned at first snapshot so gain emerges`() {
+        // First BALANCE establishes the cost basis (initial snapshot acts as
+        // the "principal"). A later BALANCE only moves the market value
+        // (quantity * price) so unrealised gain = MV - first-snapshot cost.
+        // Without this, every snapshot rewrites cost = MV and gain stays 0.
+        val portfolio =
+            Portfolio(
+                Constants.TEST,
+                currency = SGD,
+                base = SGD
+            )
+        val cpfAsset =
+            Asset(
+                code = RUBY_CPF,
+                id = RUBY_CPF,
+                name = "Ruby CPF",
+                market = Market("PRIVATE"),
+                priceSymbol = RUBY_CPF,
+                category = AssetCategory.POLICY
+            )
+        val firstBalance = BigDecimal("250000.00")
+        val secondBalance = BigDecimal("260000.00")
+        val positions = Positions(portfolio)
+
+        fun balanceTrn(qty: BigDecimal) =
+            Trn(
+                trnType = TrnType.BALANCE,
+                asset = cpfAsset,
+                quantity = qty,
+                tradeAmount = qty,
+                cashCurrency = SGD,
+                tradeCurrency = SGD,
+                tradeCashRate = BigDecimal.ONE,
+                tradeBaseRate = BigDecimal.ONE,
+                tradePortfolioRate = BigDecimal.ONE,
+                portfolio = portfolio
+            )
+
+        accumulator.accumulate(balanceTrn(firstBalance), positions)
+        val position = accumulator.accumulate(balanceTrn(secondBalance), positions)
+
+        assertThat(position.quantityValues.purchased).isEqualByComparingTo(secondBalance)
+        assertThat(position.getMoneyValues(Position.In.PORTFOLIO))
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, firstBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, firstBalance)
+        assertThat(position.getMoneyValues(Position.In.BASE))
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, firstBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, firstBalance)
+    }
+
+    @Test
     fun `BALANCE with subAccounts captures per-bucket snapshot on position`() {
         // Composite-policy BALANCE (CPF, ILP, generic pension) carries a
         // sub-account map alongside the total. The accumulator must surface


### PR DESCRIPTION
## Summary
- `BalanceBehaviour` rewrote `costBasis = MV` on every BALANCE trn, so any subsequent snapshot (CPF balance update, RE revaluation, ILP NAV refresh) reported zero gain/loss. The original phantom-100%-gain fix overcorrected.
- Capture the prior `costBasis` before `CashCost.value` resets it. Only set cost = MV on the first BALANCE (`priorCostBasis.signum() == 0`). Later snapshots leave cost pinned, so `MV − cost` surfaces real unrealised gain. First snapshot still reports gain = 0 to avoid the phantom 100% gain on freshly-linked policy/CPF positions.
- Companion to bc-view #811 ("Set Balance" now posts BALANCE trn).

## Test plan
- [x] `./gradlew :svc-position:test --tests BalanceBehaviourTest` — new test covers two-snapshot case
- [x] `./gradlew testSmart`
- [x] `./gradlew formatKotlin lintKotlin`
- [ ] Post-deploy: change CPF balance via "Set Balance" → holdings shows non-zero gain delta vs prior snapshot
- [ ] RE asset revaluation → gain/loss reflects new MV vs original cost basis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed position cost basis preservation when balance snapshots are re-applied, ensuring gain calculations are accurate as position quantities change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->