### PR TITLE
feat(prefs): payslip default portfolio + cash asset on user preferences

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/contracts/UserPreferencesRequest.kt
@@ -23,5 +23,7 @@ data class UserPreferencesRequest(
     val yearOfBirth: Int? = null,
     val monthOfBirth: Int? = null,
     val targetIndependenceAge: Int? = null,
-    val lifeExpectancy: Int? = null
+    val lifeExpectancy: Int? = null,
+    val defaultPayslipPortfolioId: String? = null,
+    val defaultPayslipCashAssetId: String? = null
 )

--- a/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/UserPreferences.kt
@@ -53,5 +53,11 @@ data class UserPreferences(
     @Column(name = "target_independence_age")
     var targetIndependenceAge: Int? = null,
     @Column(name = "life_expectancy")
-    var lifeExpectancy: Int? = null
+    var lifeExpectancy: Int? = null,
+    // Defaults remembered by the bc-view "Enter Payslip" feature so the
+    // user's preferred target portfolio and cash asset are pre-selected.
+    @Column(name = "default_payslip_portfolio_id")
+    var defaultPayslipPortfolioId: String? = null,
+    @Column(name = "default_payslip_cash_asset_id")
+    var defaultPayslipCashAssetId: String? = null
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/UserPreferencesService.kt
@@ -55,6 +55,8 @@ class UserPreferencesService(
         request.monthOfBirth?.let { preferences.monthOfBirth = it }
         request.targetIndependenceAge?.let { preferences.targetIndependenceAge = it }
         request.lifeExpectancy?.let { preferences.lifeExpectancy = it }
+        request.defaultPayslipPortfolioId?.let { preferences.defaultPayslipPortfolioId = it }
+        request.defaultPayslipCashAssetId?.let { preferences.defaultPayslipCashAssetId = it }
         return userPreferencesRepository.save(preferences)
     }
 }

--- a/svc-data/src/main/resources/db/migration/V29__add_user_preferences_payslip_defaults.sql
+++ b/svc-data/src/main/resources/db/migration/V29__add_user_preferences_payslip_defaults.sql
@@ -1,0 +1,6 @@
+-- Remember the bc-view "Enter Payslip" feature's default target portfolio and
+-- cash asset against the user's account-wide preferences (served by GET /me).
+-- Both nullable, no default — absent until the user first saves a payslip.
+ALTER TABLE user_preferences
+    ADD COLUMN default_payslip_portfolio_id VARCHAR(255),
+    ADD COLUMN default_payslip_cash_asset_id VARCHAR(255);

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/UserPreferencesServiceTest.kt
@@ -306,6 +306,37 @@ class UserPreferencesServiceTest {
         assertThat(reread.targetIndependenceAge).isEqualTo(60)
     }
 
+    @Test
+    fun `should persist payslip default portfolio and cash asset and surface them on subsequent reads`() {
+        val user = createAndAuthenticateUser("prefs-test-payslip@email.com")
+
+        // Default: both payslip preference fields null
+        val initial = userPreferencesService.getOrCreate(user)
+        assertThat(initial.defaultPayslipPortfolioId).isNull()
+        assertThat(initial.defaultPayslipCashAssetId).isNull()
+
+        val updated =
+            userPreferencesService.update(
+                user,
+                UserPreferencesRequest(
+                    defaultPayslipPortfolioId = "portfolio-123",
+                    defaultPayslipCashAssetId = "asset-456"
+                )
+            )
+
+        assertThat(updated.defaultPayslipPortfolioId).isEqualTo("portfolio-123")
+        assertThat(updated.defaultPayslipCashAssetId).isEqualTo("asset-456")
+        // Other preferences unchanged
+        assertThat(updated.defaultHoldingsView).isEqualTo(defaultView)
+
+        // Re-reading goes through the persisted store, not the in-memory
+        // return value of update() — guards against the entity field
+        // being added but the column missing.
+        val reread = userPreferencesService.getOrCreate(user)
+        assertThat(reread.defaultPayslipPortfolioId).isEqualTo("portfolio-123")
+        assertThat(reread.defaultPayslipCashAssetId).isEqualTo("asset-456")
+    }
+
     private fun createAndAuthenticateUser(email: String): SystemUser {
         val user = SystemUser(email = email, auth0 = "auth0-$email")
         authUtilService.authenticate(user, AuthUtilService.AuthProvider.AUTH0)


### PR DESCRIPTION
Adds two nullable user-preference fields for the bc-view Enter Payslip feature to remember the user's choices:
- defaultPayslipPortfolioId
- defaultPayslipCashAssetId

Surfaced on GET /me (under preferences) and accepted on PATCH /me, mirroring existing optional prefs (demographics). Flyway V29 adds the two nullable VARCHAR columns to user_preferences. AssertJ round-trip test. Backward compatible (optional).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended user preferences system with support for configuring default portfolio and cash asset selections for payslip-related operations.

* **Tests**
  * Comprehensive integration test added to verify new payslip preference fields are properly persisted to the database and correctly retrieved in subsequent queries without impacting other existing preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->