### PR TITLE
fix(eodhd): append exchange suffix to bare priceSymbol

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfig.kt
@@ -79,17 +79,24 @@ class EodhdConfig(
      *
      * EODHD always wants `${code}.${exchange}` — even US tickers use the `.US` suffix.
      * The `eodhd:` alias on each market in `application.yml` supplies the suffix (US, LSE, AU, TO, …).
-     * If an asset already carries a [Asset.priceSymbol], honour that as an explicit override.
+     *
+     * [Asset.priceSymbol] is honoured as an explicit override only when it already carries an
+     * exchange suffix (contains a `.`, e.g. `BARC.OVERRIDE`). A bare priceSymbol (e.g. `IUQA`,
+     * which is what asset creation / FIGI enrichment stamps) is treated as the code and still gets
+     * the market's eodhd suffix appended — otherwise EODHD's `/api/eod/IUQA` returns
+     * "Ticker Not Found" and the asset has no price and no price history.
      */
     override fun getPriceCode(asset: Asset): String {
-        if (!asset.priceSymbol.isNullOrEmpty()) {
-            return asset.priceSymbol!!
+        val override = asset.priceSymbol
+        if (!override.isNullOrEmpty() && override.contains(".")) {
+            return override
         }
+        val base = if (!override.isNullOrEmpty()) override else asset.code
         val marketCode = translateMarketCode(asset.market)
         return if (!marketCode.isNullOrEmpty()) {
-            asset.code + "." + marketCode
+            "$base.$marketCode"
         } else {
-            asset.code
+            base
         }
     }
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdConfigTest.kt
@@ -68,6 +68,24 @@ internal class EodhdConfigTest {
     }
 
     @Test
+    fun `getPriceCode appends the eodhd suffix to a bare priceSymbol`() {
+        // Asset creation / FIGI enrichment stamps priceSymbol with the bare code (no exchange).
+        // Without the suffix EODHD's /api/eod/IUQA returns "Ticker Not Found" — no price/history.
+        val lse = Market(code = "LSE", aliases = mapOf("eodhd" to "LSE"))
+        val ms = mock<MarketService>()
+        whenever(ms.getMarket("LSE")).thenReturn(lse)
+        val cfg = EodhdConfig(ms)
+        val asset =
+            Asset(
+                code = "IUQA",
+                market = lse,
+                priceSymbol = "IUQA"
+            )
+
+        assertThat(cfg.getPriceCode(asset)).isEqualTo("IUQA.LSE")
+    }
+
+    @Test
     fun `default config is opt-in — empty markets allowlist keeps the provider unrouted`() {
         val cfg = EodhdConfig(mock())
         ReflectionTestUtils.setField(cfg, "apiKey", "demo")


### PR DESCRIPTION
## Problem
Non-US assets (e.g. `LSE:IUQA`) showed no price and an empty price-history chart ("No price history available"). `EodhdConfig.getPriceCode` returned a non-empty `priceSymbol` verbatim:
```kotlin
if (!asset.priceSymbol.isNullOrEmpty()) return asset.priceSymbol!!
```
But asset creation / FIGI enrichment stamps `priceSymbol` with the **bare code** (`IUQA`), so the EODHD ticker lost its exchange suffix. `GET /api/eod/IUQA` → "Ticker Not Found" (verified live; `/api/eod/IUQA.LSE` works). The bulk-price path was unaffected (it passes the exchange separately), which is why this only bit the single/on-demand + history paths.

## Fix
Honour `priceSymbol` as an explicit override **only when it already carries an exchange suffix** (`contains(".")`, e.g. `BARC.OVERRIDE`). A bare `priceSymbol` is treated as the code and still gets the market's eodhd suffix appended → `IUQA.LSE`.

## Tests
`EodhdConfigTest`: new `getPriceCode appends the eodhd suffix to a bare priceSymbol` (IUQA→IUQA.LSE). Existing cases unchanged (bare code, no-alias, INDX, explicit `.`-suffixed override). `:svc-data:test *EodhdConfig*`, `testSmart`, `formatKotlin`, `lintKotlin` all green.

@coderabbitai ignore