### PR TITLE
fix(figi): resolve LSE ETF names — advance securityType chain on v3 warning no-match

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
@@ -33,7 +33,6 @@ class FigiProxy internal constructor(
     fun find(
         market: Market,
         bcAssetCode: String,
-        defaultName: String? = null,
         id: String = bcAssetCode
     ): Asset? {
         // FIGI resolution needs the market's FIGI exchange alias. A market without
@@ -51,27 +50,15 @@ class FigiProxy internal constructor(
             )
         val response = resolve(figiSearch)
         if (response?.error != null) {
+            // Hard error (rate-limit / auth). Return null so the enricher chain falls
+            // back to the default enricher rather than persisting a null-named asset.
             log.debug(
                 "Error {}/{} {}",
                 figiMarket,
                 figiCode,
                 response.error
             )
-            return if (response.error.equals(
-                    "No identifier found.",
-                    ignoreCase = true
-                )
-            ) {
-                // Unknown, so don't continue to hit the service - add a name value
-                figiAdapter.transform(
-                    market,
-                    bcAssetCode,
-                    defaultName = defaultName,
-                    id
-                )
-            } else {
-                null
-            }
+            return null
         }
         if (response?.data != null) {
             for (datum in response.data!!) {
@@ -121,18 +108,28 @@ class FigiProxy internal constructor(
     }
 
     private fun resolve(figiSearch: FigiSearch): FigiResponse? {
+        // Try each securityType in turn. Advance only on a no-match (no data AND no hard
+        // error — OpenFIGI v3 signals this with a `warning`). Stop immediately on a match
+        // (data != null) or a hard error (error != null, e.g. rate-limit/auth) so the
+        // caller can fall back to the default enricher.
         var response = findEquity(figiSearch)
-        if (response?.error != null) {
+        if (response.isNoMatch()) {
             response = findAdr(figiSearch)
-            if (response?.error != null) {
+            if (response.isNoMatch()) {
                 response = findMutualFund(figiSearch)
-                if (response?.error != null) {
+                if (response.isNoMatch()) {
                     response = findReit(figiSearch)
                 }
             }
         }
         return response
     }
+
+    /**
+     * A no-match (keep trying the next securityType): no data and no hard error.
+     * Covers the v3 `warning` no-match and a null/empty response.
+     */
+    private fun FigiResponse?.isNoMatch(): Boolean = this == null || (data == null && error == null)
 
     private fun getSearchArgs(figiSearch: FigiSearch): Collection<FigiSearch> {
         val figiSearches: MutableCollection<FigiSearch> = ArrayList()

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiResponse.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiResponse.kt
@@ -2,8 +2,14 @@ package com.beancounter.marketdata.assets.figi
 
 /**
  * FIGI API contract.
+ *
+ * OpenFIGI /v3/mapping returns one of:
+ *  - a match:    `{ "data": [ ... ] }`
+ *  - a no-match: `{ "warning": "No identifier found." }` (both data and error null)
+ *  - a hard error (rate-limit / auth): `{ "error": "..." }`
  */
 data class FigiResponse(
     var data: Collection<FigiAsset>?,
-    var error: String?
+    var error: String?,
+    var warning: String? = null
 )

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
@@ -354,9 +354,8 @@ class FigiAssetApiTest {
                             HttpHeaders.CONTENT_TYPE,
                             MediaType.APPLICATION_JSON_VALUE
                         ).withBody(
-                            "[{\"error\": \"No identifier found.\"\n" +
-                                "    }\n" +
-                                "]"
+                            // OpenFIGI v3 signals a no-match with `warning`, not `error`.
+                            "[{\"warning\": \"No identifier found.\"}]"
                         )
                 )
         )

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
@@ -1,13 +1,19 @@
 package com.beancounter.marketdata.providers.figi
 
+import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
 import com.beancounter.marketdata.assets.figi.FigiAdapter
+import com.beancounter.marketdata.assets.figi.FigiAsset
 import com.beancounter.marketdata.assets.figi.FigiConfig
 import com.beancounter.marketdata.assets.figi.FigiGateway
 import com.beancounter.marketdata.assets.figi.FigiProxy
+import com.beancounter.marketdata.assets.figi.FigiResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
 
 class FigiProxyAliasTest {
     @Test
@@ -30,5 +36,72 @@ class FigiProxyAliasTest {
         assertThat(result).isNull()
         // No FIGI HTTP call should be attempted for an unmappable market.
         Mockito.verifyNoInteractions(gateway)
+    }
+
+    @Test
+    fun `find advances past v3 warning no-match and resolves an LSE ETF as Mutual Fund`() {
+        // OpenFIGI v3 signals a no-match with `warning` (data == null && error == null),
+        // not `error`. An LSE ETF (e.g. MOTU) is classified securityType2 = "Mutual Fund".
+        // The retry chain must keep advancing on a warning no-match so it reaches the
+        // Mutual Fund attempt rather than stopping after Common Stock.
+        val config = Mockito.mock(FigiConfig::class.java)
+        whenever(config.apiKey).thenReturn("demoxx")
+        val gateway = Mockito.mock(FigiGateway::class.java)
+        val adapter = Mockito.mock(FigiAdapter::class.java)
+        val proxy = FigiProxy(config, gateway, adapter)
+        val lse = Market(code = "LSE", aliases = mapOf(FigiProxy.FIGI to "LN"))
+
+        // OpenFIGI mutates the shared FigiSearch in place per securityType, so match on
+        // call order instead of the (live, mutated) argument: Common Stock + Depositary
+        // Receipt return a `warning` no-match; the Mutual Fund attempt returns data.
+        val warningNoMatch =
+            listOf(FigiResponse(data = null, error = null).also { it.warning = "No identifier found." })
+        val mutualFundMatch =
+            listOf(
+                FigiResponse(
+                    data = listOf(FigiAsset("VANECK MSTAR WIDE MOAT ETF", "MOTU", "Mutual Fund")),
+                    error = null
+                )
+            )
+        whenever(gateway.search(any(), eq("demoxx")))
+            .thenReturn(warningNoMatch) // Common Stock
+            .thenReturn(warningNoMatch) // Depositary Receipt
+            .thenReturn(mutualFundMatch) // Mutual Fund -> match
+
+        val enriched =
+            Asset(code = "MOTU", id = "MOTU", name = "VANECK MSTAR WIDE MOAT ETF", market = lse)
+        whenever(
+            adapter.transform(any<Market>(), any<String>(), any<FigiAsset>(), any<String>())
+        ).thenReturn(enriched)
+
+        val result = proxy.find(lse, "MOTU")
+
+        assertThat(result)
+            .isNotNull
+            .hasFieldOrPropertyWithValue("name", "VANECK MSTAR WIDE MOAT ETF")
+        // Stops at Mutual Fund — REIT is never attempted.
+        Mockito.verify(gateway, Mockito.times(3)).search(any(), eq("demoxx"))
+    }
+
+    @Test
+    fun `find returns null on a true v3 warning no-match so the enricher falls back`() {
+        // Every securityType returns a `warning` no-match -> FIGI yields null and the
+        // enricher chain falls back to DefaultEnricher. The asset must NOT be created
+        // here with a null name.
+        val config = Mockito.mock(FigiConfig::class.java)
+        whenever(config.apiKey).thenReturn("demoxx")
+        val gateway = Mockito.mock(FigiGateway::class.java)
+        val adapter = Mockito.mock(FigiAdapter::class.java)
+        val proxy = FigiProxy(config, gateway, adapter)
+        val lse = Market(code = "LSE", aliases = mapOf(FigiProxy.FIGI to "LN"))
+
+        val warningNoMatch =
+            listOf(FigiResponse(data = null, error = null).also { it.warning = "No identifier found." })
+        whenever(gateway.search(any(), eq("demoxx"))).thenReturn(warningNoMatch)
+
+        val result = proxy.find(lse, "NOPE")
+
+        assertThat(result).isNull()
+        Mockito.verifyNoInteractions(adapter)
     }
 }


### PR DESCRIPTION
## Problem
LSE ETFs added to a model showed no enriched name (e.g. LSE:MOTU blank, EXUS = code). FIGI enrichment never resolved them.

## Root cause
OpenFIGI `/v3/mapping` signals a no-match with a `warning` field (`{"warning":"No identifier found."}`), not `error`. `FigiResponse` only mapped `data`+`error`, so a no-match left both null. `FigiProxy`'s securityType retry chain (Common Stock → Depositary Receipt → Mutual Fund → REIT) only advanced while `error != null`, so it **stopped after Common Stock** and never tried Mutual Fund. LSE ETFs are classified `securityType2="Mutual Fund"` in OpenFIGI → never reached → FIGI returned null → fell back to the default enricher.

Affected all non-Common-Stock securities (ETFs/funds/REITs/ADRs), not just LSE.

## Fix
- Add `warning` to `FigiResponse`.
- Advance the chain on a no-match (`data == null && error == null`) via `isNoMatch()`; stop on a match (`data`) or hard `error` (rate-limit/auth → null → fallback).
- Remove the now-dead `"No identifier found."` error branch and the unused `defaultName` param of `find()`. A hard error returns null (fallback) rather than persisting a null-named asset.

## Tests
- Regression: warning no-match on Common Stock + Depositary Receipt, match on Mutual Fund → asset gets FIGI name; exactly 3 gateway calls (REIT skipped). Fails on old chain.
- True no-match (all warning) → FIGI null, falls back, no null-named asset.
- Existing WireMock catch-all stub updated from old `error` shape to v3 `warning` shape.

Verified: `:svc-data:test --tests "*Figi*"`, `testSmart`, `formatKotlin`, `lintKotlin` all green; semgrep clean.

@coderabbitai ignore