### PR TITLE
fix(svc-position): valuation schedule fires after price-refresh window

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioValuationSchedule.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioValuationSchedule.kt
@@ -18,8 +18,11 @@ import java.time.LocalDateTime
 /**
  * Scheduled task to value all portfolios with current market prices.
  *
- * Runs on schedule (default: every 10 min, 5-7 AM Tue-Sat) and values
- * all portfolios to ensure they have up-to-date market valuations.
+ * Runs on schedule (default: 18:30 SGT Tue-Sat — after bc-data's
+ * 07:00-18:00 SGT price-refresh window) and values all portfolios so
+ * they have up-to-date market valuations. Firing earlier (e.g. pre
+ * Asia open) leaves gainOnDay=0 for Asia/Pacific positions because
+ * previousClose isn't in market_data yet.
  *
  * For each portfolio valued:
  * 1. Fetches latest prices for all assets
@@ -36,7 +39,7 @@ class PortfolioValuationSchedule(
     private val portfolioServiceClient: PortfolioServiceClient,
     private val valuationService: Valuation,
     private val dateUtils: DateUtils,
-    @Value("\${valuation.schedule:0 0/10 5-7 * * Tue-Sat}") private val schedule: String
+    @Value("\${valuation.schedule:0 30 18 * * Tue-Sat}") private val schedule: String
 ) {
     private var loginService: LoginService? = null
     private val log = LoggerFactory.getLogger(PortfolioValuationSchedule::class.java)
@@ -56,7 +59,7 @@ class PortfolioValuationSchedule(
 
     @SentryTransaction(operation = "scheduled", name = "PortfolioValuationSchedule.valuePortfolios")
     @Scheduled(
-        cron = "\${valuation.schedule:0 0/10 5-7 * * Tue-Sat}",
+        cron = "\${valuation.schedule:0 30 18 * * Tue-Sat}",
         zone = "#{@scheduleZone}"
     )
     fun valuePortfolios() {

--- a/svc-position/src/main/kotlin/com/beancounter/position/schedule/PositionScheduleConfig.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/schedule/PositionScheduleConfig.kt
@@ -31,7 +31,7 @@ class PositionScheduleConfig(
 
     @Bean
     fun valuationSchedule(
-        @Value("\${valuation.schedule:0 0/10 5-7 * * Tue-Sat}") schedule: String
+        @Value("\${valuation.schedule:0 30 18 * * Tue-Sat}") schedule: String
     ): String {
         log.info(
             "VALUATION_SCHEDULE: {}, BEANCOUNTER_ZONE: {}",

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -8,11 +8,14 @@ server:
     min-response-size: 1024
 
 # Portfolio valuation scheduling (disabled by default for local dev)
-# In production (kauri), runs every 10 mins from 5-7 AM SGT after US market close
+# Single daily run at 18:30 SGT, after bc-data's price-refresh window
+# (07:00–18:00 SGT). Running earlier (e.g. pre-Asia-open) makes
+# gainOnDay fall back to 0 for Asia/Pacific positions because
+# previousClose isn't yet in market_data.
 schedule:
   enabled: false
 valuation:
-  schedule: "0 0/10 5-7 * * Tue-Sat"
+  schedule: "0 30 18 * * Tue-Sat"
 
 springdoc:
   use-management-port: true


### PR DESCRIPTION
## Summary
- Default cron now `0 30 18 * * Tue-Sat` (18:30 SGT) instead of pre-Asia-open.
- Earlier firing ran before bc-data's 07:00–18:00 SGT price refresh, so `previousClose` wasn't in market_data yet → `MarketValue` set `gainOnDay = 0` for any position whose price refreshed later (Asia/Pacific holdings: NZD/SGD/WISE/MINTOS/PROP).
- Updates `application.yml`, both `@Value` defaults (`PortfolioValuationSchedule`, `PositionScheduleConfig`), and the class-doc.
- Companion kauri override already shipped via `bc-deploy` (`VALUATION_SCHEDULE: "0 30 18 * * Tue-Sat"`).

## Test plan
- [ ] Existing `PortfolioValuationScheduleTest` still passes (cron parsing).
- [ ] After deploy, confirm `c.b.p.s.PortfolioValuationSchedule` log line fires once at 18:30 SGT Tue-Sat.
- [ ] Spot-check a portfolio with Asia holdings: `gainOnDay` is non-zero on the next trading day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Portfolio valuation schedule updated to run daily at 6:30 PM SGT (Tue–Sat) instead of every 10 minutes during morning hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->