### PR TITLE
fix(svc-data): auto-settle uses findOrNull on stream-consumer thread (DATA-4Z)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
@@ -59,13 +59,18 @@ class CashAutoSettleService(
                 ?: return AutoSettleResult()
         if (masterId == trade.portfolio.id) return AutoSettleResult()
 
+        // findOrNull (not find) — stream-consumer threads have no JWT, and
+        // `find` calls `canView` which throws via `systemUserService.getOrThrow()`.
+        // That exception used to be swallowed by `runCatching`, but the outer
+        // `TrnService.save` `@Transactional` had already been marked
+        // rollback-only, so the commit blew up with UnexpectedRollbackException
+        // (DATA-4Z). The auto-settle path is system-internal — owner-scope
+        // is enforced upstream when the trade itself is saved.
         val master =
-            runCatching { portfolioService.find(masterId) }
-                .getOrElse {
-                    return AutoSettleResult(
-                        warnings = listOf("Cash portfolio $masterId not found; auto-settle skipped")
-                    )
-                }
+            portfolioService.findOrNull(masterId)
+                ?: return AutoSettleResult(
+                    warnings = listOf("Cash portfolio $masterId not found; auto-settle skipped")
+                )
 
         val isDebit = trade.trnType in cashDebitTypes
         val ccy = trade.cashCurrency?.code ?: cashAsset.market.currency.code

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -410,6 +411,50 @@ class CashAutoSettleServiceTest {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             trnService.unsettle(buy.id)
         }
+    }
+
+    /**
+     * Regression for DATA-4Z: stream-consumer threads (trnEventConsumer,
+     * csvImportConsumer) have no JWT in scope. When auto-settle resolved
+     * the funding portfolio via [PortfolioService.find], `canView` invoked
+     * `systemUserService.getOrThrow()` which threw inside the outer
+     * `TrnService.save` `@Transactional`. The exception was caught by a
+     * `runCatching` block, but the transaction stayed marked rollback-only,
+     * so the outer commit blew up with `UnexpectedRollbackException` and
+     * the message rebounded forever via the AMQP retry loop.
+     */
+    @Test
+    fun `auto-settle resolves master without JWT (stream consumer path)`() {
+        // Save BUY in invest portfolio after CLEARING the security context —
+        // simulates the stream-consumer thread that has no JWT.
+        SecurityContextHolder.clearContext()
+        val buy =
+            trnService
+                .save(
+                    invest,
+                    TrnRequest(
+                        invest.id,
+                        listOf(
+                            TrnInput(
+                                assetId = aaplAsset.id,
+                                cashAssetId = usdCashAsset.id,
+                                trnType = TrnType.BUY,
+                                quantity = BigDecimal("1"),
+                                price = BigDecimal("750"),
+                                tradeAmount = BigDecimal("750"),
+                                tradeCurrency = "USD",
+                                cashCurrency = "USD",
+                                cashAmount = BigDecimal("-750"),
+                                tradeCashRate = BigDecimal.ONE,
+                                tradeDate = LocalDate.now(),
+                                status = TrnStatus.SETTLED
+                            )
+                        )
+                    )
+                ).single()
+
+        val siblings = findAutoSiblings(buy)
+        assertThat(siblings).hasSize(2)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `CashAutoSettleService.emitCompensatingTransfer` resolved the funding portfolio via `PortfolioService.find`, whose `canView` calls `systemUserService.getOrThrow()`. Stream-consumer threads (`trnEventConsumer` / `csvImportConsumer`) carry no JWT → `getOrThrow` threw inside the outer `TrnService.save` `@Transactional`. `runCatching` swallowed the exception, but Spring had already marked the tx rollback-only → outer commit blew up with `UnexpectedRollbackException` and AMQP retried until the redelivery limit.
- Switch to `findOrNull` (system-internal lookup, skips `canView`) and return a "not found" warning on null. Owner-scope is enforced upstream when the trade itself is saved.
- Sentry: `DATA-4Z`, 84 events Jun 4–5.

## Test plan
- [x] Red test (new): `auto-settle resolves master without JWT (stream consumer path)` — saves a BUY with `SecurityContextHolder.clearContext()` and asserts the W+D pair is emitted. Reproduces `UnexpectedRollbackException` on `main`, passes after fix.
- [x] All other `CashAutoSettleServiceTest` scenarios still pass.
- [ ] After deploy, monitor `bc-trn-event-demo.bc-data` queue + Sentry `DATA-4Z` for fresh events.

Fixes DATA-4Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cash auto-settle reliability by refining master portfolio resolution logic to reduce potential transactional rollback failures in certain scenarios.

* **Tests**
  * Added regression test to verify auto-settle compensating transactions function correctly in stream consumer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->