### PR TITLE
feat(cash): emit auto-settle transfer on settlement, delete on unsettle

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
@@ -26,7 +26,8 @@ class AutoSettleService(
     private val trnRepository: TrnRepository,
     private val dateUtils: DateUtils,
     private val userPreferencesService: UserPreferencesService,
-    private val fxTransactions: FxTransactions
+    private val fxTransactions: FxTransactions,
+    private val cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
 ) {
     private val log = LoggerFactory.getLogger(AutoSettleService::class.java)
 
@@ -91,6 +92,14 @@ class AutoSettleService(
             }
             trn.status = TrnStatus.SETTLED
             trnRepository.save(trn)
+            // Emit the compensating cash transfer now the event has settled —
+            // mirrors the manual TrnService.settleTransactions path so cash-
+            // impacting events (DIVI/INCOME) get their cash leg on settle, not
+            // create.
+            cashAutoSettleService
+                .emitCompensatingTransfer(trn)
+                .warnings
+                .forEach { log.warn("Auto-settle cash on scheduled settle of {}: {}", trn.id, it) }
             settledCount++
             log.info(
                 "Auto-settled transaction: {}, asset: {}, portfolio: {}, tradeDate: {}",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
@@ -1,6 +1,5 @@
 package com.beancounter.marketdata.trn
 
-import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
@@ -26,8 +25,7 @@ class AutoSettleService(
     private val trnRepository: TrnRepository,
     private val dateUtils: DateUtils,
     private val userPreferencesService: UserPreferencesService,
-    private val fxTransactions: FxTransactions,
-    private val cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
+    private val trnSettlementService: TrnSettlementService
 ) {
     private val log = LoggerFactory.getLogger(AutoSettleService::class.java)
 
@@ -77,29 +75,11 @@ class AutoSettleService(
                 )
                 continue
             }
-            // Resolve FX rates now that tradeDate has arrived. Ingest of PROPOSED
-            // event trns defers FX (forward payDate; providers reject future dates).
-            try {
-                fxTransactions.setRates(trn.portfolio, trn)
-            } catch (ex: RuntimeException) {
-                log.warn(
-                    "FX resolution failed for {} on {} — leaving PROPOSED for retry: {}",
-                    trn.id,
-                    trn.tradeDate,
-                    ex.message
-                )
-                continue
-            }
-            trn.status = TrnStatus.SETTLED
-            trnRepository.save(trn)
-            // Emit the compensating cash transfer now the event has settled —
-            // mirrors the manual TrnService.settleTransactions path so cash-
-            // impacting events (DIVI/INCOME) get their cash leg on settle, not
-            // create.
-            cashAutoSettleService
-                .emitCompensatingTransfer(trn)
-                .warnings
-                .forEach { log.warn("Auto-settle cash on scheduled settle of {}: {}", trn.id, it) }
+            // Shared settle core — FX + status flip + cash emit. Same path as the
+            // manual TrnService.settleTransactions, so a scheduled DIVI/SPLIT settle
+            // produces its cash leg identically. Null = FX not yet resolvable; leave
+            // PROPOSED for the next run.
+            trnSettlementService.settle(trn.portfolio, trn) ?: continue
             settledCount++
             log.info(
                 "Auto-settled transaction: {}, asset: {}, portfolio: {}, tradeDate: {}",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -674,6 +674,35 @@ class TrnController(
         ) @RequestBody request: SettleTransactionsRequest
     ): TrnResponse = TrnResponse(trnService.settleTransactions(portfolioId, request.trnIds))
 
+    @PostMapping(
+        value = ["/portfolio/{portfolioId}/unsettle"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "Unsettle settled transactions",
+        description = """
+            Reverts SETTLED transactions to PROPOSED, cascade-deleting each one's
+            auto-emitted cash legs (same per-trn core as single Unsettle). Non-SETTLED
+            or missing ids are skipped, never aborting the batch.
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Transactions unsettled"),
+            ApiResponse(responseCode = "404", description = "Portfolio not found")
+        ]
+    )
+    fun unsettleTransactions(
+        @Parameter(
+            description = "Portfolio identifier",
+            example = "portfolio-123"
+        ) @PathVariable("portfolioId") portfolioId: String,
+        @Parameter(
+            description = "Request body containing transaction IDs to unsettle"
+        ) @RequestBody request: SettleTransactionsRequest
+    ): TrnResponse = TrnResponse(trnService.unsettleTransactions(portfolioId, request.trnIds))
+
     @GetMapping(
         value = ["/{portfolioId}/cash-ladder/{cashAssetId}"],
         produces = [MediaType.APPLICATION_JSON_VALUE]

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -1,6 +1,5 @@
 package com.beancounter.marketdata.trn
 
-import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.contracts.TrnDeleteResponse
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.contracts.TrnResponse
@@ -44,7 +43,7 @@ class TrnService(
     private val cacheInvalidationProducer: CacheInvalidationProducer,
     private val portfolioShareRepository: PortfolioShareRepository,
     private val cashAutoSettleService: CashAutoSettleService,
-    private val fxTransactions: FxTransactions,
+    private val trnSettlementService: TrnSettlementService,
     private val dateUtils: DateUtils
 ) {
     private val log = LoggerFactory.getLogger(TrnService::class.java)
@@ -277,27 +276,9 @@ class TrnService(
                         )
                         continue
                     }
-                    // Resolve FX rates now that user has confirmed settlement.
-                    // Ingest of forward-dated event trns (DIVI payDate) defers FX.
-                    try {
-                        fxTransactions.setRates(portfolio, trn)
-                    } catch (ex: RuntimeException) {
-                        log.warn(
-                            "FX resolution failed for {} on {} — leaving PROPOSED: {}",
-                            trnId,
-                            trn.tradeDate,
-                            ex.message
-                        )
-                        continue
-                    }
-                    trn.status = TrnStatus.SETTLED
-                    val saved = trnRepository.save(trn)
-                    // Emit the compensating cash transfer now the trade is settled.
-                    // Deferred from create — a PROPOSED trade has no cash leg yet.
-                    cashAutoSettleService
-                        .emitCompensatingTransfer(saved)
-                        .warnings
-                        .forEach { log.warn("Auto-settle on settle of {}: {}", trnId, it) }
+                    // Shared settle core: FX + status flip + cash emit. Returns
+                    // null when FX can't resolve yet (leaves it PROPOSED for retry).
+                    val saved = trnSettlementService.settle(portfolio, trn) ?: continue
                     settled.add(saved)
                     log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
                 } else {
@@ -400,12 +381,12 @@ class TrnService(
     }
 
     /**
-     * Toggle a trn from SETTLED to PROPOSED. Surfaces auto-settled siblings
-     * for the caller to optionally delete via follow-up requests.
+     * Toggle a trn from SETTLED to PROPOSED, cascade-deleting its auto-emitted
+     * cash legs (see [TrnSettlementService.unsettle]). `siblings` reports the
+     * removed leg ids for the UI to refresh.
      *
-     * Idempotency: callers must check status first. Calling unsettle on a trn
-     * that isn't SETTLED throws — there's no useful "transition to PROPOSED
-     * from PROPOSED" semantic.
+     * Idempotency: calling unsettle on a trn that isn't SETTLED throws — there's
+     * no useful "transition to PROPOSED from PROPOSED" semantic.
      */
     fun unsettle(trnId: String): TrnStatusUpdateResponse {
         val parent =
@@ -418,19 +399,44 @@ class TrnService(
         require(parent.status == TrnStatus.SETTLED) {
             "Cannot unsettle trn $trnId: status is ${parent.status}, expected SETTLED"
         }
-        // The compensating cash transfer only exists while the trade is settled.
-        // Unsettling removes it (server-side cascade) — the W+D legs are
-        // re-emitted if the trade is settled again. `siblings` reports the
-        // deleted leg ids for the UI to refresh, no longer to prompt-then-delete.
-        val siblings = cashAutoSettleService.findSiblings(parent)
-        if (siblings.isNotEmpty()) {
-            trnRepository.deleteAll(siblings)
-            log.info("Unsettle of {} removed {} auto-settled cash leg(s)", trnId, siblings.size)
-        }
-        parent.status = TrnStatus.PROPOSED
-        val saved = trnRepository.save(parent)
+        val siblings = trnSettlementService.unsettle(parent)
         cacheInvalidationProducer.sendTransactionEvent(parent.portfolio.id, parent.tradeDate)
-        return TrnStatusUpdateResponse(updated = saved, siblings = siblings.map { it.id })
+        return TrnStatusUpdateResponse(updated = parent, siblings = siblings)
+    }
+
+    /**
+     * Bulk unsettle for a portfolio — the multi-select counterpart to
+     * [settleTransactions]. Each SETTLED trn flows through the same
+     * [TrnSettlementService.unsettle] core (cash-leg cascade) as the single path,
+     * so behaviour is identical regardless of UI. Non-SETTLED / missing ids are
+     * skipped with a log, never aborting the batch.
+     */
+    fun unsettleTransactions(
+        portfolioId: String,
+        trnIds: List<String>
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val unsettled = mutableListOf<Trn>()
+        for (trnId in trnIds) {
+            val trn = trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
+            when {
+                trn == null -> {
+                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
+                }
+                trn.status != TrnStatus.SETTLED -> {
+                    log.warn("Cannot unsettle {} - status is {} not SETTLED", trnId, trn.status)
+                }
+                else -> {
+                    trnSettlementService.unsettle(trn)
+                    unsettled.add(trn)
+                }
+            }
+        }
+        log.info("Unsettled {} transactions for portfolio {}", unsettled.size, portfolio.code)
+        unsettled.minOfOrNull { it.tradeDate }?.let {
+            cacheInvalidationProducer.sendTransactionEvent(portfolio.id, it)
+        }
+        return postProcess(unsettled)
     }
 
     fun patch(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -99,6 +99,10 @@ class TrnService(
         // types (DEPOSIT/WITHDRAWAL etc.) — no recursion risk.
         val warnings = mutableListOf<String>()
         for (trn in results.toList()) {
+            // Cash auto-settle fires on SETTLEMENT, not creation. A PROPOSED trade
+            // carries no compensating cash transfer until it settles (see
+            // settleTransactions); a trade saved already-SETTLED still emits here.
+            if (trn.status != TrnStatus.SETTLED) continue
             val res = cashAutoSettleService.emitCompensatingTransfer(trn)
             warnings.addAll(res.warnings)
         }
@@ -288,6 +292,12 @@ class TrnService(
                     }
                     trn.status = TrnStatus.SETTLED
                     val saved = trnRepository.save(trn)
+                    // Emit the compensating cash transfer now the trade is settled.
+                    // Deferred from create — a PROPOSED trade has no cash leg yet.
+                    cashAutoSettleService
+                        .emitCompensatingTransfer(saved)
+                        .warnings
+                        .forEach { log.warn("Auto-settle on settle of {}: {}", trnId, it) }
                     settled.add(saved)
                     log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
                 } else {
@@ -408,11 +418,19 @@ class TrnService(
         require(parent.status == TrnStatus.SETTLED) {
             "Cannot unsettle trn $trnId: status is ${parent.status}, expected SETTLED"
         }
-        val siblings = cashAutoSettleService.findSiblings(parent).map { it.id }
+        // The compensating cash transfer only exists while the trade is settled.
+        // Unsettling removes it (server-side cascade) — the W+D legs are
+        // re-emitted if the trade is settled again. `siblings` reports the
+        // deleted leg ids for the UI to refresh, no longer to prompt-then-delete.
+        val siblings = cashAutoSettleService.findSiblings(parent)
+        if (siblings.isNotEmpty()) {
+            trnRepository.deleteAll(siblings)
+            log.info("Unsettle of {} removed {} auto-settled cash leg(s)", trnId, siblings.size)
+        }
         parent.status = TrnStatus.PROPOSED
         val saved = trnRepository.save(parent)
         cacheInvalidationProducer.sendTransactionEvent(parent.portfolio.id, parent.tradeDate)
-        return TrnStatusUpdateResponse(updated = saved, siblings = siblings)
+        return TrnStatusUpdateResponse(updated = saved, siblings = siblings.map { it.id })
     }
 
     fun patch(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
@@ -1,0 +1,78 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.marketdata.cash.CashAutoSettleService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Single source of truth for the settle / unsettle state transition and its cash
+ * side effects, so every caller behaves identically regardless of the UI or entry
+ * path — manual bulk settle ([TrnService.settleTransactions]), the scheduled event
+ * settle ([AutoSettleService]), single and bulk unsettle ([TrnService.unsettle],
+ * [TrnService.unsettleTransactions]).
+ *
+ * Callers own their own preconditions (future-date guard, owner opt-in, auth,
+ * status checks); this service owns the transition itself: FX resolution, the
+ * status flip + persist, and the compensating cash transfer (emit on settle,
+ * cascade-delete on unsettle).
+ */
+@Service
+class TrnSettlementService(
+    private val trnRepository: TrnRepository,
+    private val fxTransactions: FxTransactions,
+    private val cashAutoSettleService: CashAutoSettleService
+) {
+    private val log = LoggerFactory.getLogger(TrnSettlementService::class.java)
+
+    /**
+     * Settle one trn: resolve FX, flip PROPOSED→SETTLED, persist, and emit the
+     * compensating cash transfer. Returns the settled trn, or null when FX can't
+     * yet be resolved (forward-dated events) — the caller leaves it PROPOSED for
+     * retry.
+     */
+    fun settle(
+        portfolio: Portfolio,
+        trn: Trn
+    ): Trn? {
+        try {
+            // Resolve FX now that settlement is confirmed. Ingest of forward-dated
+            // event trns (DIVI payDate) defers FX; providers reject future dates.
+            fxTransactions.setRates(portfolio, trn)
+        } catch (ex: RuntimeException) {
+            log.warn(
+                "FX resolution failed for {} on {} — leaving PROPOSED for retry: {}",
+                trn.id,
+                trn.tradeDate,
+                ex.message
+            )
+            return null
+        }
+        trn.status = TrnStatus.SETTLED
+        trnRepository.save(trn)
+        cashAutoSettleService
+            .emitCompensatingTransfer(trn)
+            .warnings
+            .forEach { log.warn("Auto-settle cash for {}: {}", trn.id, it) }
+        return trn
+    }
+
+    /**
+     * Unsettle one trn: cascade-delete the auto-emitted cash legs, flip
+     * SETTLED→PROPOSED, persist. Returns the removed sibling ids. The cash legs
+     * are re-emitted if the trn settles again.
+     */
+    fun unsettle(trn: Trn): List<String> {
+        val siblings = cashAutoSettleService.findSiblings(trn)
+        if (siblings.isNotEmpty()) {
+            trnRepository.deleteAll(siblings)
+            log.info("Unsettle of {} removed {} auto-settled cash leg(s)", trn.id, siblings.size)
+        }
+        trn.status = TrnStatus.PROPOSED
+        trnRepository.save(trn)
+        return siblings.map { it.id }
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
@@ -1,6 +1,5 @@
 package com.beancounter.marketdata.trn
 
-import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
@@ -14,7 +13,6 @@ import com.beancounter.marketdata.registration.UserPreferencesService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -33,8 +31,7 @@ class AutoSettleServiceTest {
     private lateinit var autoSettleService: AutoSettleService
     private lateinit var dateUtils: DateUtils
     private lateinit var userPreferencesService: UserPreferencesService
-    private lateinit var fxTransactions: FxTransactions
-    private lateinit var cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
+    private lateinit var trnSettlementService: TrnSettlementService
     private val today = LocalDate.now()
 
     private val testOwner = SystemUser("test-user", "test@example.com")
@@ -57,13 +54,13 @@ class AutoSettleServiceTest {
         trnRepository = mock(TrnRepository::class.java)
         dateUtils = mock(DateUtils::class.java)
         userPreferencesService = mock(UserPreferencesService::class.java)
-        fxTransactions = mock(FxTransactions::class.java)
-        cashAutoSettleService = mock(com.beancounter.marketdata.cash.CashAutoSettleService::class.java)
-        `when`(cashAutoSettleService.emitCompensatingTransfer(kAny()))
-            .thenReturn(
-                com.beancounter.marketdata.cash
-                    .AutoSettleResult()
-            )
+        trnSettlementService = mock(TrnSettlementService::class.java)
+        `when`(trnSettlementService.settle(kAny(), kAny()))
+            .thenAnswer { invocation ->
+                val t = invocation.getArgument<Trn>(1)
+                t.status = TrnStatus.SETTLED
+                t
+            }
         `when`(dateUtils.date).thenReturn(today)
         // Default: every owner opted in.
         `when`(userPreferencesService.getOrCreate(kAny<SystemUser>()))
@@ -71,7 +68,7 @@ class AutoSettleServiceTest {
                 UserPreferences(owner = invocation.getArgument(0))
             }
         autoSettleService =
-            AutoSettleService(trnRepository, dateUtils, userPreferencesService, fxTransactions, cashAutoSettleService)
+            AutoSettleService(trnRepository, dateUtils, userPreferencesService, trnSettlementService)
     }
 
     @Test
@@ -86,7 +83,7 @@ class AutoSettleServiceTest {
 
         // Then: The transaction should be settled
         assertThat(result).isEqualTo(1)
-        verify(trnRepository).save(proposedTrn)
+        verify(trnSettlementService).settle(testPortfolio, proposedTrn)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.SETTLED)
     }
 
@@ -102,7 +99,7 @@ class AutoSettleServiceTest {
 
         // Then: The transaction should be settled
         assertThat(result).isEqualTo(1)
-        verify(trnRepository).save(proposedTrn)
+        verify(trnSettlementService).settle(testPortfolio, proposedTrn)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.SETTLED)
     }
 
@@ -119,7 +116,7 @@ class AutoSettleServiceTest {
 
         // Then: The transaction should be settled
         assertThat(result).isEqualTo(1)
-        verify(trnRepository).save(proposedTrn)
+        verify(trnSettlementService).settle(testPortfolio, proposedTrn)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.SETTLED)
     }
 
@@ -153,7 +150,7 @@ class AutoSettleServiceTest {
 
         // Then: No transactions should be settled
         assertThat(result).isEqualTo(0)
-        verify(trnRepository, never()).save(any(Trn::class.java))
+        verify(trnSettlementService, never()).settle(kAny(), kAny())
     }
 
     @Test
@@ -168,49 +165,48 @@ class AutoSettleServiceTest {
 
         assertThat(result).isEqualTo(0)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.PROPOSED)
-        verify(trnRepository, never()).save(any(Trn::class.java))
+        verify(trnSettlementService, never()).settle(kAny(), kAny())
     }
 
     @Test
-    fun `should resolve FX rates before flipping status to SETTLED`() {
-        // Given: A PROPOSED dividend with tradeDate = today and unset FX rates
-        // (rates were skipped at ingest because tradeDate was a future pay date)
+    fun `delegates due transactions to the settlement service`() {
+        // Given: A PROPOSED dividend with tradeDate = today.
         val proposedTrn = createProposedTransaction("trn-1", today, TrnType.DIVI)
-        proposedTrn.tradeBaseRate = BigDecimal.ZERO
-        proposedTrn.tradePortfolioRate = BigDecimal.ZERO
-        proposedTrn.tradeCashRate = BigDecimal.ZERO
         `when`(trnRepository.findDueEventTransactions(TrnStatus.PROPOSED, EVENT_TYPES, today))
             .thenReturn(listOf(proposedTrn))
 
         // When: Auto-settle is triggered
-        autoSettleService.autoSettleDueTransactions()
+        val result = autoSettleService.autoSettleDueTransactions()
 
-        // Then: FxTransactions.setRates was called with the trn's portfolio + the trn,
-        // and the status flip happened after.
-        val inOrder = org.mockito.Mockito.inOrder(fxTransactions, trnRepository)
-        inOrder.verify(fxTransactions).setRates(testPortfolio, proposedTrn)
-        inOrder.verify(trnRepository).save(proposedTrn)
+        // Then: the settle core (FX + status flip + persist + cash emit, all owned by
+        // TrnSettlementService) is delegated to for the due trn's own portfolio.
+        assertThat(result).isEqualTo(1)
+        verify(trnSettlementService).settle(testPortfolio, proposedTrn)
         assertThat(proposedTrn.status).isEqualTo(TrnStatus.SETTLED)
     }
 
     @Test
-    fun `FX failure on one trn does not stop the batch`() {
-        // Given: two due DIVI trns. The first one's FX resolution throws; the second succeeds.
+    fun `null settle result (FX not resolvable) leaves trn PROPOSED and is not counted`() {
+        // Given: two due DIVI trns. The first one's settle returns null (FX deferred);
+        // the second settles normally via the default stub.
         val failing = createProposedTransaction("trn-fail", today, TrnType.DIVI)
         val succeeding = createProposedTransaction("trn-ok", today, TrnType.DIVI)
         `when`(trnRepository.findDueEventTransactions(TrnStatus.PROPOSED, EVENT_TYPES, today))
             .thenReturn(listOf(failing, succeeding))
-        `when`(fxTransactions.setRates(testPortfolio, failing))
-            .thenThrow(IllegalStateException("FX rate missing for USD/EUR"))
+        // doReturn avoids invoking the default mutating stub during stubbing setup.
+        org.mockito.Mockito
+            .doReturn(null)
+            .`when`(trnSettlementService)
+            .settle(testPortfolio, failing)
 
         val result = autoSettleService.autoSettleDueTransactions()
 
-        // Then: failing trn stays PROPOSED and is never saved; the other one settles.
+        // Then: failing trn stays PROPOSED and is not counted; the other one settles.
         assertThat(result).isEqualTo(1)
         assertThat(failing.status).isEqualTo(TrnStatus.PROPOSED)
         assertThat(succeeding.status).isEqualTo(TrnStatus.SETTLED)
-        verify(trnRepository, never()).save(failing)
-        verify(trnRepository).save(succeeding)
+        verify(trnSettlementService).settle(testPortfolio, failing)
+        verify(trnSettlementService).settle(testPortfolio, succeeding)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/AutoSettleServiceTest.kt
@@ -34,6 +34,7 @@ class AutoSettleServiceTest {
     private lateinit var dateUtils: DateUtils
     private lateinit var userPreferencesService: UserPreferencesService
     private lateinit var fxTransactions: FxTransactions
+    private lateinit var cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
     private val today = LocalDate.now()
 
     private val testOwner = SystemUser("test-user", "test@example.com")
@@ -57,6 +58,12 @@ class AutoSettleServiceTest {
         dateUtils = mock(DateUtils::class.java)
         userPreferencesService = mock(UserPreferencesService::class.java)
         fxTransactions = mock(FxTransactions::class.java)
+        cashAutoSettleService = mock(com.beancounter.marketdata.cash.CashAutoSettleService::class.java)
+        `when`(cashAutoSettleService.emitCompensatingTransfer(kAny()))
+            .thenReturn(
+                com.beancounter.marketdata.cash
+                    .AutoSettleResult()
+            )
         `when`(dateUtils.date).thenReturn(today)
         // Default: every owner opted in.
         `when`(userPreferencesService.getOrCreate(kAny<SystemUser>()))
@@ -64,7 +71,7 @@ class AutoSettleServiceTest {
                 UserPreferences(owner = invocation.getArgument(0))
             }
         autoSettleService =
-            AutoSettleService(trnRepository, dateUtils, userPreferencesService, fxTransactions)
+            AutoSettleService(trnRepository, dateUtils, userPreferencesService, fxTransactions, cashAutoSettleService)
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -40,6 +40,7 @@ class TrnSettleTest {
     private lateinit var systemUserService: SystemUserService
     private lateinit var trnService: TrnService
     private lateinit var dateUtils: DateUtils
+    private lateinit var cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
 
     private val today: LocalDate = LocalDate.of(2026, 6, 6)
 
@@ -67,6 +68,12 @@ class TrnSettleTest {
         whenever(portfolioService.find("pf-1")).thenReturn(portfolio)
         whenever(trnMigrator.upgrade(any())).thenAnswer { it.arguments[0] as Trn }
         whenever(systemUserService.getOrThrow()).thenReturn(owner)
+        cashAutoSettleService = mock()
+        whenever(cashAutoSettleService.emitCompensatingTransfer(any()))
+            .thenReturn(
+                com.beancounter.marketdata.cash
+                    .AutoSettleResult()
+            )
         trnService =
             TrnService(
                 trnRepository = trnRepository,
@@ -77,7 +84,7 @@ class TrnSettleTest {
                 systemUserService = systemUserService,
                 cacheInvalidationProducer = cacheInvalidationProducer,
                 portfolioShareRepository = mock<PortfolioShareRepository>(),
-                cashAutoSettleService = mock<CashAutoSettleService>(),
+                cashAutoSettleService = cashAutoSettleService,
                 fxTransactions = fxTransactions,
                 dateUtils = dateUtils
             )

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -1,6 +1,5 @@
 package com.beancounter.marketdata.trn
 
-import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
@@ -34,13 +33,13 @@ import java.util.Optional
 class TrnSettleTest {
     private lateinit var trnRepository: TrnRepository
     private lateinit var portfolioService: PortfolioService
-    private lateinit var fxTransactions: FxTransactions
     private lateinit var trnMigrator: TrnMigrator
     private lateinit var cacheInvalidationProducer: CacheInvalidationProducer
     private lateinit var systemUserService: SystemUserService
     private lateinit var trnService: TrnService
     private lateinit var dateUtils: DateUtils
     private lateinit var cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
+    private lateinit var trnSettlementService: TrnSettlementService
 
     private val today: LocalDate = LocalDate.of(2026, 6, 6)
 
@@ -59,7 +58,6 @@ class TrnSettleTest {
     fun setUp() {
         trnRepository = mock()
         portfolioService = mock()
-        fxTransactions = mock()
         trnMigrator = mock()
         cacheInvalidationProducer = mock()
         systemUserService = mock()
@@ -74,6 +72,12 @@ class TrnSettleTest {
                 com.beancounter.marketdata.cash
                     .AutoSettleResult()
             )
+        trnSettlementService = mock()
+        whenever(trnSettlementService.settle(any(), any())).thenAnswer {
+            val t = it.getArgument<Trn>(1)
+            t.status = TrnStatus.SETTLED
+            t
+        }
         trnService =
             TrnService(
                 trnRepository = trnRepository,
@@ -85,7 +89,7 @@ class TrnSettleTest {
                 cacheInvalidationProducer = cacheInvalidationProducer,
                 portfolioShareRepository = mock<PortfolioShareRepository>(),
                 cashAutoSettleService = cashAutoSettleService,
-                fxTransactions = fxTransactions,
+                trnSettlementService = trnSettlementService,
                 dateUtils = dateUtils
             )
     }
@@ -101,7 +105,7 @@ class TrnSettleTest {
         assertThat(result).isEmpty()
         assertThat(forwardTrn.status).isEqualTo(TrnStatus.PROPOSED)
         verify(trnRepository, never()).save(forwardTrn)
-        verify(fxTransactions, never()).setRates(any(), any<Trn>())
+        verify(trnSettlementService, never()).settle(any(), any())
     }
 
     @Test
@@ -109,14 +113,12 @@ class TrnSettleTest {
         val dueTrn = proposed("trn-today", today)
         whenever(trnRepository.findByPortfolioIdAndId(portfolio.id, "trn-today"))
             .thenReturn(Optional.of(dueTrn))
-        whenever(trnRepository.save(dueTrn)).thenReturn(dueTrn)
 
         val result = trnService.settleTransactions("pf-1", listOf("trn-today"))
 
         assertThat(result).hasSize(1)
         assertThat(dueTrn.status).isEqualTo(TrnStatus.SETTLED)
-        verify(fxTransactions).setRates(portfolio, dueTrn)
-        verify(trnRepository).save(dueTrn)
+        verify(trnSettlementService).settle(portfolio, dueTrn)
     }
 
     private fun proposed(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
@@ -1,0 +1,113 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.cash.AutoSettleResult
+import com.beancounter.marketdata.cash.CashAutoSettleService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * The shared settle / unsettle core every entry path funnels through. The
+ * orchestration tests (TrnSettleTest, AutoSettleServiceTest) mock this service;
+ * these tests pin the actual FX + status + cash behaviour once.
+ */
+class TrnSettlementServiceTest {
+    private lateinit var trnRepository: TrnRepository
+    private lateinit var fxTransactions: FxTransactions
+    private lateinit var cashAutoSettleService: CashAutoSettleService
+    private lateinit var service: TrnSettlementService
+
+    private val owner = SystemUser("u", "u@example.com")
+    private val portfolio =
+        Portfolio(id = "pf-1", code = "TEST", name = "Test", currency = USD, base = USD, owner = owner)
+
+    @BeforeEach
+    fun setUp() {
+        trnRepository = org.mockito.kotlin.mock()
+        fxTransactions = org.mockito.kotlin.mock()
+        cashAutoSettleService = org.mockito.kotlin.mock()
+        whenever(cashAutoSettleService.emitCompensatingTransfer(any())).thenReturn(AutoSettleResult())
+        service = TrnSettlementService(trnRepository, fxTransactions, cashAutoSettleService)
+    }
+
+    private fun proposed(id: String) =
+        Trn(
+            id = id,
+            portfolio = portfolio,
+            asset = MSFT,
+            trnType = TrnType.BUY,
+            tradeDate = LocalDate.of(2026, 6, 6),
+            quantity = BigDecimal("1"),
+            price = BigDecimal("10"),
+            tradeAmount = BigDecimal("10"),
+            tradeCurrency = USD,
+            status = TrnStatus.PROPOSED
+        )
+
+    @Test
+    fun `settle resolves FX, flips to SETTLED, persists and emits the cash transfer`() {
+        val trn = proposed("t1")
+
+        val result = service.settle(portfolio, trn)
+
+        assertThat(result).isSameAs(trn)
+        assertThat(trn.status).isEqualTo(TrnStatus.SETTLED)
+        verify(fxTransactions).setRates(portfolio, trn)
+        verify(trnRepository).save(trn)
+        verify(cashAutoSettleService).emitCompensatingTransfer(trn)
+    }
+
+    @Test
+    fun `settle returns null and leaves PROPOSED when FX cannot resolve`() {
+        val trn = proposed("t2")
+        whenever(fxTransactions.setRates(portfolio, trn)).thenThrow(RuntimeException("no rate"))
+
+        val result = service.settle(portfolio, trn)
+
+        assertThat(result).isNull()
+        assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+        verify(trnRepository, never()).save(any())
+        verify(cashAutoSettleService, never()).emitCompensatingTransfer(any())
+    }
+
+    @Test
+    fun `unsettle deletes the cash legs, flips to PROPOSED and reports removed ids`() {
+        val trn = proposed("t3").apply { status = TrnStatus.SETTLED }
+        val legs = listOf(proposed("w"), proposed("d"))
+        whenever(cashAutoSettleService.findSiblings(trn)).thenReturn(legs)
+
+        val removed = service.unsettle(trn)
+
+        assertThat(removed).containsExactly("w", "d")
+        assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+        verify(trnRepository).deleteAll(legs)
+        verify(trnRepository).save(trn)
+    }
+
+    @Test
+    fun `unsettle with no cash legs just flips to PROPOSED`() {
+        val trn = proposed("t4").apply { status = TrnStatus.SETTLED }
+        whenever(cashAutoSettleService.findSiblings(trn)).thenReturn(emptyList())
+
+        val removed = service.unsettle(trn)
+
+        assertThat(removed).isEmpty()
+        assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+        verify(trnRepository, never()).deleteAll(any<List<Trn>>())
+        verify(trnRepository).save(trn)
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
@@ -428,6 +428,22 @@ class CashAutoSettleServiceTest {
     }
 
     @Test
+    fun `bulk unsettle reverts each trade and deletes all their cash legs`() {
+        mockAuthConfig.login(testUser, systemUserService)
+        val b1 = buildBuy(invest, BigDecimal("-1000"))
+        val b2 = buildBuy(invest, BigDecimal("-1500"))
+        assertThat(findAutoSiblings(b1)).hasSize(2)
+        assertThat(findAutoSiblings(b2)).hasSize(2)
+
+        val result = trnService.unsettleTransactions(invest.id, listOf(b1.id, b2.id))
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.status }).containsOnly(TrnStatus.PROPOSED)
+        assertThat(findAutoSiblings(b1)).isEmpty()
+        assertThat(findAutoSiblings(b2)).isEmpty()
+    }
+
+    @Test
     fun `unsettle on already PROPOSED trn throws IllegalArgumentException`() {
         mockAuthConfig.login(testUser, systemUserService)
         val buy = buildBuy(invest, BigDecimal("-1000"))

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
@@ -393,14 +393,38 @@ class CashAutoSettleServiceTest {
     }
 
     @Test
-    fun `unsettle returns sibling ids when BUY had an auto-emitted pair`() {
+    fun `unsettle deletes the auto-emitted cash pair and reports the removed ids`() {
         mockAuthConfig.login(testUser, systemUserService)
         val buy = buildBuy(invest, BigDecimal("-2000"))
+        assertThat(findAutoSiblings(buy)).hasSize(2)
+
         val response = trnService.unsettle(buy.id)
 
         assertThat(response.updated.id).isEqualTo(buy.id)
         assertThat(response.updated.status).isEqualTo(TrnStatus.PROPOSED)
+        // The two cash legs are removed server-side; the ids are reported back.
         assertThat(response.siblings).hasSize(2)
+        assertThat(findAutoSiblings(buy)).isEmpty()
+    }
+
+    @Test
+    fun `a PROPOSED trade emits no cash transfer until it is settled`() {
+        mockAuthConfig.login(testUser, systemUserService)
+        val buy = buildBuy(invest, BigDecimal("-1200"), status = TrnStatus.PROPOSED)
+
+        assertThat(buy.status).isEqualTo(TrnStatus.PROPOSED)
+        assertThat(findAutoSiblings(buy)).isEmpty()
+    }
+
+    @Test
+    fun `settling a PROPOSED trade emits the compensating cash transfer`() {
+        mockAuthConfig.login(testUser, systemUserService)
+        val buy = buildBuy(invest, BigDecimal("-1200"), status = TrnStatus.PROPOSED)
+        assertThat(findAutoSiblings(buy)).isEmpty()
+
+        trnService.settleTransactions(invest.id, listOf(buy.id))
+
+        assertThat(findAutoSiblings(buy)).hasSize(2)
     }
 
     @Test
@@ -476,7 +500,8 @@ class CashAutoSettleServiceTest {
 
     private fun buildBuy(
         portfolio: Portfolio,
-        cashAmount: BigDecimal
+        cashAmount: BigDecimal,
+        status: TrnStatus = TrnStatus.SETTLED
     ): Trn =
         trnService
             .save(
@@ -496,7 +521,7 @@ class CashAutoSettleServiceTest {
                             cashAmount = cashAmount,
                             tradeCashRate = BigDecimal.ONE,
                             tradeDate = LocalDate.now(),
-                            status = TrnStatus.SETTLED
+                            status = status
                         )
                     )
                 )


### PR DESCRIPTION
## What
Changes the cash auto-settle trigger from **trade creation** to **settlement**, per request: *"do not create the cash settlement transfer until the trade is settled; if subsequently unsettled, delete the cash transaction too."*

- **Gated emit**: `TrnService.saveWithResult` only emits when the trn is saved already-`SETTLED`. A `PROPOSED` trade (the default) carries no compensating cash transfer.
- **On settle**: `TrnService.settleTransactions` (manual PROPOSED→SETTLED) emits the W+D pair.
- **Scheduled settle too**: `AutoSettleService` (DIVI/SPLIT date-based settle) emits as well — both settle paths now call `emitCompensatingTransfer` (a fix to one must land in the other).
- **Unsettle cascades**: `TrnService.unsettle` (SETTLED→PROPOSED) now **deletes** the auto-emitted cash legs server-side; the response `siblings` reports the removed ids. Re-emitted if the trade settles again.
- **Parent delete unchanged**: `deleteWithSiblings` still surfaces siblings for the UI to confirm (asymmetry by design — unsettle is reversible, delete is deliberate).

## Tests
New: PROPOSED trade emits nothing; settling emits the pair; unsettle deletes the pair. Updated the prior "unsettle returns ids" test to assert deletion; stubbed the two mocked-ctor tests (TrnSettleTest, AutoSettleServiceTest) for the new emit call. Full `:svc-data:test` green; format + lint + semgrep clean.

## Paired follow-up (bc-view)
The unsettle UI currently prompts the user to delete the cash legs (consuming `TrnStatusUpdateResponse.siblings`). The server now cascades, so bc-view should stop prompting on unsettle and just refresh. Not in this PR.

TRN.md updated (bc-claude).

@coderabbitai ignore