### PR TITLE
chore(deps): bump spring-ai 1.1.5→1.1.8, spring-boot 3.5.14→3.5.15

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 kotlin = "2.3.20"
 kotlinter = "5.4.2"
-spring-boot = "3.5.14"
+spring-boot = "3.5.15"
 spring-cloud = "2025.0.2"
 spring-cloud-contract = "4.3.1"
 spring-data-bom = "2025.0.8"
@@ -16,7 +16,7 @@ sentry = "8.40.0"
 postgres = "42.7.10"
 guava = "33.5.0-jre"
 servlet-api = "6.1.0"
-spring-ai = "1.1.5"
+spring-ai = "1.1.8"
 flyway = "11.20.0"
 # Pinned because jar-common exposes the bridge as an api dep but
 # downstream modules (e.g. jar-shell) don't import the spring-boot


### PR DESCRIPTION
## Summary
- `spring-ai` 1.1.5 → 1.1.8 (patch; no API changes for svc-agent)
- `spring-boot` 3.5.14 → 3.5.15 (pulled in by Spring AI 1.1.8 release)

## What changed in 1.1.6–1.1.8
- 1.1.6: chat memory advisors require explicit `conversationId` — **not used** in svc-agent
- 1.1.7: OpenAI streaming chunk-drop fix; Ollama GraalVM native fix
- 1.1.8: MCP SDK 0.18.3; ZhiPuAI finish-reason fix

Spring AI 2.0.0 (GA 2026-06-12) requires Spring Boot 4.1 — tracked in `bc-claude/AI_UPGRADES.md`, deferred.

## Test plan
- [ ] `./gradlew testSmart` passes
- [ ] svc-agent boots on anthropic/ollama profiles
- [ ] `/agent/query` tool-calling works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core platform and AI library versions to newer releases, which may improve stability and compatibility across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->