### PR TITLE
fix(position): CPF/policy BALANCE gain reflects interest, not contributions

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/model/Trn.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/model/Trn.kt
@@ -15,6 +15,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Transient
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
@@ -110,6 +111,13 @@ data class Trn(
     var modelId: String? = null,
     @JdbcTypeCode(SqlTypes.JSON)
     var subAccounts: Map<String, BigDecimal>? = null,
+    // Read-time only (never persisted). For POLICY/contribution BALANCE
+    // snapshots (CPF, pension), the contribution recognised SINCE the prior
+    // snapshot. svc-data derives it from PrivateAssetConfig at query time;
+    // svc-position adds it to cost basis so gain reflects interest rather
+    // than fresh principal. Null for everything else.
+    @Transient
+    var contribution: BigDecimal? = null,
     @ManyToOne
     var createdBy: SystemUser? = null,
     // Server-generated creation timestamp. Used as the chronological

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BalanceContributionStamper.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BalanceContributionStamper.kt
@@ -1,0 +1,73 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.assets.ContributionFrequency
+import com.beancounter.marketdata.assets.PrivateAssetConfig
+import com.beancounter.marketdata.assets.PrivateAssetConfigRepository
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.temporal.ChronoUnit
+
+/**
+ * Read-time enrichment for BALANCE snapshots of contribution-driven private
+ * assets (CPF, pensions).
+ *
+ * A BALANCE is a point-in-time snapshot of an account whose balance grows
+ * mostly from FRESH CONTRIBUTIONS, with interest on top. Without separating
+ * the two, svc-position can only treat every balance increase as either all
+ * gain (absurd growth) or all principal (no gain). This stamps each non-first
+ * snapshot with the contribution recognised since the prior snapshot — derived
+ * from the asset's [PrivateAssetConfig.monthlyContribution] — so svc-position
+ * can grow cost basis by contributions and surface only interest as gain.
+ *
+ * The value is an ESTIMATE (the configured contribution, not recorded actuals)
+ * and is never persisted — [Trn.contribution] is `@Transient`.
+ */
+@Component
+class BalanceContributionStamper(
+    private val privateAssetConfigRepository: PrivateAssetConfigRepository
+) {
+    fun stamp(trns: Collection<Trn>) {
+        val balances = trns.filter { it.trnType == TrnType.BALANCE && it.asset != null }
+        if (balances.isEmpty()) return
+
+        val configByAsset =
+            privateAssetConfigRepository
+                .findByAssetIdIn(balances.mapNotNull { it.asset?.id }.distinct())
+                .associateBy { it.assetId }
+
+        // Each (portfolio, asset) is an independent snapshot series.
+        balances
+            .groupBy { it.portfolio.id to it.asset!!.id }
+            .forEach { (key, series) ->
+                val monthly = monthlyEquivalent(configByAsset[key.second]) ?: return@forEach
+                val ordered = series.sortedWith(compareBy({ it.tradeDate }, { it.createdAt }))
+                // First snapshot is the starting principal — leave contribution
+                // null so svc-position pins cost at that balance (gain 0).
+                for (i in 1 until ordered.size) {
+                    val months =
+                        ChronoUnit.MONTHS
+                            .between(
+                                ordered[i - 1].tradeDate.withDayOfMonth(1),
+                                ordered[i].tradeDate.withDayOfMonth(1)
+                            ).coerceAtLeast(0)
+                    if (months > 0) {
+                        ordered[i].contribution = monthly.multiply(BigDecimal(months))
+                    }
+                }
+            }
+    }
+
+    /** Monthly-equivalent contribution, or null when none is configured. */
+    private fun monthlyEquivalent(config: PrivateAssetConfig?): BigDecimal? {
+        val amount = config?.monthlyContribution ?: return null
+        if (amount.signum() <= 0) return null
+        return if (config.contributionFrequency == ContributionFrequency.ANNUAL) {
+            amount.divide(BigDecimal(12), 4, RoundingMode.HALF_UP)
+        } else {
+            amount
+        }
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -44,7 +44,8 @@ class TrnService(
     private val portfolioShareRepository: PortfolioShareRepository,
     private val cashAutoSettleService: CashAutoSettleService,
     private val trnSettlementService: TrnSettlementService,
-    private val dateUtils: DateUtils
+    private val dateUtils: DateUtils,
+    private val balanceContributionStamper: BalanceContributionStamper
 ) {
     private val log = LoggerFactory.getLogger(TrnService::class.java)
 
@@ -475,6 +476,9 @@ class TrnService(
                 trnRepository.save(upgraded)
             }
         }
+        // Read-time only: stamp contribution on BALANCE snapshots so
+        // svc-position can separate interest from fresh principal.
+        balanceContributionStamper.stamp(trns)
         log.trace("Completed postProcess trns: ${trns.size}")
         return trns
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BalanceContributionStamperTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BalanceContributionStamperTest.kt
@@ -1,0 +1,96 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.assets.ContributionFrequency
+import com.beancounter.marketdata.assets.PrivateAssetConfig
+import com.beancounter.marketdata.assets.PrivateAssetConfigRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Verifies BALANCE snapshots are stamped with the contribution recognised
+ * since the prior snapshot, derived from the asset's contribution config.
+ */
+class BalanceContributionStamperTest {
+    private val repository = mock<PrivateAssetConfigRepository>()
+    private val stamper = BalanceContributionStamper(repository)
+
+    private val portfolio = Portfolio(id = "P1", code = "P1")
+    private val cpf =
+        Asset(code = "CPF", id = "cpf-1", market = Market("PRIVATE"))
+
+    private fun balance(
+        date: String,
+        amount: String
+    ) = Trn(
+        trnType = TrnType.BALANCE,
+        asset = cpf,
+        quantity = BigDecimal(amount),
+        tradeAmount = BigDecimal(amount),
+        tradeDate = LocalDate.parse(date),
+        portfolio = portfolio
+    )
+
+    @Test
+    fun `stamps contribution on later snapshots and leaves the first one null`() {
+        whenever(repository.findByAssetIdIn(listOf("cpf-1")))
+            .thenReturn(
+                listOf(
+                    PrivateAssetConfig(
+                        assetId = "cpf-1",
+                        monthlyContribution = BigDecimal("600"),
+                        contributionFrequency = ContributionFrequency.MONTHLY
+                    )
+                )
+            )
+        val first = balance("2026-01-15", "100000")
+        val second = balance("2026-04-15", "102000") // 3 months later
+
+        stamper.stamp(listOf(first, second))
+
+        assertThat(first.contribution).isNull()
+        // 3 months * 600 = 1,800 of the 2,000 increase is contribution.
+        assertThat(second.contribution).isEqualByComparingTo(BigDecimal("1800"))
+    }
+
+    @Test
+    fun `annual frequency is converted to a monthly equivalent`() {
+        whenever(repository.findByAssetIdIn(listOf("cpf-1")))
+            .thenReturn(
+                listOf(
+                    PrivateAssetConfig(
+                        assetId = "cpf-1",
+                        monthlyContribution = BigDecimal("12000"),
+                        contributionFrequency = ContributionFrequency.ANNUAL
+                    )
+                )
+            )
+        val first = balance("2026-01-10", "50000")
+        val second = balance("2026-07-10", "55000") // 6 months later
+
+        stamper.stamp(listOf(first, second))
+
+        // 12,000/yr -> 1,000/mo * 6 months = 6,000.
+        assertThat(second.contribution).isEqualByComparingTo(BigDecimal("6000"))
+    }
+
+    @Test
+    fun `no config means no contribution is stamped`() {
+        whenever(repository.findByAssetIdIn(listOf("cpf-1"))).thenReturn(emptyList())
+        val first = balance("2026-01-15", "100000")
+        val second = balance("2026-04-15", "102000")
+
+        stamper.stamp(listOf(first, second))
+
+        assertThat(first.contribution).isNull()
+        assertThat(second.contribution).isNull()
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -90,7 +90,8 @@ class TrnSettleTest {
                 portfolioShareRepository = mock<PortfolioShareRepository>(),
                 cashAutoSettleService = cashAutoSettleService,
                 trnSettlementService = trnSettlementService,
-                dateUtils = dateUtils
+                dateUtils = dateUtils,
+                balanceContributionStamper = mock()
             )
     }
 

--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BalanceBehaviour.kt
@@ -79,8 +79,9 @@ class BalanceBehaviour(
                 position
             )
         // Capture the prior cost basis before CashCost.value resets it; a
-        // non-zero prior means a previous BALANCE already pinned cost and
-        // subsequent snapshots must leave it alone so gain can emerge.
+        // non-zero prior means a previous BALANCE already set the principal,
+        // so this snapshot grows cost by its contribution rather than
+        // re-pinning the whole balance as gain.
         val priorCostBasis = moneyValues.costBasis
         cashCost.value(
             moneyValues,
@@ -92,6 +93,7 @@ class BalanceBehaviour(
             setSnapshotCost(
                 moneyValues,
                 trn.tradeAmount,
+                trn.contribution,
                 rate,
                 priorCostBasis
             )
@@ -99,25 +101,41 @@ class BalanceBehaviour(
     }
 
     /**
-     * Non-cash BALANCE: pin cost basis at the first snapshot ("principal")
-     * and leave it alone on subsequent snapshots so MV - cost surfaces real
-     * unrealised gain. First snapshot still sets cost = MV (gain = 0) so a
-     * freshly linked CPF/policy position doesn't report a phantom 100% gain.
+     * Non-cash BALANCE cost basis.
+     *
+     * A BALANCE is a snapshot of a contribution-driven account (CPF, pension):
+     * its increase between snapshots is mostly FRESH PRINCIPAL (contributions),
+     * not market gain. Pinning cost at the first snapshot and treating every
+     * later rise as gain therefore reports absurd growth (e.g. +3340%).
+     *
+     * Instead:
+     * - First snapshot: cost = market value, so the starting balance is the
+     *   principal and gain = 0 (no phantom 100% gain on a freshly linked
+     *   position).
+     * - Later snapshots: grow cost by the [contribution] recognised since the
+     *   prior snapshot (supplied by svc-data from the asset's contribution
+     *   config), so only interest surfaces as unrealised gain. Capped at the
+     *   current market value so an over-stated contribution estimate can't
+     *   show a phantom loss. When no contribution is supplied, cost tracks the
+     *   balance (gain = 0) — never a phantom gain.
      */
     private fun setSnapshotCost(
         moneyValues: MoneyValues,
         tradeAmount: BigDecimal,
+        contribution: BigDecimal?,
         rate: BigDecimal,
         priorCostBasis: BigDecimal
     ) {
-        if (priorCostBasis.signum() != 0) {
-            moneyValues.costBasis = priorCostBasis
-            moneyValues.costValue = priorCostBasis
-            return
-        }
-        val amount = MathUtils.multiply(tradeAmount, rate) ?: return
-        moneyValues.costBasis = amount.abs()
-        moneyValues.costValue = amount.abs()
+        val marketValue = (MathUtils.multiply(tradeAmount, rate) ?: return).abs()
+        val cost =
+            if (priorCostBasis.signum() == 0 || contribution == null) {
+                marketValue
+            } else {
+                val contributed = (MathUtils.multiply(contribution, rate) ?: BigDecimal.ZERO).abs()
+                (priorCostBasis + contributed).min(marketValue)
+            }
+        moneyValues.costBasis = cost
+        moneyValues.costValue = cost
         moneyValues.averageCost = BigDecimal.ONE
     }
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -153,55 +153,105 @@ class BalanceBehaviourTest {
         )
     }
 
+    private fun cpfPolicyAsset() =
+        Asset(
+            code = RUBY_CPF,
+            id = RUBY_CPF,
+            name = "Ruby CPF",
+            market = Market("PRIVATE"),
+            priceSymbol = RUBY_CPF,
+            category = AssetCategory.POLICY
+        )
+
+    private fun balanceTrn(
+        portfolio: Portfolio,
+        asset: Asset,
+        qty: BigDecimal,
+        contribution: BigDecimal? = null
+    ) = Trn(
+        trnType = TrnType.BALANCE,
+        asset = asset,
+        quantity = qty,
+        tradeAmount = qty,
+        contribution = contribution,
+        cashCurrency = SGD,
+        tradeCurrency = SGD,
+        tradeCashRate = BigDecimal.ONE,
+        tradeBaseRate = BigDecimal.ONE,
+        tradePortfolioRate = BigDecimal.ONE,
+        portfolio = portfolio
+    )
+
     @Test
-    fun `second BALANCE leaves cost pinned at first snapshot so gain emerges`() {
-        // First BALANCE establishes the cost basis (initial snapshot acts as
-        // the "principal"). A later BALANCE only moves the market value
-        // (quantity * price) so unrealised gain = MV - first-snapshot cost.
-        // Without this, every snapshot rewrites cost = MV and gain stays 0.
-        val portfolio =
-            Portfolio(
-                Constants.TEST,
-                currency = SGD,
-                base = SGD
-            )
-        val cpfAsset =
-            Asset(
-                code = RUBY_CPF,
-                id = RUBY_CPF,
-                name = "Ruby CPF",
-                market = Market("PRIVATE"),
-                priceSymbol = RUBY_CPF,
-                category = AssetCategory.POLICY
-            )
-        val firstBalance = BigDecimal("250000.00")
+    fun `second BALANCE without a contribution tracks the balance so gain stays zero`() {
+        // A bare BALANCE snapshot carries no contribution info. The increase
+        // could be all contribution or all interest — unknowable — so cost
+        // tracks the balance and no phantom gain is reported. (Regression:
+        // pinning cost at the first snapshot turned every later contribution
+        // into "gain", producing absurd growth like +3340%.)
+        val portfolio = Portfolio(Constants.TEST, currency = SGD, base = SGD)
+        val cpfAsset = cpfPolicyAsset()
         val secondBalance = BigDecimal("260000.00")
         val positions = Positions(portfolio)
 
-        fun balanceTrn(qty: BigDecimal) =
-            Trn(
-                trnType = TrnType.BALANCE,
-                asset = cpfAsset,
-                quantity = qty,
-                tradeAmount = qty,
-                cashCurrency = SGD,
-                tradeCurrency = SGD,
-                tradeCashRate = BigDecimal.ONE,
-                tradeBaseRate = BigDecimal.ONE,
-                tradePortfolioRate = BigDecimal.ONE,
-                portfolio = portfolio
-            )
-
-        accumulator.accumulate(balanceTrn(firstBalance), positions)
-        val position = accumulator.accumulate(balanceTrn(secondBalance), positions)
+        accumulator.accumulate(balanceTrn(portfolio, cpfAsset, BigDecimal("250000.00")), positions)
+        val position = accumulator.accumulate(balanceTrn(portfolio, cpfAsset, secondBalance), positions)
 
         assertThat(position.quantityValues.purchased).isEqualByComparingTo(secondBalance)
         assertThat(position.getMoneyValues(Position.In.PORTFOLIO))
-            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, firstBalance)
-            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, firstBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, secondBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, secondBalance)
         assertThat(position.getMoneyValues(Position.In.BASE))
-            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, firstBalance)
-            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, firstBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, secondBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, secondBalance)
+    }
+
+    @Test
+    fun `second BALANCE grows cost by the contribution so only interest is gain`() {
+        // First snapshot pins the starting principal (250,000). The second
+        // snapshot is 260,000 with a recognised contribution of 8,000, so
+        // cost = 250,000 + 8,000 = 258,000 and unrealised gain = 260,000 -
+        // 258,000 = 2,000 (the interest), NOT the full 10,000 delta.
+        val portfolio = Portfolio(Constants.TEST, currency = SGD, base = SGD)
+        val cpfAsset = cpfPolicyAsset()
+        val positions = Positions(portfolio)
+        val expectedCost = BigDecimal("258000.00")
+
+        accumulator.accumulate(balanceTrn(portfolio, cpfAsset, BigDecimal("250000.00")), positions)
+        val position =
+            accumulator.accumulate(
+                balanceTrn(portfolio, cpfAsset, BigDecimal("260000.00"), contribution = BigDecimal("8000.00")),
+                positions
+            )
+
+        assertThat(position.getMoneyValues(Position.In.PORTFOLIO))
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, expectedCost)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, expectedCost)
+        assertThat(position.getMoneyValues(Position.In.BASE))
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, expectedCost)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, expectedCost)
+    }
+
+    @Test
+    fun `an over-stated contribution is capped at market value so no phantom loss appears`() {
+        // If the contribution estimate exceeds the actual balance increase,
+        // cost is clamped to market value (gain 0) rather than showing a loss.
+        val portfolio = Portfolio(Constants.TEST, currency = SGD, base = SGD)
+        val cpfAsset = cpfPolicyAsset()
+        val secondBalance = BigDecimal("255000.00")
+        val positions = Positions(portfolio)
+
+        accumulator.accumulate(balanceTrn(portfolio, cpfAsset, BigDecimal("250000.00")), positions)
+        val position =
+            accumulator.accumulate(
+                // 9,000 contribution > 5,000 actual increase → cap at MV.
+                balanceTrn(portfolio, cpfAsset, secondBalance, contribution = BigDecimal("9000.00")),
+                positions
+            )
+
+        assertThat(position.getMoneyValues(Position.In.PORTFOLIO))
+            .hasFieldOrPropertyWithValue(PROP_COST_BASIS, secondBalance)
+            .hasFieldOrPropertyWithValue(PROP_COST_VALUE, secondBalance)
     }
 
     @Test


