### PR TITLE
fix(figi): null-guard missing FIGI alias; add FIGI:LN to LSE (DATA-5K)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
@@ -36,6 +36,14 @@ class FigiProxy internal constructor(
         defaultName: String? = null,
         id: String = bcAssetCode
     ): Asset? {
+        // FIGI resolution needs the market's FIGI exchange alias. A market without
+        // one (e.g. a USD-on-LSE listing) can't be FIGI-resolved — return null so
+        // the enricher chain falls back to the default enricher instead of NPEing
+        // on the alias lookup in resolve() (DATA-5K).
+        if (market.aliases[FIGI] == null) {
+            log.debug("No FIGI alias for market {} — skipping FIGI enrichment", market.code)
+            return null
+        }
         val (figiCode, figiMarket, figiSearch) =
             resolve(
                 bcAssetCode,

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -501,6 +501,7 @@ beancounter:
         currencyId: "USD"
         timezoneId: "Europe/London"
         aliases:
+          FIGI: "LN"
           eodhd: "LSE"
 
       - code: "AMS"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
@@ -1,0 +1,34 @@
+package com.beancounter.marketdata.providers.figi
+
+import com.beancounter.common.model.Market
+import com.beancounter.marketdata.assets.figi.FigiAdapter
+import com.beancounter.marketdata.assets.figi.FigiConfig
+import com.beancounter.marketdata.assets.figi.FigiGateway
+import com.beancounter.marketdata.assets.figi.FigiProxy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class FigiProxyAliasTest {
+    @Test
+    fun `find skips FIGI and returns null when the market has no FIGI alias`() {
+        // DATA-5K: enriching an asset on a market without a FIGI exchange alias
+        // (e.g. the USD-on-LSE market, which only carries an eodhd alias) used to
+        // NPE on `market.aliases["FIGI"]!!`. It must instead return null so the
+        // enricher chain falls back to the default enricher.
+        val gateway = Mockito.mock(FigiGateway::class.java)
+        val proxy =
+            FigiProxy(
+                Mockito.mock(FigiConfig::class.java),
+                gateway,
+                Mockito.mock(FigiAdapter::class.java)
+            )
+        val lseUsd = Market(code = "LSE", aliases = mapOf("eodhd" to "LSE"))
+
+        val result = proxy.find(lseUsd, "VUAA")
+
+        assertThat(result).isNull()
+        // No FIGI HTTP call should be attempted for an unmappable market.
+        Mockito.verifyNoInteractions(gateway)
+    }
+}


### PR DESCRIPTION
## What
`POST /assets/{id}/enrich` 500'd (NPE) when re-enriching VUAA on the new `LSE` market. `FigiProxy.resolve` does `market.aliases["FIGI"]!!` — and the LSE market only had an `eodhd` alias, so the `!!` NPE'd. Sentry DATA-5K.

## Fix (two parts)
1. **Robustness:** `FigiProxy.find` now returns `null` when the market has no FIGI alias, so `FigiEnricher` falls back to the default enricher (its existing `?:` path) instead of NPEing. Protects any FIGI-aliasless market, not just LSE.
2. **Config:** give `LSE` a `FIGI: "LN"` alias (London) so its assets actually enrich (name/identifiers) via FIGI.

## Test
RED→GREEN unit test: `find` on a market with no FIGI alias returns null and makes no FIGI HTTP call (was NPE). figi + markets packages green; format + lint + semgrep clean.

@coderabbitai ignore