### PR TITLE
fix(eodhd): currency-aware market resolution for shared LSE exchange

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -211,12 +211,12 @@ class EodhdPriceService(
      *
      * EODHD reports its own exchange (e.g. `LSE`), but the UI posts the result's `market` to
      * `/api/assets`, which only accepts BC market codes — posting the raw exchange trips "Unable to
-     * resolve market code" → 404 (asset creation disables alias resolution). [MarketService.getMarket]
-     * resolves the exchange via the alias map (`LSE` → `LON`); rows whose exchange maps to no BC
-     * market are dropped rather than surfaced with an un-postable code — mirroring the FIGI path.
+     * resolve market code" → 404 (asset creation disables alias resolution). [resolveMarket]
+     * resolves the exchange via the alias map (`LSE` → `LON`/`LSE`); rows whose exchange maps to no
+     * BC market are dropped rather than surfaced with an un-postable code — mirroring the FIGI path.
      */
     private fun toSearchResult(row: EodhdSearchResult): AssetSearchResult? {
-        val market = runCatching { eodhdConfig.marketService.getMarket(row.exchange) }.getOrNull()
+        val market = resolveMarket(row.exchange, row.currency)
         if (market == null) {
             log.debug("Dropping EODHD result {} — exchange {} maps to no BC market", row.code, row.exchange)
             return null
@@ -231,7 +231,69 @@ class EodhdPriceService(
         )
     }
 
+    /**
+     * Resolve an EODHD [exchange] to the owning BC [Market], disambiguating on the instrument
+     * [currency] when several BC markets share one EODHD exchange.
+     *
+     * EODHD reports a single exchange code (`LSE`) for all of London, but BC splits London into
+     * `LON` (currencyId GBP, pence-quoted UK equities) and `LSE` (currencyId USD, USD-denominated
+     * London ETFs) — both carrying `aliases.eodhd = "LSE"`. Picking the first/direct-code match
+     * mis-keys GBP equities to LSE/USD, breaking price caching (currency mismatch → re-fetch every
+     * call). So for an ambiguous exchange we route on the normalized EODHD currency.
+     *
+     * The US `eodhd` alias is shared by the inactive aggregator markets (NASDAQ/NYSE/AMEX) and the
+     * active `US` market — all USD, so currency can't disambiguate them. We prefer active candidates
+     * and, when the resolved code is an aggregator, collapse to canonical `US` via [MarketService].
+     *
+     * @return the resolved market, or null when no BC market addresses the exchange.
+     */
+    private fun resolveMarket(
+        exchange: String,
+        currency: String?
+    ): Market? {
+        val candidates =
+            eodhdConfig.marketService
+                .getMarketMap()
+                .values
+                .filter { market ->
+                    market.code.equals(exchange, ignoreCase = true) ||
+                        market.getAlias(EODHD_ALIAS)?.equals(exchange, ignoreCase = true) == true
+                }
+        val resolved =
+            when (candidates.size) {
+                0 -> {
+                    return null
+                }
+                1 -> {
+                    candidates.first()
+                }
+                else -> {
+                    // Active markets are the real persistence targets; inactive aggregators
+                    // (NASDAQ/NYSE/AMEX) collapse to US below.
+                    val preferred = candidates.filter { it.active }.ifEmpty { candidates }
+                    val normalized = normalizeCurrency(currency)
+                    preferred.firstOrNull { it.currencyId.equals(normalized, ignoreCase = true) }
+                        ?: preferred.firstOrNull()
+                        ?: runCatching { eodhdConfig.marketService.getMarket(exchange) }.getOrNull()
+                        ?: return null
+                }
+            }
+        return runCatching { eodhdConfig.marketService.canonical(resolved.code) }.getOrDefault(resolved)
+    }
+
+    /**
+     * Map an EODHD currency to the BC market's `currencyId`. EODHD quotes London pence as `GBX`
+     * (BC's LON market is currencyId GBP with the 0.01 multiplier), so GBX/GBp/GBX. all collapse to
+     * GBP; every other currency is uppercased as-is. A null currency yields an empty string so the
+     * ambiguous-exchange resolver falls through to its safe default.
+     */
+    private fun normalizeCurrency(currency: String?): String {
+        val raw = currency?.trim()?.uppercase()?.removeSuffix(".") ?: return ""
+        return if (raw == "GBX" || raw == "GBP") "GBP" else raw
+    }
+
     companion object {
         const val ID = "EODHD"
+        private const val EODHD_ALIAS = "eodhd"
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceServiceSearchTest.kt
@@ -1,11 +1,11 @@
 package com.beancounter.marketdata.providers.eodhd
 
-import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.Market
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -25,28 +25,51 @@ internal class EodhdPriceServiceSearchTest {
     private val adapter = mock<EodhdAdapter>()
     private val dateUtils = DateUtils()
 
+    // BC splits London into LON (GBP, pence-quoted) and LSE (USD ETFs); both carry the same
+    // EODHD alias ("LSE"). US is the unambiguous control. The currency-aware resolver disambiguates
+    // the London pair on EODHD's reported instrument currency.
+    private val lon = Market(code = "LON", currencyId = "GBP", aliases = mapOf("eodhd" to "LSE"))
+    private val lse = Market(code = "LSE", currencyId = "USD", aliases = mapOf("eodhd" to "LSE"))
+    private val us = Market(code = "US", currencyId = "USD")
+
+    @BeforeEach
+    fun stubMarketMap() {
+        val markets = mapOf("LON" to lon, "LSE" to lse, "US" to us)
+        whenever(marketService.getMarketMap()).thenReturn(markets)
+        // canonical() only collapses the inactive US aggregator codes; for these
+        // active markets it is identity, mirroring the real MarketService.
+        whenever(marketService.canonical(any())).thenAnswer { inv ->
+            markets.getValue(inv.getArgument<String>(0))
+        }
+    }
+
     private fun configWithMarkets(markets: String): EodhdConfig =
         EodhdConfig(marketService).also {
             ReflectionTestUtils.setField(it, "apiKey", "demo")
             ReflectionTestUtils.setField(it, "markets", markets)
         }
 
+    private fun searchResult(
+        code: String,
+        exchange: String,
+        currency: String?,
+        name: String = code,
+        type: String = "ETF"
+    ) = EodhdSearchResult(
+        code = code,
+        exchange = exchange,
+        name = name,
+        type = type,
+        country = "XX",
+        currency = currency,
+        isin = null
+    )
+
     @Test
     fun `searchAssets returns mapped results from EODHD search`() {
         val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
-        whenever(marketService.getMarket("US")).thenReturn(Market("US"))
         whenever(proxy.searchAssets(any(), any())).thenReturn(
-            listOf(
-                EodhdSearchResult(
-                    code = "HYSA",
-                    exchange = "US",
-                    name = HYSA_NAME,
-                    type = "ETF",
-                    country = "USA",
-                    currency = "USD",
-                    isin = "US69374H4047"
-                )
-            )
+            listOf(searchResult(code = "HYSA", exchange = "US", currency = "USD", name = HYSA_NAME))
         )
 
         val results = service.searchAssets("HYSA", "US")
@@ -61,31 +84,63 @@ internal class EodhdPriceServiceSearchTest {
     }
 
     @Test
-    fun `searchAssets maps the EODHD exchange to its BC market code`() {
-        // EODHD returns its own exchange ("LSE"); the result must carry the owning BC market code
-        // ("LON") so the UI can POST it to /api/assets without tripping "Unable to resolve market".
-        val service = EodhdPriceService(configWithMarkets("LON"), proxy, adapter, dateUtils)
-        whenever(marketService.getMarket("LSE")).thenReturn(Market(code = "LON", currencyId = "USD"))
+    fun `searchAssets routes a USD London listing to the LSE market`() {
+        // VUAA/MOTU et al — USD-denominated London ETFs key to LSE (currencyId USD).
+        val service = EodhdPriceService(configWithMarkets("LON,LSE"), proxy, adapter, dateUtils)
         whenever(proxy.searchAssets(any(), any())).thenReturn(
-            listOf(
-                EodhdSearchResult(
-                    code = "MOTU",
-                    exchange = "LSE",
-                    name = MOTU_NAME,
-                    type = "ETF",
-                    country = "UK",
-                    currency = "USD",
-                    isin = null
-                )
-            )
+            listOf(searchResult(code = "MOTU", exchange = "LSE", currency = "USD", name = MOTU_NAME))
         )
 
-        val results = service.searchAssets("MOTU", "LON")
+        val results = service.searchAssets("MOTU", null)
+
+        assertThat(results).hasSize(1)
+        assertThat(results.first().market).isEqualTo("LSE")
+        assertThat(results.first().symbol).isEqualTo("MOTU")
+        assertThat(results.first().currency).isEqualTo("USD")
+    }
+
+    @Test
+    fun `searchAssets routes a GBX London listing to the LON market`() {
+        // EODHD reports London pence as GBX; BC's LON market is currencyId GBP (0.01 multiplier).
+        val service = EodhdPriceService(configWithMarkets("LON,LSE"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(searchResult(code = "VOD", exchange = "LSE", currency = "GBX"))
+        )
+
+        val results = service.searchAssets("VOD", null)
 
         assertThat(results).hasSize(1)
         assertThat(results.first().market).isEqualTo("LON")
-        assertThat(results.first().symbol).isEqualTo("MOTU")
-        assertThat(results.first().currency).isEqualTo("USD")
+        assertThat(results.first().currency).isEqualTo("GBX")
+    }
+
+    @Test
+    fun `searchAssets routes a GBP London listing to the LON market`() {
+        val service = EodhdPriceService(configWithMarkets("LON,LSE"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(searchResult(code = "TSCO", exchange = "LSE", currency = "GBP"))
+        )
+
+        val results = service.searchAssets("TSCO", null)
+
+        assertThat(results).hasSize(1)
+        assertThat(results.first().market).isEqualTo("LON")
+        assertThat(results.first().currency).isEqualTo("GBP")
+    }
+
+    @Test
+    fun `searchAssets resolves an unambiguous exchange regardless of currency`() {
+        // US maps to a single BC market; the currency must not affect routing.
+        val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
+        whenever(proxy.searchAssets(any(), any())).thenReturn(
+            listOf(searchResult(code = "HYSA", exchange = "US", currency = "EUR", name = HYSA_NAME))
+        )
+
+        val results = service.searchAssets("HYSA", "US")
+
+        assertThat(results).hasSize(1)
+        assertThat(results.first().market).isEqualTo("US")
+        assertThat(results.first().currency).isEqualTo("EUR")
     }
 
     @Test
@@ -93,19 +148,8 @@ internal class EodhdPriceServiceSearchTest {
         // An EODHD exchange with no BC market (e.g. XETRA) must be dropped, not surfaced with a raw
         // code the UI would post and 404 on.
         val service = EodhdPriceService(configWithMarkets("LON"), proxy, adapter, dateUtils)
-        whenever(marketService.getMarket("XETRA")).thenThrow(NotFoundException("Unable to resolve market code XETRA"))
         whenever(proxy.searchAssets(any(), any())).thenReturn(
-            listOf(
-                EodhdSearchResult(
-                    code = "XYZ",
-                    exchange = "XETRA",
-                    name = "Some Frankfurt Listing",
-                    type = "ETF",
-                    country = "DE",
-                    currency = "EUR",
-                    isin = null
-                )
-            )
+            listOf(searchResult(code = "XYZ", exchange = "XETRA", currency = "EUR", name = "Some Frankfurt Listing"))
         )
 
         val results = service.searchAssets("XYZ", "LON")
@@ -126,19 +170,8 @@ internal class EodhdPriceServiceSearchTest {
     @Test
     fun `searchAssets with null market still queries EODHD when provider is enabled`() {
         val service = EodhdPriceService(configWithMarkets("US"), proxy, adapter, dateUtils)
-        whenever(marketService.getMarket("US")).thenReturn(Market("US"))
         whenever(proxy.searchAssets(any(), any())).thenReturn(
-            listOf(
-                EodhdSearchResult(
-                    code = "HYSA",
-                    exchange = "US",
-                    name = HYSA_NAME,
-                    type = "ETF",
-                    country = "USA",
-                    currency = "USD",
-                    isin = null
-                )
-            )
+            listOf(searchResult(code = "HYSA", exchange = "US", currency = "USD"))
         )
 
         val results = service.searchAssets("HYSA", null)


### PR DESCRIPTION
## Problem
EODHD reports one exchange code `LSE` for all London listings, but BC splits London into `LON` (currencyId GBP, pence, multiplier 0.01) and `LSE` (currencyId USD). Both carry `aliases.eodhd = "LSE"`. `EodhdPriceService.toSearchResult` resolved via `getMarket(exchange)`, which (by code precedence) always returned `LSE`/USD — so GBP London equities mis-key to USD. A mis-keyed asset can't cache its price (currency mismatch) → re-fetches EODHD on every price call (the perf leak seen in trace `e261d30a…`: 20× ~1s for the mis-keyed MOTU).

This is the shared root of both the "shows as GBP/USD wrong" display bug and the price-fetch churn.

## Fix
New `resolveMarket(exchange, currency)`: collect BC markets matching the exchange (by code or `eodhd` alias); 0→drop, 1→use, >1→disambiguate on the normalized EODHD currency (`GBX`/`GBP`→GBP→LON, `USD`→LSE). Prefer active candidates and collapse US aggregators (NASDAQ/NYSE/AMEX, also sharing eodhd `US`) via `MarketService.canonical`, so the US path is unchanged. Falls back to the prior `getMarket` result if currency can't disambiguate — never regresses.

## Tests
`EodhdPriceServiceSearchTest` (AssertJ): LSE+USD→LSE, LSE+GBX→LON, LSE+GBP→LON, unambiguous exchange ignores currency, unknown exchange dropped. RED before / green after. `:svc-data:test *Eodhd*`, `testSmart`, `formatKotlin`, `lintKotlin` all green; semgrep clean.

@coderabbitai ignore