### PR DESCRIPTION
## Problem
Demo CPF showed **+3340% growth / absurd XIRR**. PR #936 pinned cost basis at the first `BALANCE` snapshot so "gain emerges" on later snapshots. But a CPF/pension balance rises mostly from **fresh contributions**, not market gain — so every contribution was counted as gain (profit ≈ whole balance, growth in the thousands of %; XIRR sees a value jump with no cash inflow → absurd annualised).

## Fix (contributions-as-cost)
Cost basis = cumulative **contributions**, so gain = interest only.

- **jar-common** — new `@Transient Trn.contribution` (read-time only, never persisted; no migration).
- **svc-data** — `BalanceContributionStamper`, called from `TrnService.postProcess`, stamps each non-first BALANCE with the contribution recognised since the prior snapshot, derived from `PrivateAssetConfig.monthlyContribution` × months between snapshots (ANNUAL frequency → /12). Gated to assets that have a contribution config.
- **svc-position** — `BalanceBehaviour`: first snapshot = principal (gain 0); later snapshots grow cost by `contribution` (capped at market value so an over-stated estimate can't show a phantom loss). **No contribution → cost tracks the balance (gain 0)** — never a phantom gain, so the demo is fixed even before any config is set.

## Caveat
The contribution is the *configured* figure (a planning estimate), not recorded actuals — gain ≈ estimated interest. CPF actual contributions vary with salary; revisit if actuals become available.

## Tests
`BalanceBehaviourTest` (no-contribution → gain 0; contribution → interest-only gain; over-stated estimate capped) and `BalanceContributionStamperTest` (monthly/annual frequency, no-config). Full `:svc-position:test` + `:svc-data:test` green; format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contribution tracking for balance-based investments to improve accuracy of gain and loss calculations.
  * Support for configuring both monthly and annual contribution amounts.

* **Improvements**
  * Cost basis calculations now properly account for periodic contributions when determining investment performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->