### PR TITLE
feat(asset): reject create on wrong exchange (prevent phantom mis-tags)

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetMarketVerifier.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetMarketVerifier.kt
@@ -1,0 +1,80 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.model.Market
+import com.beancounter.marketdata.markets.MarketService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Guards against silently creating a phantom asset on the wrong exchange.
+ *
+ * The bc-view trade form defaults an asset's market from the portfolio currency
+ * (USD → US), so a USD-denominated foreign listing — e.g. Vanguard VUAA on the
+ * LSE — gets created as `VUAA` on `US`. EODHD then can't price `VUAA.US`, which
+ * cascaded into a broken valuation and an empty retirement projection.
+ *
+ * When the enricher chain can't resolve a ticker on the supplied market (blank
+ * name), the search providers are asked where the ticker actually trades. If it
+ * resolves on other exchanges but NOT one equivalent to the supplied market, the
+ * create is rejected with the valid market(s).
+ *
+ * Equivalence is by **provider exchange**, not raw BC market code: US / NASDAQ /
+ * NYSE / AMEX all share the EODHD exchange `US`, so a ticker the search reports on
+ * `NASDAQ` must not be rejected for a `US` create. The eodhd alias (falling back to
+ * the market code) is the canonical exchange key.
+ *
+ * Fail-open by design: no search hits (a genuinely new or private ticker) or a
+ * search error never blocks creation — only a positive "listed elsewhere, not
+ * here" rejects.
+ */
+@Service
+class AssetMarketVerifier(
+    private val assetSearchService: AssetSearchService,
+    private val marketService: MarketService
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    /**
+     * @throws BusinessException when [code] resolves on other exchanges but not one
+     *   equivalent to [market].
+     */
+    fun verify(
+        code: String,
+        market: Market,
+        enrichedName: String?
+    ) {
+        // An enricher resolved the ticker on this market — trust it, no lookup.
+        if (!enrichedName.isNullOrBlank()) return
+        // Internal / synthetic markets carry no external exchange listing to check.
+        if (market.code.uppercase() in EXEMPT_MARKETS) return
+
+        val ticker = code.uppercase()
+        val listedExchanges =
+            runCatching { assetSearchService.search(ticker, null).data }
+                .onFailure { log.debug("Market verify search failed for {}: {}", ticker, it.message) }
+                .getOrDefault(emptyList())
+                .filter { it.symbol.equals(ticker, ignoreCase = true) && !it.market.isNullOrBlank() }
+                .mapNotNull { runCatching { marketService.getMarket(it.market!!) }.getOrNull() }
+                .map { exchangeKey(it) }
+                .toSet()
+
+        if (listedExchanges.isNotEmpty() && exchangeKey(market) !in listedExchanges) {
+            throw BusinessException(
+                "$code was not found on market ${market.code}. " +
+                    "It is listed on: ${listedExchanges.sorted().joinToString(", ")}. " +
+                    "Re-enter the trade selecting the correct market."
+            )
+        }
+    }
+
+    // Canonical exchange identity: the EODHD exchange the market routes to (US, LSE,
+    // AS, …), so equivalent BC markets (US/NASDAQ/NYSE/AMEX → US) compare equal.
+    // Falls back to the market code for markets without an eodhd alias (NZX, SGX).
+    private fun exchangeKey(market: Market): String = (market.getAlias("eodhd") ?: market.code).uppercase()
+
+    private companion object {
+        // Internal/synthetic markets with no external exchange listing to verify.
+        val EXEMPT_MARKETS = setOf("CASH", "PRIVATE", "RE", "INDEX", "MUTF")
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetService.kt
@@ -17,6 +17,7 @@ import com.beancounter.marketdata.trn.TrnRepository
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Lazy
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
@@ -42,6 +43,10 @@ class AssetService(
     private val accountingTypeService: AccountingTypeService,
     private val trnRepository: TrnRepository,
     private val assetCascadeDeleter: AssetCascadeDeleter,
+    // @Lazy breaks the construction cycle: AssetService → AssetMarketVerifier →
+    // AssetSearchService → MdFactory → Alpha* → AssetService. The verifier is only
+    // touched on the create path, so a lazy proxy is resolved well after startup.
+    @Lazy private val assetMarketVerifier: AssetMarketVerifier,
     transactionManager: PlatformTransactionManager
 ) : Assets {
     // New transaction template for recovery lookups after constraint violations
@@ -191,6 +196,10 @@ class AssetService(
                         market = market,
                         assetInput = assetInput
                     )
+            // Reject a phantom on the wrong exchange (e.g. a USD-on-LSE ETF entered
+            // as US) before it is persisted unpriceable. Fail-open — only rejects
+            // when the ticker is positively listed on other markets, not this one.
+            assetMarketVerifier.verify(assetInput.code, market, asset.name)
             try {
                 // saveAndFlush — see findOrCreate above for rationale.
                 assetRepository.saveAndFlush(asset)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetMarketVerifierTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetMarketVerifierTest.kt
@@ -1,0 +1,102 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.common.contracts.AssetSearchResponse
+import com.beancounter.common.contracts.AssetSearchResult
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.model.Market
+import com.beancounter.marketdata.markets.MarketService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AssetMarketVerifierTest {
+    private val assetSearchService = mock<AssetSearchService>()
+    private val marketService = mock<MarketService>()
+    private val verifier = AssetMarketVerifier(assetSearchService, marketService)
+
+    private fun market(
+        code: String,
+        eodhd: String? = null
+    ) = Market(code = code, aliases = eodhd?.let { mapOf("eodhd" to it) } ?: emptyMap())
+
+    private fun hit(
+        symbol: String,
+        market: String
+    ) = AssetSearchResult(
+        symbol = symbol,
+        name = "n",
+        type = "ETF",
+        region = null,
+        currency = "USD",
+        market = market
+    )
+
+    @BeforeEach
+    fun stubMarkets() {
+        whenever(marketService.getMarket("US")).thenReturn(market("US", "US"))
+        whenever(marketService.getMarket("NASDAQ")).thenReturn(market("NASDAQ", "US"))
+        whenever(marketService.getMarket("LSE")).thenReturn(market("LSE", "LSE"))
+        whenever(marketService.getMarket("AMS")).thenReturn(market("AMS", "AS"))
+    }
+
+    @Test
+    fun `rejects when ticker is listed only on a different exchange`() {
+        whenever(assetSearchService.search("VUAA", null))
+            .thenReturn(AssetSearchResponse(listOf(hit("VUAA", "LSE"), hit("VUAA", "AMS"))))
+
+        assertThatThrownBy { verifier.verify("VUAA", market("US", "US"), enrichedName = null) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining("US")
+            .hasMessageContaining("LSE")
+    }
+
+    @Test
+    fun `allows US ticker the search reports on NASDAQ (same EODHD exchange)`() {
+        // Regression: US / NASDAQ / NYSE / AMEX share the EODHD exchange "US", so a
+        // ticker the search tags NASDAQ must NOT be rejected for a US create.
+        whenever(assetSearchService.search("BRK.B", null))
+            .thenReturn(AssetSearchResponse(listOf(hit("BRK.B", "NASDAQ"))))
+
+        verifier.verify("BRK.B", market("US", "US"), enrichedName = null)
+    }
+
+    @Test
+    fun `allows when the ticker is not found anywhere (new or private ticker)`() {
+        whenever(assetSearchService.search(any(), anyOrNull()))
+            .thenReturn(AssetSearchResponse(emptyList()))
+
+        verifier.verify("NEWCO", market("US", "US"), enrichedName = null)
+    }
+
+    @Test
+    fun `skips the lookup entirely when the asset was enriched`() {
+        verifier.verify("AAPL", market("US", "US"), enrichedName = "Apple Inc")
+
+        verify(assetSearchService, never()).search(any(), anyOrNull())
+    }
+
+    @Test
+    fun `skips internal markets that have no exchange listing`() {
+        verifier.verify("USD", market("CASH"), enrichedName = null)
+        verifier.verify("MYHOUSE", market("PRIVATE"), enrichedName = null)
+
+        verify(assetSearchService, never()).search(any(), anyOrNull())
+    }
+
+    @Test
+    fun `fails open when the search provider errors`() {
+        whenever(assetSearchService.search(any(), anyOrNull()))
+            .thenThrow(RuntimeException("provider down"))
+
+        // No throw — a search outage must never block asset creation.
+        verifier.verify("VUAA", market("US", "US"), enrichedName = null)
+        assertThat(true).isTrue()
+    }
+}


### PR DESCRIPTION
## Why
Prevention for the root cause of the Mike-metrics outage. bc-view's trade form defaults the market from the **portfolio currency** (USD → `US`), so a USD-denominated foreign listing — Vanguard `VUAA` on the LSE — was created as `VUAA.US`. EODHD can't price `VUAA.US` → 500 on /allocation → empty/false-depleted projection. Nothing validated that the ticker actually trades on the chosen exchange.

## What
`AssetMarketVerifier`, called from `AssetService.create` after enrichment:
- Only acts when the enricher chain **couldn't resolve** the ticker (blank name) on a provider-backed market.
- Asks the search providers where the ticker trades. If it lists **only on a different exchange**, reject (400) with the valid market(s): *"VUAA was not found on market US. It is listed on: LSE, AS."*
- **Equivalence by EODHD exchange**, not raw market code: US / NASDAQ / NYSE / AMEX all map to EODHD `US`, so a ticker the search reports on NASDAQ is **not** rejected for a US create (regression-tested).
- **Fail-open**: no search hits (new/private ticker) or a search error never blocks creation.
- Exempts CASH / PRIVATE / RE / INDEX / MUTF.
- `@Lazy` injection breaks the construction cycle (AssetService → verifier → AssetSearchService → MdFactory → Alpha* → AssetService).

## Tests
Unit test (mocked search + markets): rejects wrong-exchange; **allows US ticker reported on NASDAQ**; allows when unknown; skips when enriched / internal markets; fails open on search error. Full `:svc-data:test` green; format + lint + semgrep clean.

## Note
This is the backend backstop (covers trade entry AND CSV import). The bc-view UX nicety (verify-on-entry / kill the silent US default) is a smaller follow-up; the currency-default itself still picks US for USD — this catches the resulting mistake at persist time.

@coderabbitai ignore