### PR TITLE
feat(market): add LSE (USD) market for USD-settled London listings

### DIFF
--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -492,6 +492,17 @@ beancounter:
           FIGI: "LN"
           eodhd: "LSE"
 
+      - code: "LSE"
+        name: "London Stock Exchange (USD)"
+        # USD-denominated lines on the LSE — e.g. Vanguard VUAA (S&P 500 UCITS USD
+        # Acc). Same physical exchange + EODHD suffix as LON, but these settle in
+        # USD and are quoted whole (not pence), so currency must be USD with no
+        # pence multiplier — otherwise the price is FX-converted as GBP and wrong.
+        currencyId: "USD"
+        timezoneId: "Europe/London"
+        aliases:
+          eodhd: "LSE"
+
       - code: "AMS"
         name: "Euronext Amsterdam"
         currencyId: "EUR"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
@@ -73,6 +73,23 @@ class MarketServiceTest {
     }
 
     @Test
+    fun `should resolve LSE (USD) market distinct from LON (GBP)`() {
+        // VUAA-on-LSE settles in USD. LON is GBP/pence; pricing a USD line as LON
+        // FX-converts it as GBP (~1.27x wrong). LSE shares the EODHD exchange suffix
+        // but carries USD so the USD-settled LSE listings price correctly.
+        val lse = marketService.getMarket("LSE")
+        assertThat(lse)
+            .isNotNull
+            .hasFieldOrPropertyWithValue("currency.code", USD.code)
+            .hasFieldOrPropertyWithValue("timezone", TimeZone.getTimeZone("Europe/London"))
+        assertThat(lse.getAlias("eodhd")).isEqualTo("LSE")
+
+        val lon = marketService.getMarket("LON")
+        assertThat(lon.currency.code).isEqualTo(GBP.code)
+        assertThat(lon.getAlias("eodhd")).isEqualTo("LSE")
+    }
+
+    @Test
     fun `should find market for alias`() {
         val nyse = marketService.getMarket(Constants.NYSE.code)
         val nzx = marketService.getMarket(Constants.NZX.code)


### PR DESCRIPTION
Final piece of the Mike-metrics / VUAA thread. `VUAA.LSE` on EODHD is **USD** ("S&P 500 UCITS USD Acc"), but BC's `LON` market is **GBP, pence-quoted** — so a USD-settled LSE listing tagged LON is FX-converted as GBP (~1.27x wrong). No BC market paired the LSE exchange with USD.

Adds an `LSE` market: `currencyId: USD`, `eodhd: LSE`, no pence multiplier — distinct from `LON` (GBP) which stays for genuinely GBX-quoted UK stocks. EODHD prices are not multiplier-adjusted (only Alpha is), so currency is the only thing that needed fixing.

Test asserts LSE resolves USD + eodhd=LSE, distinct from LON=GBP. markets + eodhd test packages green; format + lint clean.

Paired with bc-deploy adding `LSE` to `BEANCOUNTER_MARKET_PROVIDERS_EODHD_MARKETS` so EODHD is routed for the new market. After both deploy, the VUAA asset is retagged US→LSE.

@coderabbitai ignore