### PR TITLE
fix(svc-position): POLICY gain emerges after cost basis is pinned

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
@@ -111,11 +111,15 @@ class MarketValue(
             moneyValues.unrealisedGain = BigDecimal.ZERO // moneyValues.marketValue.subtract(moneyValues.costBasis)
             moneyValues.totalGain = BigDecimal.ZERO
             // moneyValues.realisedGain.add(moneyValues.unrealisedGain) // moneyValues.marketValue
-        } else if (mktData.asset.assetCategory.id == "POLICY") {
-            // Composite / pension assets (CPF, ILP, life policies) are balance
-            // snapshots, not traded positions. Book = current market by
-            // construction so per-pool FX rate drift on the snapshot DEPOSIT
-            // can't surface as a phantom gain/loss.
+        } else if (mktData.asset.assetCategory.id == "POLICY" &&
+            moneyValues.costBasis.signum() == 0
+        ) {
+            // Legacy composite/pension positions reached via DEPOSIT trns
+            // carry no cost basis (CashCost cost-tracking is disabled), so a
+            // straight MV-vs-cost calc would print a phantom 100% gain. Pin
+            // cost = MV for that case only. BalanceBehaviour pins cost on the
+            // first BALANCE snapshot, so subsequent snapshots fall through to
+            // gains.value below and the real gain/loss surfaces.
             moneyValues.costBasis = moneyValues.marketValue
             moneyValues.costValue = moneyValues.marketValue
             moneyValues.realisedGain = BigDecimal.ZERO

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
@@ -333,15 +333,12 @@ internal class MarketValueTest {
     }
 
     @Test
-    fun `POLICY assets report zero gain even when snapshot cost drifts from market value`() {
-        // Mirror the CPF/pension flow: snapshot DEPOSIT seeds cost basis, then
-        // composite valuation feeds the runtime balance. Per-pool FX drift
-        // on the snapshot rate would otherwise show as Your Loss on the
-        // holdings page (kauri bug: -955.40 on Mary's 281,000 SGD CPF).
-        // Reproduce the deserialized-Asset shape from a cross-service call:
-        // the @JsonIgnore `category` field stays at its default ("Equity"),
-        // but `assetCategory.id` survives JSON → that is the canonical
-        // category source MarketValue must consult.
+    fun `POLICY assets with no prior cost basis report zero gain`() {
+        // Legacy DEPOSIT-only path: CashCost cost-tracking is disabled so the
+        // accumulator leaves costBasis at zero. Without this override the
+        // valuator would print a phantom 100% gain. BalanceBehaviour-driven
+        // positions now pin cost on the first snapshot — see the separate
+        // `gain emerges` test for that path.
         val policyAsset =
             Asset(
                 code = "CPF",
@@ -359,14 +356,7 @@ internal class MarketValueTest {
         val positions = Positions(portfolio)
         val position = positions.getOrCreate(policyAsset)
         position.quantityValues.purchased = BigDecimal("281000")
-
-        // Snapshot cost recorded at trn time (slightly off the runtime price)
-        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { pool ->
-            val moneyValues = position.getMoneyValues(pool, policyAsset.market.currency)
-            moneyValues.costBasis = BigDecimal("360635.40")
-            moneyValues.costValue = BigDecimal("360635.40")
-            moneyValues.purchases = BigDecimal("360635.40")
-        }
+        // costBasis intentionally left at zero — simulates legacy DEPOSIT flow.
 
         val marketData = MarketData(policyAsset, close = BigDecimal("1.28"))
         val fxRateMap = getRates(portfolio, policyAsset, BigDecimal.ONE)
@@ -380,6 +370,46 @@ internal class MarketValueTest {
             assertThat(moneyValues.realisedGain).isEqualByComparingTo(BigDecimal.ZERO)
             assertThat(moneyValues.costValue).isEqualByComparingTo(moneyValues.marketValue)
             assertThat(moneyValues.costBasis).isEqualByComparingTo(moneyValues.marketValue)
+        }
+    }
+
+    @Test
+    fun `POLICY assets surface gain when market value exceeds pinned cost basis`() {
+        // BalanceBehaviour-driven path: prior BALANCE trn pinned cost at the
+        // first snapshot. A later snapshot at a higher quantity should report
+        // unrealisedGain = MV - costBasis instead of being silently zeroed.
+        val policyAsset =
+            Asset(
+                code = "CPF",
+                id = "CPF",
+                name = "CPF",
+                market = NASDAQ,
+                status = com.beancounter.common.model.Status.Active
+            ).apply {
+                assetCategory =
+                    com.beancounter.common.model
+                        .AssetCategory("POLICY", "Retirement Fund")
+            }
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(policyAsset)
+        val pinnedCost = BigDecimal("276000")
+        position.quantityValues.purchased = BigDecimal("291000")
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { pool ->
+            val moneyValues = position.getMoneyValues(pool, policyAsset.market.currency)
+            moneyValues.costBasis = pinnedCost
+            moneyValues.costValue = pinnedCost
+        }
+
+        val marketData = MarketData(policyAsset, close = BigDecimal.ONE)
+        val fxRateMap = getRates(portfolio, policyAsset, BigDecimal.ONE)
+
+        MarketValue(Gains()).value(positions, marketData, fxRateMap)
+
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { pool ->
+            val moneyValues = position.getMoneyValues(pool, policyAsset.market.currency)
+            assertThat(moneyValues.marketValue).isEqualByComparingTo(BigDecimal("291000"))
+            assertThat(moneyValues.costBasis).isEqualByComparingTo(pinnedCost)
+            assertThat(moneyValues.unrealisedGain).isEqualByComparingTo(BigDecimal("15000"))
         }
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #936. After that fix, `BalanceBehaviour` correctly pins cost on the first BALANCE snapshot, but `MarketValue.value`'s POLICY branch unconditionally rewrote `costBasis = marketValue` at valuation time — so gain still printed as zero on CPF after a Set Balance change. Verified on kauri with Mary's CPF (286k → 291k snapshot, profit stayed $0).

Gate the override on `costBasis == 0` so:
- Legacy DEPOSIT-only positions keep the phantom-100%-gain protection (CashCost disables cost tracking → costBasis stays at 0).
- BalanceBehaviour-driven positions fall through to `gains.value` and `unrealisedGain` surfaces as `MV − pinned cost`.

The existing FX-drift regression test is split:
- `POLICY assets with no prior cost basis report zero gain` — legacy DEPOSIT path.
- `POLICY assets surface gain when market value exceeds pinned cost basis` — BALANCE-trn path (`cost=276k`, `MV=291k`, expects `unrealisedGain=15k`).

## Test plan
- [x] `./gradlew :svc-position:test --tests MarketValueTest --tests BalanceBehaviourTest`
- [x] `./gradlew testSmart formatKotlin lintKotlin`
- [ ] Post-deploy: change Mary's CPF via Set Balance → "Your Profit" line on the holdings card reflects MV − first-snapshot cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected valuation calculations for pension/legacy assets. Positions with an established cost basis now accurately compute and display realized and unrealized gains instead of applying legacy composite valuation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->