### PR TITLE
feat(svc-position): event-driven portfolio revaluation ~10 min after price refresh

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/CacheInvalidationConsumer.kt
@@ -2,7 +2,9 @@ package com.beancounter.position.cache
 
 import com.beancounter.common.contracts.CacheChangeType
 import com.beancounter.common.contracts.CacheInvalidationEvent
+import com.beancounter.position.schedule.PortfolioRevaluationTrigger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.dao.DataAccessException
@@ -12,6 +14,18 @@ import java.util.function.Consumer
 class CacheInvalidationConsumer(
     private val cacheService: PerformanceCacheService
 ) {
+    /**
+     * Event-driven revaluation trigger, present only when
+     * `revaluation.trigger.enabled=true`. Optional so unit tests and the
+     * local dev profile don't have to wire it.
+     */
+    private var revaluationTrigger: PortfolioRevaluationTrigger? = null
+
+    @Autowired(required = false)
+    fun setRevaluationTrigger(trigger: PortfolioRevaluationTrigger?) {
+        this.revaluationTrigger = trigger
+    }
+
     @Bean
     fun performanceCacheInvalidation(): Consumer<CacheInvalidationEvent> =
         Consumer { event ->
@@ -26,6 +40,11 @@ class CacheInvalidationConsumer(
                     }
                     CacheChangeType.PRICE, CacheChangeType.FX -> {
                         cacheService.invalidateOnDate(event.fromDate)
+                        // Debounced trigger: collapses a burst of refreshes into one
+                        // revaluation ~10 min after the last event in the burst.
+                        revaluationTrigger?.scheduleRevaluation(
+                            reason = "cache:${event.changeType}"
+                        )
                     }
                     // Deep price-history backfill — any portfolio holding the
                     // asset may need to recompute from fromDate onwards. We

--- a/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioRevaluationTrigger.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioRevaluationTrigger.kt
@@ -1,0 +1,93 @@
+package com.beancounter.position.schedule
+
+import jakarta.annotation.PreDestroy
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Debounced revaluation trigger. Cache-invalidation events (PRICE / FX)
+ * arrive from bc-data each time a price refresh completes; rather than
+ * revalue every batch, we coalesce arrivals into a single run scheduled
+ * `revaluation.trigger.debounce` after the most recent event (default
+ * PT10M). A burst of refreshes therefore yields one revaluation ~10 min
+ * after the burst settles.
+ *
+ * The actual loop is delegated to [PortfolioRevaluator], which also holds
+ * a single-flight lock so the cron and the trigger can't double-run.
+ */
+@Service
+@ConditionalOnProperty(
+    value = ["revaluation.trigger.enabled"],
+    havingValue = "true",
+    matchIfMissing = false
+)
+class PortfolioRevaluationTrigger(
+    private val revaluator: PortfolioRevaluator,
+    @Value("\${revaluation.trigger.debounce:PT10M}") private val debounce: Duration,
+    taskScheduler: TaskScheduler? = null
+) {
+    /**
+     * Use the injected scheduler when one is on the classpath (kauri /
+     * Spring Boot's auto-configured `ThreadPoolTaskScheduler`); otherwise
+     * own a minimal one so the trigger works regardless of whether
+     * `@EnableScheduling` is active in this profile.
+     */
+    private val scheduler: TaskScheduler = taskScheduler ?: defaultScheduler()
+    private val ownsScheduler: Boolean = taskScheduler == null
+    private val pending = AtomicReference<ScheduledFuture<*>?>()
+
+    init {
+        log.info("PortfolioRevaluationTrigger enabled with debounce {}", debounce)
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        if (ownsScheduler && scheduler is ThreadPoolTaskScheduler) {
+            scheduler.shutdown()
+        }
+    }
+
+    /**
+     * Schedule a revaluation `debounce` from now. Cancels any pending task
+     * so later events extend the window — fits the "fire ~10 min after the
+     * LAST price update of a batch" requirement.
+     */
+    @Synchronized
+    fun scheduleRevaluation(reason: String) {
+        val fireAt = Instant.now().plus(debounce)
+        val task = scheduler.schedule({ revaluator.revalueAll(reason = reason) }, fireAt)
+        val previous = pending.getAndSet(task)
+        if (previous != null && previous.cancel(false)) {
+            log.debug("Replaced pending revaluation; new fire at {} (reason={})", fireAt, reason)
+        } else {
+            log.info("Scheduled revaluation at {} (reason={})", fireAt, reason)
+        }
+    }
+
+    /**
+     * Test hook — exposed so the (rare) caller that wants to observe the
+     * pending task can join on it. Production code should not depend on
+     * this.
+     */
+    internal fun pendingTask(): ScheduledFuture<*>? = pending.get()
+
+    private fun defaultScheduler(): ThreadPoolTaskScheduler =
+        ThreadPoolTaskScheduler().apply {
+            poolSize = 1
+            setThreadNamePrefix("revaluation-trigger-")
+            setRemoveOnCancelPolicy(true)
+            initialize()
+        }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PortfolioRevaluationTrigger::class.java)
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioRevaluator.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioRevaluator.kt
@@ -1,0 +1,121 @@
+package com.beancounter.position.schedule
+
+import com.beancounter.auth.client.LoginService
+import com.beancounter.client.services.PortfolioServiceClient
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.position.valuation.Valuation
+import io.sentry.spring.jakarta.tracing.SentryTransaction
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientException
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Reusable "value every portfolio against today's prices" loop. Called by
+ * the daily cron ([PortfolioValuationSchedule]) as a safety net and by the
+ * event-driven [PortfolioRevaluationTrigger] ~10 min after a price/FX
+ * refresh in svc-data.
+ *
+ * Holds an internal lock so concurrent triggers (cron + event) don't
+ * double-run the loop on the same minute.
+ */
+@Service
+class PortfolioRevaluator(
+    private val portfolioServiceClient: PortfolioServiceClient,
+    private val valuationService: Valuation
+) {
+    private var loginService: LoginService? = null
+    private val lock = ReentrantLock()
+
+    @Autowired(required = false)
+    fun setLoginService(loginService: LoginService?) {
+        this.loginService = loginService
+    }
+
+    @SentryTransaction(operation = "scheduled", name = "PortfolioRevaluator.revalueAll")
+    fun revalueAll(reason: String): Result {
+        val currentLoginService = loginService
+        if (currentLoginService == null) {
+            log.warn("LoginService not available, skipping revaluation ({})", reason)
+            return Result.SKIPPED_NO_LOGIN
+        }
+
+        // Single-flight: if a run is already in progress, skip rather than queue.
+        if (!lock.tryLock()) {
+            log.info("Portfolio revaluation already running, skipping trigger ({})", reason)
+            return Result.SKIPPED_BUSY
+        }
+        try {
+            return runLocked(currentLoginService, reason)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun runLocked(
+        currentLoginService: LoginService,
+        reason: String
+    ): Result {
+        log.info("Portfolio revaluation starting ({})", reason)
+        var successCount = 0
+        var errorCount = 0
+        currentLoginService.retryOnJwtExpiry {
+            val token = currentLoginService.loginM2m()
+            val bearerToken = "Bearer ${token.token}"
+            val allPortfolios = portfolioServiceClient.getAllPortfolios(bearerToken).data
+            if (allPortfolios.isEmpty()) {
+                log.info("No portfolios in system")
+                return@retryOnJwtExpiry
+            }
+            log.info("Valuing {} portfolios", allPortfolios.size)
+            for (portfolio in allPortfolios) {
+                try {
+                    valuationService.getPositions(
+                        portfolio,
+                        DateUtils.TODAY,
+                        true
+                    )
+                    successCount++
+                    log.debug("Valued portfolio: {} ({})", portfolio.code, portfolio.id)
+                } catch (e: RestClientException) {
+                    errorCount++
+                    log.error("Failed to value portfolio: {} ({})", portfolio.code, portfolio.id, e)
+                } catch (e: BusinessException) {
+                    errorCount++
+                    log.error("Failed to value portfolio: {} ({})", portfolio.code, portfolio.id, e)
+                }
+            }
+        }
+        log.info(
+            "Portfolio revaluation completed ({}): {} success, {} errors",
+            reason,
+            successCount,
+            errorCount
+        )
+        return Result.completed(successCount, errorCount)
+    }
+
+    enum class ResultStatus { COMPLETED, SKIPPED_BUSY, SKIPPED_NO_LOGIN }
+
+    data class Result(
+        val status: ResultStatus,
+        val successCount: Int = 0,
+        val errorCount: Int = 0
+    ) {
+        companion object {
+            val SKIPPED_BUSY = Result(ResultStatus.SKIPPED_BUSY)
+            val SKIPPED_NO_LOGIN = Result(ResultStatus.SKIPPED_NO_LOGIN)
+
+            fun completed(
+                successCount: Int,
+                errorCount: Int
+            ): Result = Result(ResultStatus.COMPLETED, successCount, errorCount)
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PortfolioRevaluator::class.java)
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioValuationSchedule.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/schedule/PortfolioValuationSchedule.kt
@@ -1,33 +1,21 @@
 package com.beancounter.position.schedule
 
-import com.beancounter.auth.client.LoginService
-import com.beancounter.client.services.PortfolioServiceClient
-import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.utils.DateUtils
-import com.beancounter.position.valuation.Valuation
 import io.sentry.spring.jakarta.tracing.SentryTransaction
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import org.springframework.web.client.RestClientException
 import java.time.LocalDateTime
 
 /**
- * Scheduled task to value all portfolios with current market prices.
- *
- * Runs on schedule (default: 18:30 SGT Tue-Sat — after bc-data's
- * 07:00-18:00 SGT price-refresh window) and values all portfolios so
- * they have up-to-date market valuations. Firing earlier (e.g. pre
- * Asia open) leaves gainOnDay=0 for Asia/Pacific positions because
- * previousClose isn't in market_data yet.
- *
- * For each portfolio valued:
- * 1. Fetches latest prices for all assets
- * 2. Calculates positions and market values
- * 3. Sends updated marketValue to svc-data via Kafka/Stream
+ * Daily cron safety-net that values all portfolios with current market
+ * prices. Default `0 30 18 * * Tue-Sat` (18:30 SGT) fires after bc-data's
+ * 07:00-18:00 SGT price-refresh window completes. The event-driven
+ * [PortfolioRevaluationTrigger] handles intra-day revaluation; this cron
+ * guarantees a single end-of-day pass even if no cache-invalidation event
+ * fires (e.g. RabbitMQ outage).
  */
 @Service
 @ConditionalOnProperty(
@@ -36,18 +24,11 @@ import java.time.LocalDateTime
     matchIfMissing = false
 )
 class PortfolioValuationSchedule(
-    private val portfolioServiceClient: PortfolioServiceClient,
-    private val valuationService: Valuation,
+    private val revaluator: PortfolioRevaluator,
     private val dateUtils: DateUtils,
     @Value("\${valuation.schedule:0 30 18 * * Tue-Sat}") private val schedule: String
 ) {
-    private var loginService: LoginService? = null
     private val log = LoggerFactory.getLogger(PortfolioValuationSchedule::class.java)
-
-    @Autowired(required = false)
-    fun setLoginService(loginService: LoginService?) {
-        this.loginService = loginService
-    }
 
     init {
         log.info(
@@ -63,73 +44,11 @@ class PortfolioValuationSchedule(
         zone = "#{@scheduleZone}"
     )
     fun valuePortfolios() {
-        val currentLoginService = loginService
-        if (currentLoginService == null) {
-            log.warn("LoginService not available, skipping portfolio valuation")
-            return
-        }
-
         log.info(
             "Portfolio valuation scheduled task starting {} - {}",
             LocalDateTime.now(dateUtils.zoneId),
             dateUtils.zoneId.id
         )
-
-        currentLoginService.retryOnJwtExpiry {
-            // Authenticate with M2M credentials
-            val token = currentLoginService.loginM2m()
-            val bearerToken = "Bearer ${token.token}"
-
-            // Get all portfolios in the system
-            val allPortfolios = portfolioServiceClient.getAllPortfolios(bearerToken).data
-
-            if (allPortfolios.isEmpty()) {
-                log.info("No portfolios in system")
-                return@retryOnJwtExpiry
-            }
-
-            log.info("Valuing {} portfolios", allPortfolios.size)
-
-            var successCount = 0
-            var errorCount = 0
-
-            for (portfolio in allPortfolios) {
-                try {
-                    valuationService.getPositions(
-                        portfolio,
-                        DateUtils.TODAY,
-                        true
-                    )
-                    successCount++
-                    log.debug(
-                        "Valued portfolio: {} ({})",
-                        portfolio.code,
-                        portfolio.id
-                    )
-                } catch (e: RestClientException) {
-                    errorCount++
-                    log.error(
-                        "Failed to value portfolio: {} ({})",
-                        portfolio.code,
-                        portfolio.id,
-                        e
-                    )
-                } catch (e: BusinessException) {
-                    errorCount++
-                    log.error(
-                        "Failed to value portfolio: {} ({})",
-                        portfolio.code,
-                        portfolio.id,
-                        e
-                    )
-                }
-            }
-
-            log.info(
-                "Portfolio valuation completed: {} success, {} errors",
-                successCount,
-                errorCount
-            )
-        }
+        revaluator.revalueAll(reason = "cron")
     }
 }

--- a/svc-position/src/main/resources/application.yml
+++ b/svc-position/src/main/resources/application.yml
@@ -7,15 +7,21 @@ server:
     mime-types: application/json,application/xml,text/html,text/plain,text/css,application/javascript
     min-response-size: 1024
 
-# Portfolio valuation scheduling (disabled by default for local dev)
-# Single daily run at 18:30 SGT, after bc-data's price-refresh window
-# (07:00–18:00 SGT). Running earlier (e.g. pre-Asia-open) makes
-# gainOnDay fall back to 0 for Asia/Pacific positions because
-# previousClose isn't yet in market_data.
+# Portfolio valuation scheduling (disabled by default for local dev).
+# Two triggers, both opt-in:
+#   - revaluation.trigger.enabled: fires ~debounce after the LAST
+#     CacheInvalidationEvent (PRICE / FX) in a burst, i.e. shortly
+#     after a bc-data price refresh completes.
+#   - schedule.enabled + valuation.schedule: single daily cron safety
+#     net (18:30 SGT, after bc-data's 07:00-18:00 SGT refresh window).
 schedule:
   enabled: false
 valuation:
   schedule: "0 30 18 * * Tue-Sat"
+revaluation:
+  trigger:
+    enabled: false
+    debounce: "PT10M"
 
 springdoc:
   use-management-port: true

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/CacheInvalidationConsumerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/CacheInvalidationConsumerTest.kt
@@ -2,10 +2,14 @@ package com.beancounter.position.cache
 
 import com.beancounter.common.contracts.CacheChangeType
 import com.beancounter.common.contracts.CacheInvalidationEvent
+import com.beancounter.position.schedule.PortfolioRevaluationTrigger
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.time.LocalDate
 
@@ -13,6 +17,9 @@ import java.time.LocalDate
 class CacheInvalidationConsumerTest {
     @Mock
     private lateinit var cacheService: PerformanceCacheService
+
+    @Mock
+    private lateinit var revaluationTrigger: PortfolioRevaluationTrigger
 
     @Test
     fun `TRANSACTION event invalidates portfolio from date`() {
@@ -74,5 +81,54 @@ class CacheInvalidationConsumerTest {
         handler.accept(event)
 
         verify(cacheService).invalidateFromDate(LocalDate.of(2020, 1, 1))
+    }
+
+    @Test
+    fun `PRICE event schedules a debounced revaluation when trigger is wired`() {
+        val consumer = CacheInvalidationConsumer(cacheService)
+        consumer.setRevaluationTrigger(revaluationTrigger)
+        val handler = consumer.performanceCacheInvalidation()
+        val event =
+            CacheInvalidationEvent(
+                changeType = CacheChangeType.PRICE,
+                fromDate = LocalDate.of(2024, 6, 15)
+            )
+
+        handler.accept(event)
+
+        verify(revaluationTrigger).scheduleRevaluation(eq("cache:PRICE"))
+    }
+
+    @Test
+    fun `FX event schedules a debounced revaluation when trigger is wired`() {
+        val consumer = CacheInvalidationConsumer(cacheService)
+        consumer.setRevaluationTrigger(revaluationTrigger)
+        val handler = consumer.performanceCacheInvalidation()
+        val event =
+            CacheInvalidationEvent(
+                changeType = CacheChangeType.FX,
+                fromDate = LocalDate.of(2024, 6, 15)
+            )
+
+        handler.accept(event)
+
+        verify(revaluationTrigger).scheduleRevaluation(eq("cache:FX"))
+    }
+
+    @Test
+    fun `TRANSACTION event does not trigger revaluation`() {
+        val consumer = CacheInvalidationConsumer(cacheService)
+        consumer.setRevaluationTrigger(revaluationTrigger)
+        val handler = consumer.performanceCacheInvalidation()
+        val event =
+            CacheInvalidationEvent(
+                changeType = CacheChangeType.TRANSACTION,
+                portfolioId = "pf-123",
+                fromDate = LocalDate.of(2024, 6, 15)
+            )
+
+        handler.accept(event)
+
+        verify(revaluationTrigger, never()).scheduleRevaluation(any())
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioRevaluationTriggerTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioRevaluationTriggerTest.kt
@@ -1,0 +1,92 @@
+package com.beancounter.position.schedule
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+class PortfolioRevaluationTriggerTest {
+    @Mock
+    private lateinit var revaluator: PortfolioRevaluator
+
+    private val scheduler =
+        ThreadPoolTaskScheduler().apply {
+            poolSize = 1
+            setThreadNamePrefix("revaluation-trigger-test-")
+            setRemoveOnCancelPolicy(true)
+            initialize()
+        }
+
+    @Test
+    fun `single event runs revaluation after debounce window elapses`() {
+        val latch = CountDownLatch(1)
+        whenever(revaluator.revalueAll(any())).thenAnswer {
+            latch.countDown()
+            PortfolioRevaluator.Result.completed(1, 0)
+        }
+        val trigger =
+            PortfolioRevaluationTrigger(
+                revaluator = revaluator,
+                debounce = Duration.ofMillis(150),
+                taskScheduler = scheduler
+            )
+
+        trigger.scheduleRevaluation(reason = "test")
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue()
+        verify(revaluator, times(1)).revalueAll(eq("test"))
+    }
+
+    @Test
+    fun `burst of events collapses to a single revaluation`() {
+        val latch = CountDownLatch(1)
+        whenever(revaluator.revalueAll(any())).thenAnswer {
+            latch.countDown()
+            PortfolioRevaluator.Result.completed(1, 0)
+        }
+        val trigger =
+            PortfolioRevaluationTrigger(
+                revaluator = revaluator,
+                debounce = Duration.ofMillis(200),
+                taskScheduler = scheduler
+            )
+
+        repeat(5) { trigger.scheduleRevaluation(reason = "burst") }
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue()
+        // No second invocation in the lifetime of this test, which is
+        // bounded by the latch.await window above (~200 ms post-fire).
+        verify(revaluator, times(1)).revalueAll(any())
+    }
+
+    @Test
+    fun `early cancellation prevents revaluation`() {
+        val trigger =
+            PortfolioRevaluationTrigger(
+                revaluator = revaluator,
+                debounce = Duration.ofSeconds(5),
+                taskScheduler = scheduler
+            )
+
+        trigger.scheduleRevaluation(reason = "to-cancel")
+        val pending = trigger.pendingTask()
+        checkNotNull(pending)
+        assertThat(pending.cancel(false)).isTrue()
+
+        // No revaluation should fire within the inflate window (1 s « 5 s debounce).
+        Thread.sleep(1_000)
+        verify(revaluator, never()).revalueAll(any())
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioRevaluatorTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioRevaluatorTest.kt
@@ -1,0 +1,111 @@
+package com.beancounter.position.schedule
+
+import com.beancounter.auth.AuthConfig
+import com.beancounter.auth.client.LoginService
+import com.beancounter.auth.model.OpenIdResponse
+import com.beancounter.client.services.PortfolioServiceClient
+import com.beancounter.common.contracts.PortfoliosResponse
+import com.beancounter.common.model.Currency
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.position.valuation.Valuation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class PortfolioRevaluatorTest {
+    @Mock
+    private lateinit var portfolioServiceClient: PortfolioServiceClient
+
+    @Mock
+    private lateinit var valuationService: Valuation
+
+    @Mock
+    private lateinit var loginService: LoginService
+
+    @Mock
+    private lateinit var authConfig: AuthConfig
+
+    private lateinit var revaluator: PortfolioRevaluator
+
+    @BeforeEach
+    fun setUp() {
+        revaluator = PortfolioRevaluator(portfolioServiceClient, valuationService)
+        revaluator.setLoginService(loginService)
+    }
+
+    @Test
+    fun `revalueAll values every portfolio`() {
+        val portfolios = listOf(portfolio("PORT1"), portfolio("PORT2"), portfolio("PORT3"))
+        wireLogin(portfolios)
+
+        val result = revaluator.revalueAll(reason = "test")
+
+        verify(valuationService).getPositions(eq(portfolios[0]), eq(DateUtils.TODAY), eq(true))
+        verify(valuationService).getPositions(eq(portfolios[1]), eq(DateUtils.TODAY), eq(true))
+        verify(valuationService).getPositions(eq(portfolios[2]), eq(DateUtils.TODAY), eq(true))
+        verify(valuationService, times(3)).getPositions(any(), any(), any())
+        assertThat(result.status).isEqualTo(PortfolioRevaluator.ResultStatus.COMPLETED)
+        assertThat(result.successCount).isEqualTo(3)
+        assertThat(result.errorCount).isZero()
+    }
+
+    @Test
+    fun `revalueAll handles empty portfolio list`() {
+        wireLogin(emptyList())
+
+        val result = revaluator.revalueAll(reason = "test")
+
+        verify(valuationService, never()).getPositions(any(), any(), any())
+        assertThat(result.status).isEqualTo(PortfolioRevaluator.ResultStatus.COMPLETED)
+    }
+
+    @Test
+    fun `revalueAll returns SKIPPED_NO_LOGIN when LoginService missing`() {
+        val noLogin = PortfolioRevaluator(portfolioServiceClient, valuationService)
+        // intentionally not calling setLoginService
+
+        val result = noLogin.revalueAll(reason = "test")
+
+        verify(portfolioServiceClient, never()).getAllPortfolios(any())
+        assertThat(result.status).isEqualTo(PortfolioRevaluator.ResultStatus.SKIPPED_NO_LOGIN)
+    }
+
+    private fun portfolio(code: String): Portfolio =
+        Portfolio(
+            id = code,
+            code = code,
+            name = "$code Portfolio",
+            currency = Currency("USD"),
+            base = Currency("USD")
+        )
+
+    private fun wireLogin(portfolios: List<Portfolio>) {
+        val token =
+            OpenIdResponse(
+                token = "test-token",
+                scope = "openid",
+                expiry = 3600,
+                type = "Bearer"
+            )
+        whenever(loginService.authConfig).thenReturn(authConfig)
+        whenever(authConfig.clientSecret).thenReturn("test-secret")
+        whenever(loginService.loginM2m(any())).thenReturn(token)
+        whenever(loginService.retryOnJwtExpiry<Unit>(any())).thenAnswer { invocation ->
+            val block = invocation.getArgument<() -> Unit>(0)
+            block()
+        }
+        whenever(portfolioServiceClient.getAllPortfolios(any()))
+            .thenReturn(PortfoliosResponse(portfolios))
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioValuationScheduleTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/schedule/PortfolioValuationScheduleTest.kt
@@ -1,134 +1,33 @@
 package com.beancounter.position.schedule
 
-import com.beancounter.auth.AuthConfig
-import com.beancounter.auth.client.LoginService
-import com.beancounter.auth.model.OpenIdResponse
-import com.beancounter.client.services.PortfolioServiceClient
-import com.beancounter.common.contracts.PortfoliosResponse
-import com.beancounter.common.model.Currency
-import com.beancounter.common.model.Portfolio
 import com.beancounter.common.utils.DateUtils
-import com.beancounter.position.valuation.Valuation
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 /**
- * Tests for PortfolioValuationSchedule to verify all portfolios are valued.
+ * Cron now delegates the actual loop to [PortfolioRevaluator]; this test
+ * exists to lock in the contract that the scheduled task fires with
+ * `reason=cron`. The loop body itself is covered by
+ * [PortfolioRevaluatorTest].
  */
 @ExtendWith(MockitoExtension::class)
 class PortfolioValuationScheduleTest {
     @Mock
-    private lateinit var portfolioServiceClient: PortfolioServiceClient
+    private lateinit var revaluator: PortfolioRevaluator
 
-    @Mock
-    private lateinit var valuationService: Valuation
-
-    @Mock
-    private lateinit var loginService: LoginService
-
-    @Mock
-    private lateinit var authConfig: AuthConfig
-
-    private lateinit var dateUtils: DateUtils
-    private lateinit var schedule: PortfolioValuationSchedule
-
-    @BeforeEach
-    fun setUp() {
-        dateUtils = DateUtils()
-        schedule =
+    @Test
+    fun `cron delegates to revaluator with reason cron`() {
+        val schedule =
             PortfolioValuationSchedule(
-                portfolioServiceClient,
-                valuationService,
-                dateUtils,
-                "0 0 7 * * *"
+                revaluator = revaluator,
+                dateUtils = DateUtils(),
+                schedule = "0 0 7 * * *"
             )
-        schedule.setLoginService(loginService)
-    }
-
-    @Test
-    fun `should value all portfolios`() {
-        // Given - multiple portfolios
-        val portfolio1 = createPortfolio("PORT1")
-        val portfolio2 = createPortfolio("PORT2")
-        val portfolio3 = createPortfolio("PORT3")
-        setupMocks(listOf(portfolio1, portfolio2, portfolio3))
-
-        // When
         schedule.valuePortfolios()
-
-        // Then - should value all portfolios
-        verify(valuationService).getPositions(eq(portfolio1), eq(DateUtils.TODAY), eq(true))
-        verify(valuationService).getPositions(eq(portfolio2), eq(DateUtils.TODAY), eq(true))
-        verify(valuationService).getPositions(eq(portfolio3), eq(DateUtils.TODAY), eq(true))
-        verify(valuationService, times(3)).getPositions(any(), any(), any())
-    }
-
-    @Test
-    fun `should handle empty portfolio list`() {
-        // Given - no portfolios
-        setupMocks(emptyList())
-
-        // When
-        schedule.valuePortfolios()
-
-        // Then - should not call valuationService
-        verify(valuationService, never()).getPositions(any(), any(), any())
-    }
-
-    @Test
-    fun `should skip when login service not available`() {
-        // Given - no login service
-        val scheduleNoLogin =
-            PortfolioValuationSchedule(
-                portfolioServiceClient,
-                valuationService,
-                dateUtils,
-                "0 0 7 * * *"
-            )
-        // Don't set login service
-
-        // When
-        scheduleNoLogin.valuePortfolios()
-
-        // Then - should not attempt to get portfolios
-        verify(portfolioServiceClient, never()).getAllPortfolios(any())
-    }
-
-    private fun createPortfolio(code: String): Portfolio =
-        Portfolio(
-            id = code,
-            code = code,
-            name = "$code Portfolio",
-            currency = Currency("USD"),
-            base = Currency("USD")
-        )
-
-    private fun setupMocks(portfolios: List<Portfolio>) {
-        val token =
-            OpenIdResponse(
-                token = "test-token",
-                scope = "openid",
-                expiry = 3600,
-                type = "Bearer"
-            )
-        // Mock authConfig to provide default parameter for loginM2m()
-        whenever(loginService.authConfig).thenReturn(authConfig)
-        whenever(authConfig.clientSecret).thenReturn("test-secret")
-        whenever(loginService.loginM2m(any())).thenReturn(token)
-        whenever(loginService.retryOnJwtExpiry<Unit>(any())).thenAnswer { invocation ->
-            val block = invocation.getArgument<() -> Unit>(0)
-            block()
-        }
-        whenever(portfolioServiceClient.getAllPortfolios(any()))
-            .thenReturn(PortfoliosResponse(portfolios))
+        verify(revaluator).revalueAll(eq("cron"))
     }
 }


### PR DESCRIPTION
## Summary
- Today, portfolio gainOnDay only updates once a day at 18:30 SGT (cron). bc-data already publishes a `CacheInvalidationEvent` after every price/FX refresh, but svc-position only used it to drop the perf-cache. This change wires the same signal to a debounced revaluation so user-visible values refresh shortly after EOD prices land.
- **Refactor.** Loop body lifted from `PortfolioValuationSchedule` into `PortfolioRevaluator`. Holds a `ReentrantLock` so cron + trigger can't double-run.
- **Trigger.** `PortfolioRevaluationTrigger` (opt-in via `revaluation.trigger.enabled`) keeps a single `ScheduledFuture` reference; every event cancels + replaces it with `Instant.now() + debounce`. A burst of refreshes therefore collapses to one revaluation ~10 min after the last event.
- **Consumer.** `CacheInvalidationConsumer` calls `trigger.scheduleRevaluation()` on PRICE / FX events; PRICE_HISTORY and TRANSACTION skip the trigger (they don't reflect a broad close-price update).
- **Cron.** Stays as a once-daily safety net (RMQ outage / event drop). No change to existing default.
- **Kauri.** `REVALUATION_TRIGGER_ENABLED=true`, `REVALUATION_TRIGGER_DEBOUNCE=PT10M` already staged on `bc-deploy/main` (e1fd43c).

## Test plan
- [x] `PortfolioRevaluatorTest` covers happy path, empty portfolio list, missing LoginService.
- [x] `PortfolioRevaluationTriggerTest` covers single fire after debounce, burst collapsing to one fire, cancellation aborts pending fire.
- [x] `CacheInvalidationConsumerTest` extended to assert PRICE/FX schedule the trigger and TRANSACTION does not.
- [x] `./gradlew :svc-position:test :svc-position:formatKotlin :svc-position:lintKotlin` clean.
- [ ] After deploy, watch bc-position logs: `Scheduled revaluation at ...` immediately after each `c.b.marketdata.providers.PriceRefresh` completion + `Portfolio revaluation starting (cache:PRICE)` ~10 min later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio valuations now automatically refresh when prices or exchange rates change, enabling faster updates beyond scheduled runs.
  * Optional debounced revaluation trigger for cache invalidation events (disabled by default, configurable via settings).

* **Chores**
  * Refactored portfolio valuation logic to improve code organization and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->