### PR TITLE
feat(trn): asset trades across multiple portfolios

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -458,6 +458,51 @@ class TrnController(
             )
         )
 
+    @GetMapping(
+        value = ["/asset/{assetId}/trades"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "Get trade transactions for an asset across multiple portfolios",
+        description = """
+            Retrieves trade transactions for a single asset across several portfolios,
+            used by the aggregated holdings drill-down where an asset is held in more
+            than one portfolio. Each transaction carries its portfolio so the caller
+            can group the union by portfolio.
+
+            The request fails closed: if any supplied portfolio is unknown or not
+            viewable by the caller, the whole request is rejected rather than
+            returning a partial result.
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Trade transactions retrieved successfully"
+            ), ApiResponse(
+                responseCode = "404",
+                description = "A portfolio or asset was not found"
+            )
+        ]
+    )
+    fun findAssetTradesAcrossPortfolios(
+        @Parameter(
+            description = "Asset identifier",
+            example = "AAPL"
+        ) @PathVariable("assetId") assetId: String,
+        @Parameter(
+            description = "Comma-separated portfolio identifiers",
+            example = "portfolio-123,portfolio-456"
+        ) @RequestParam("portfolios") portfolios: String
+    ): TrnResponse =
+        TrnResponse(
+            trnQueryService.findAssetTrades(
+                portfolios.split(",").map { it.trim() }.filter { it.isNotBlank() },
+                assetId
+            )
+        )
+
     @PostMapping(
         value = ["/query"]
     )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnQueryService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnQueryService.kt
@@ -89,6 +89,26 @@ class TrnQueryService(
         )
 
     /**
+     * Trades for an asset across multiple portfolios — used by the aggregated
+     * holdings drill-down, where one asset is held in several portfolios.
+     *
+     * [PortfolioService.find] is called per id, so an unknown or unauthorized
+     * portfolio rejects the whole request (fail-closed) rather than silently
+     * returning a partial result. Each Trn carries its portfolio, so callers can
+     * group the union by portfolio.
+     */
+    fun findAssetTrades(
+        portfolioIds: List<String>,
+        assetId: String
+    ): Collection<Trn> =
+        portfolioIds.flatMap { portfolioId ->
+            findAssetTrades(
+                portfolioService.find(portfolioId),
+                assetId
+            )
+        }
+
+    /**
      * Corporate actions
      *
      * @param portfolioId fully qualified portfolio the caller is authorized to view

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnControllerFlowTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnControllerFlowTest.kt
@@ -313,6 +313,92 @@ class TrnControllerFlowTest(
         ).isNotNull.isEqualTo("3")
     }
 
+    // MSFT BUY with a unique callerRef so it never collides with trades posted
+    // by other tests sharing this class's database.
+    private fun msftBuy(callerId: String): TrnInput =
+        TrnInput(
+            CallerRef(callerId = callerId),
+            assetId = msft.id,
+            trnType = TrnType.BUY,
+            quantity = BigDecimal.TEN,
+            tradeDate = dateUtils.getFormattedDate(TRADE_DATE),
+            price = BigDecimal.TEN,
+            tradeCurrency = USD.code,
+            tradeBaseRate = BigDecimal.ONE,
+            tradeCashRate = BigDecimal.ONE,
+            tradePortfolioRate = BigDecimal.ONE,
+            status = TrnStatus.SETTLED
+        )
+
+    @Test
+    fun `should return asset trades across multiple portfolios`() {
+        val portfolioA =
+            bcMvcHelper.portfolio(
+                PortfolioInput("MultiA", "Name A", currency = NZD.code)
+            )
+        val portfolioB =
+            bcMvcHelper.portfolio(
+                PortfolioInput("MultiB", "Name B", currency = NZD.code)
+            )
+        // Two MSFT trades in each portfolio
+        bcMvcHelper.postTrn(TrnRequest(portfolioA.id, listOf(msftBuy("ma1"), msftBuy("ma2"))))
+        bcMvcHelper.postTrn(TrnRequest(portfolioB.id, listOf(msftBuy("mb1"), msftBuy("mb2"))))
+
+        val response =
+            findTradesMulti(
+                msft,
+                listOf(portfolioA.id, portfolioB.id),
+                token
+            )
+
+        // Union of both portfolios' MSFT trades
+        assertThat(response.data.trns).hasSize(4)
+        assertThat(response.data.trns.map { it.portfolioId })
+            .containsOnly(portfolioA.id, portfolioB.id)
+    }
+
+    @Test
+    fun `should fail closed when one portfolio is not viewable`() {
+        val portfolioA =
+            bcMvcHelper.portfolio(
+                PortfolioInput("OwnedA", "Owned", currency = NZD.code)
+            )
+        bcMvcHelper.postTrn(TrnRequest(portfolioA.id, listOf(msftBuy("fc1"))))
+
+        // A bogus/unauthorized portfolio id must reject the whole request, never
+        // silently return only the owned portfolio's trades.
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("$TRNS_ROOT/asset/{assetId}/trades", msft.id)
+                    .param("portfolios", "${portfolioA.id},does-not-exist")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+            ).andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
+
+    private fun findTradesMulti(
+        asset: Asset,
+        portfolioIds: List<String>,
+        token: Jwt
+    ): TrnResponse {
+        val result =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("$TRNS_ROOT/asset/{assetId}/trades", asset.id)
+                        .param("portfolios", portfolioIds.joinToString(","))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn()
+        return objectMapper.readValue(
+            result.response.contentAsString,
+            TrnResponse::class.java
+        )
+    }
+
     private fun deleteTransaction(
         id: String,
         token: Jwt


### PR DESCRIPTION
## What
New `GET /trns/asset/{assetId}/trades?portfolios=id1,id2` returning trade transactions for one asset across several portfolios. Each trn carries its portfolio so callers can group by portfolio.

## Why
The aggregated-holdings drill-down in bc-view only ever queried `portfolios.first().id`, so trades for an asset held in any other portfolio were never returned.

## Design
- `TrnQueryService.findAssetTrades(portfolioIds, assetId)` unions per-portfolio results.
- `portfolioService.find` is called per id → **fail-closed**: an unknown/unauthorized portfolio rejects the whole request (no partial result).

## Tests
- union across 2 portfolios → 4 trns, asserts both portfolio ids present
- fail-closed 404 when one portfolio is not viewable
- `test` + `formatKotlin` + `lintKotlin` green

Pairs with bc-view `feat/aggregate-trades-by-portfolio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New API endpoint enables querying all trades for a specific asset across multiple portfolios in a single request using comma-separated portfolio identifiers.

* **Tests**
  * Added comprehensive test coverage for multi-portfolio asset trade queries, including authorization validation with fail-closed security behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->