### PR TITLE
fix(position): don't warn on undefined IRR (no sign change)

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/irr/IrrCalculator.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/irr/IrrCalculator.kt
@@ -57,7 +57,7 @@ class IrrCalculator(
     fun calculate(periodicCashFlows: PeriodicCashFlows): Double {
         // Early returns for edge cases
         if (periodicCashFlows.cashFlows.isEmpty()) {
-            log.warn("No cash flows to calculate IRR")
+            log.debug("No cash flows to calculate IRR")
             return 0.0
         }
 
@@ -73,13 +73,14 @@ class IrrCalculator(
         val allZero = periodicCashFlows.cashFlows.all { it.amount == 0.0 }
 
         if (allZero) {
-            log.warn("IRR calculation requires non-zero cash flows")
+            log.debug("IRR calculation requires non-zero cash flows")
             return 0.0
         }
 
-        // For strictly all positive or all negative (no zeros), early return
+        // For strictly all positive or all negative (no zeros), early return.
+        // No sign change → no NPV root → IRR undefined (not an error).
         if (allSameSign && !periodicCashFlows.cashFlows.any { it.amount == 0.0 }) {
-            log.warn("IRR calculation requires both positive and negative cash flows")
+            log.debug("IRR calculation requires both positive and negative cash flows")
             return 0.0
         }
 

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
@@ -352,7 +352,12 @@ class PositionValuationService(
     ): BigDecimal {
         val result = config.irrCalculator.calculate(periodicCashFlows)
 
-        if (result == 0.0 && periodicCashFlows.cashFlows.isNotEmpty()) {
+        // Only flag a zero IRR when one was actually solvable. A series with
+        // no sign change (e.g. a cash / funding portfolio that only ever
+        // received settlement deposits) has a mathematically undefined IRR —
+        // `0` there means "undefined", not "0% return". Warning on it produced
+        // false-positive noise (e.g. "Failed to calculate IRR for SGD").
+        if (result == 0.0 && irrIsDefined(periodicCashFlows)) {
             val cashFlowSummary =
                 periodicCashFlows.cashFlows
                     .sortedBy { it.date }
@@ -369,5 +374,22 @@ class PositionValuationService(
         }
 
         return BigDecimal(result)
+    }
+
+    companion object {
+        /**
+         * An IRR exists only when the cash-flow series can cross zero NPV:
+         * at least two flows, not all zero, and at least one sign change
+         * (an outflow you invest and an inflow you get back). All other
+         * series — empty, single, all-positive, all-negative — have no
+         * real root and their IRR is mathematically undefined.
+         */
+        fun irrIsDefined(periodicCashFlows: PeriodicCashFlows): Boolean {
+            val flows = periodicCashFlows.cashFlows
+            if (flows.size < 2) return false
+            val hasInflow = flows.any { it.amount > 0.0 }
+            val hasOutflow = flows.any { it.amount < 0.0 }
+            return hasInflow && hasOutflow
+        }
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
@@ -121,6 +121,29 @@ class PositionValuationServiceTest {
     }
 
     @Test
+    fun `irrIsDefined requires at least two flows with a sign change`() {
+        fun flows(vararg amounts: Double): com.beancounter.common.model.PeriodicCashFlows =
+            com.beancounter.common.model.PeriodicCashFlows().apply {
+                amounts.forEachIndexed { i, amount ->
+                    cashFlows.add(
+                        com.beancounter.common.model
+                            .CashFlow(amount, LocalDate.now().minusDays((amounts.size - i).toLong()))
+                    )
+                }
+            }
+
+        // Undefined: empty, single, all-positive (e.g. cash deposits), all-negative, all-zero
+        assertThat(PositionValuationService.irrIsDefined(flows())).isFalse()
+        assertThat(PositionValuationService.irrIsDefined(flows(-1000.0))).isFalse()
+        assertThat(PositionValuationService.irrIsDefined(flows(100.0, 200.0))).isFalse()
+        assertThat(PositionValuationService.irrIsDefined(flows(-100.0, -200.0))).isFalse()
+        assertThat(PositionValuationService.irrIsDefined(flows(0.0, 0.0))).isFalse()
+
+        // Defined: an outflow and an inflow
+        assertThat(PositionValuationService.irrIsDefined(flows(-1000.0, 1100.0))).isTrue()
+    }
+
+    @Test
     fun `should return positions unchanged when assets are empty`() {
         // Given
         val positions = TestHelpers.createTestPositions(portfolio, emptyList())


### PR DESCRIPTION
## Problem
Cash / funding portfolios (e.g. SGD) have same-sign cash flows (settlement deposits) → IRR has no NPV root → mathematically **undefined**. The code returned the `0.0` sentinel and logged `Failed to calculate IRR for SGD` + a Sentry breadcrumb, conflating *undefined* with *0% return*.

## Fix
- `PositionValuationService.calculateIrrSafely`: warn only when `result == 0.0 && irrIsDefined(flows)` — a series that was actually solvable. Undefined series return ZERO silently.
- New `companion irrIsDefined()`: ≥2 flows with at least one inflow **and** one outflow (the only case with a real IRR). Unit-tested.
- `IrrCalculator`: downgraded the three 'undefined IRR' `warn` logs (empty / all-zero / no sign change) to `debug` — normal cash-portfolio cases, not anomalies.

`calculate()` is still always invoked, so genuine ROI fallbacks (e.g. total-loss -100%) are preserved; only the logging changed.

## Tests
`:svc-position:test` (PositionValuationServiceTest + IrrCalculator*) green; format + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed false-positive warnings for IRR calculations in edge cases where the IRR is mathematically undefined (e.g., all positive or all negative cash flows).
  * Reduced log verbosity for scenarios with insufficient cash-flow data.

* **Tests**
  * Added test coverage validating IRR mathematical validity conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->