### PR TITLE
fix(eodhd): fail-soft on non-array bulk price body (POSITION-2F)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -15,7 +15,7 @@ import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestClientException
 import java.time.LocalDate
 
 /**
@@ -80,8 +80,11 @@ class EodhdPriceService(
         val rows =
             try {
                 eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
-            } catch (e: HttpClientErrorException) {
-                log.warn("EODHD {} for {} on {} — skipping", e.statusCode, symbol, priceDate)
+            } catch (e: RestClientException) {
+                // Broad RestClientException, not just 4xx: also covers body-extraction
+                // failures when EODHD returns a non-array error payload for a bad or
+                // mis-tagged symbol. One bad ticker must never abort the valuation cycle.
+                log.warn("EODHD error for {} on {} — skipping: {}", symbol, priceDate, e.message)
                 return emptyList()
             }
         return eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows)
@@ -108,13 +111,18 @@ class EodhdPriceService(
         val bulkRows: List<EodhdBulkPrice> =
             try {
                 eodhdProxy.getBulkPrices(exchange, csv, priceDate, eodhdConfig.apiKey)
-            } catch (e: HttpClientErrorException) {
+            } catch (e: RestClientException) {
+                // Broad RestClientException, not just HttpClientErrorException: a non-array
+                // EODHD error body throws "Error while extracting response for type
+                // [EodhdBulkPrice[]]" (a body-extraction failure, not a 4xx). Falling back
+                // to per-symbol keeps the good symbols instead of 500ing the whole
+                // valuation and zeroing every portfolio in the cycle (POSITION-2F).
                 log.warn(
-                    "EODHD bulk {} for batch {} ({} symbols) on {} — falling back to per-symbol",
-                    e.statusCode,
+                    "EODHD bulk error for batch {} ({} symbols) on {} — falling back to per-symbol: {}",
                     batchId,
                     symbols.size,
-                    priceDate
+                    priceDate,
+                    e.message
                 )
                 return symbols.flatMap { fetchSingle(providerArguments, it, priceDate) }
             }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -307,6 +307,42 @@ internal class EodhdApiTest {
         assertThat(hit.type).isEqualTo("ETF")
     }
 
+    @Test
+    fun `non-array bulk error body falls back to per-symbol instead of aborting the batch`() {
+        // Regression POSITION-2F: a symbol on the wrong exchange (e.g. a LON-listed
+        // ETF tagged US) makes EODHD return an error OBJECT, not the expected array.
+        // RestClient then throws "Error while extracting response for type
+        // [EodhdBulkPrice[]]" — NOT an HttpClientErrorException, so the old catch
+        // missed it and the entire valuation 500'd, zeroing every portfolio in the
+        // cycle. Must fall back to per-symbol so good symbols still resolve.
+        stubFor(
+            get(urlPathEqualTo(BULK_LAST_DAY_US))
+                .willReturn(
+                    aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("""{"code":"NOT_FOUND","message":"Symbols not found"}""")
+                        .withStatus(200)
+                )
+        )
+        stubEod("AAPL.US", "mock/eodhd/AAPL-US.json")
+        stubEod("MSFT.US", "mock/eodhd/no-data.json")
+
+        val result =
+            eodhdPriceService.getMarketData(
+                PriceRequest(
+                    "2024-11-29",
+                    listOf(PriceAsset(AAPL), PriceAsset(MSFT))
+                )
+            )
+
+        // Bulk parse failed → per-symbol fallback exercised, batch not aborted.
+        WireMock.verify(getRequestedFor(urlPathEqualTo("/api/eod/AAPL.US")))
+        assertThat(result).hasSize(2)
+        val byCode = result.associateBy { it.asset.code }
+        assertThat(byCode["AAPL"]?.close).isEqualByComparingTo(BigDecimal("237.33"))
+        assertThat(byCode["MSFT"]?.close).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
     private fun stubEod(
         symbol: String,
         fixturePath: String


### PR DESCRIPTION
## What
Root cause of Mike's slow/empty retire metrics, traced from Sentry POSITION-2F.

A holding mis-tagged to the wrong exchange (a **LON**-listed Vanguard ETF `VUAA` recorded as **US**) makes EODHD's bulk endpoint return an **error object**, not the expected `EodhdBulkPrice[]` array. `RestClient.body<Array<…>>()` then throws *"Error while extracting response for type [EodhdBulkPrice[]]"* — a body-extraction `RestClientException`, **not** an `HttpClientErrorException`.

`EodhdPriceService.fetchBulk` and `fetchSingle` only caught `HttpClientErrorException` (4xx), so the parse failure escaped → bc-data `/api/prices` **500** → bc-position `/api/allocation` 500 → svc-retire degraded to **0 assets** → Mike's projection empty / instant-depletion, ~1.4s of failing+retrying = "very long" metrics. One bad ticker zeroed **every** portfolio in the valuation cycle.

## Fix
Broaden both catches from `HttpClientErrorException` to its supertype **`RestClientException`** (covers 4xx *and* body-extraction failures). Bulk → falls back to per-symbol; single → skips with a zero-close row. Batch isolation now holds for the parse-failure mode too, exactly as the existing 404 path already did.

## Test
RED→GREEN verified (reverting the fix fails it): new WireMock test — bulk endpoint returns a non-array error body → service falls back to per-symbol, good symbols still resolve, no 500. Existing 404/bulk-isolation tests unchanged. `:svc-data:test` EodhdApiTest green; format + lint + semgrep clean.

## Follow-ups (separate, noted not done)
- bc-position `PriceService.getPrices` resilience4j **retries** this deterministic failure (~1s wasted) — should not retry a parse error.
- svc-retire should surface a `warning` when allocation returns null/500 rather than silently showing a retired user a "depleted" plan.
- Data: `VUAA` should be re-tagged to its LON listing (user already set the trade to proposed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for market data price fetches, with automatic fallback to per-symbol requests when bulk operations fail, ensuring more reliable data retrieval.
  * Improved error logging with contextual details for troubleshooting.

* **Tests**
  * Added integration test verifying graceful fallback behavior during bulk request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->