### PR TITLE
feat(prices): market-close-aligned refresh in market timezone (UK + US)

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/utils/MarketHolidays.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/utils/MarketHolidays.kt
@@ -4,10 +4,16 @@ import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
+import java.time.ZoneId
 
 /**
- * Determines if a date is a US market holiday.
- * US stock markets (NYSE, NASDAQ) are closed on these holidays.
+ * Determines whether a date is a market holiday.
+ *
+ * Routing is by exchange timezone:
+ *  - `Europe/London` resolves to the LSE (England & Wales) bank-holiday
+ *    calendar.
+ *  - every other zone resolves to the US (NYSE/NASDAQ) calendar, which is
+ *    also the back-compatible default for the zone-less [isHoliday] overload.
  */
 @Service
 class MarketHolidays {
@@ -15,15 +21,99 @@ class MarketHolidays {
         private const val JUNETEENTH_DAY = 19
         private const val JUNETEENTH_FIRST_YEAR = 2021
         private const val CHRISTMAS_DAY = 25
+        private const val BOXING_DAY = 26
+        private val LONDON: ZoneId = ZoneId.of("Europe/London")
     }
 
     /**
-     * Check if the given date is a US market holiday.
+     * Check if the given date is a US market holiday (back-compatible default).
      */
-    fun isHoliday(date: LocalDate): Boolean =
+    fun isHoliday(date: LocalDate): Boolean = isUsHoliday(date)
+
+    /**
+     * Check if the given date is a holiday for the market in [zone].
+     * London markets use the UK calendar; all others fall back to the US one.
+     */
+    fun isHoliday(
+        date: LocalDate,
+        zone: ZoneId?
+    ): Boolean =
+        if (zone == LONDON) {
+            isUkHoliday(date)
+        } else {
+            isUsHoliday(date)
+        }
+
+    private fun isUsHoliday(date: LocalDate): Boolean =
         isFixedHoliday(date) ||
             isObservedHoliday(date) ||
             isFloatingHoliday(date)
+
+    /**
+     * LSE bank holidays for [date]'s year, including weekend-substitute days.
+     */
+    fun isUkHoliday(date: LocalDate): Boolean = ukHolidays(date.year).contains(date)
+
+    private fun ukHolidays(year: Int): Set<LocalDate> {
+        val easterSunday = calculateEasterSunday(year)
+        val holidays = sortedSetOf<LocalDate>()
+
+        // Fixed weekday holidays (Easter-relative + bank holiday Mondays) —
+        // these always fall on a weekday so need no substitution.
+        holidays.add(easterSunday.minusDays(2)) // Good Friday
+        holidays.add(easterSunday.plusDays(1)) // Easter Monday
+        holidays.add(firstMondayOf(year, Month.MAY)) // Early May bank holiday
+        holidays.add(lastMondayOf(year, Month.MAY)) // Spring bank holiday
+        holidays.add(lastMondayOf(year, Month.AUGUST)) // Summer bank holiday
+
+        // Fixed-date holidays that shift to a substitute weekday on weekends.
+        addObserved(holidays, LocalDate.of(year, Month.JANUARY, 1)) // New Year
+        addObserved(holidays, LocalDate.of(year, Month.DECEMBER, CHRISTMAS_DAY))
+        addObserved(holidays, LocalDate.of(year, Month.DECEMBER, BOXING_DAY))
+
+        return holidays
+    }
+
+    /**
+     * Adds [holiday] to [set], substituting weekend dates (and resolving
+     * collisions, e.g. Christmas & Boxing Day both falling on a weekend) to
+     * the next free weekday.
+     */
+    private fun addObserved(
+        set: MutableSet<LocalDate>,
+        holiday: LocalDate
+    ) {
+        var observed = holiday
+        while (set.contains(observed) ||
+            observed.dayOfWeek == DayOfWeek.SATURDAY ||
+            observed.dayOfWeek == DayOfWeek.SUNDAY
+        ) {
+            observed = observed.plusDays(1)
+        }
+        set.add(observed)
+    }
+
+    private fun firstMondayOf(
+        year: Int,
+        month: Month
+    ): LocalDate {
+        var date = LocalDate.of(year, month, 1)
+        while (date.dayOfWeek != DayOfWeek.MONDAY) {
+            date = date.plusDays(1)
+        }
+        return date
+    }
+
+    private fun lastMondayOf(
+        year: Int,
+        month: Month
+    ): LocalDate {
+        var date = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1)
+        while (date.dayOfWeek != DayOfWeek.MONDAY) {
+            date = date.minusDays(1)
+        }
+        return date
+    }
 
     /**
      * Fixed date holidays (always on the same date).

--- a/jar-common/src/main/kotlin/com/beancounter/common/utils/PreviousClosePriceDate.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/utils/PreviousClosePriceDate.kt
@@ -23,49 +23,63 @@ class PreviousClosePriceDate(
     }
 
     fun getPriceDate(
-        utcRequestDateTime: ZonedDateTime,
+        requestDateTime: ZonedDateTime,
         market: Market,
-        isCurrent: Boolean = dateUtils.isToday(utcRequestDateTime.toLocalDate().toString())
+        isCurrent: Boolean = dateUtils.isToday(requestDateTime.toLocalDate().toString())
     ): LocalDate =
         if (isCurrent) {
+            // Re-express "now" on the market's own wall clock so priceTime is
+            // honoured in the exchange timezone (DST included), independent of
+            // the request's or the server's zone. Both the availability check
+            // and the trading-day walk-back then operate in market-local time.
+            val marketLocal = requestDateTime.withZoneSameInstant(market.timezone.toZoneId())
             val pricesAvailable =
                 getPricesAvailable(
-                    utcRequestDateTime,
+                    requestDateTime,
                     market
                 )
             val daysToSubtract =
                 getDaysToSubtract(
                     market,
-                    utcRequestDateTime.toLocalDateTime(),
+                    marketLocal.toLocalDateTime(),
                     pricesAvailable.toLocalDateTime()
                 )
 
             log.trace(
-                "utc: $utcRequestDateTime, subtract: $daysToSubtract, marketLocal: $utcRequestDateTime, " +
-                    "marketCloses: $pricesAvailable, timezone: ${dateUtils.zoneId}"
+                "request: $requestDateTime, subtract: $daysToSubtract, marketLocal: $marketLocal, " +
+                    "marketCloses: $pricesAvailable, timezone: ${market.timezoneId}"
             )
             getPriceDate(
-                utcRequestDateTime,
-                daysToSubtract
+                marketLocal,
+                daysToSubtract,
+                market
             )
         } else {
             // Just account for work days
             log.trace("Returning last working day relative to requested date")
             getPriceDate(
-                utcRequestDateTime,
-                0
+                requestDateTime,
+                0,
+                market
             )
         }
 
+    /**
+     * When today's close price becomes available, expressed on the market's
+     * local clock: the requested instant projected into the market timezone,
+     * at the market's configured [Market.priceTime].
+     */
     fun getPricesAvailable(
-        marketLocal: ZonedDateTime,
+        requestDateTime: ZonedDateTime,
         market: Market
-    ): OffsetDateTime =
-        OffsetDateTime.of(
+    ): OffsetDateTime {
+        val marketLocal = requestDateTime.withZoneSameInstant(market.timezone.toZoneId())
+        return OffsetDateTime.of(
             marketLocal.toLocalDate(),
             market.priceTime,
             marketLocal.offset
         )
+    }
 
     private fun getDaysToSubtract(
         market: Market,
@@ -87,16 +101,20 @@ class PreviousClosePriceDate(
      */
     fun getPriceDate(
         seedDate: ZonedDateTime,
-        daysToSubtract: Int
+        daysToSubtract: Int,
+        market: Market? = null
     ): LocalDate {
         var notionalDateTime = seedDate.minusDays(daysToSubtract.toLong())
-        while (!isTradingDay(notionalDateTime)) {
+        while (!isTradingDay(notionalDateTime, market)) {
             notionalDateTime = notionalDateTime.minusDays(1)
         }
         return notionalDateTime.toLocalDate()
     }
 
-    fun isTradingDay(dateTime: ZonedDateTime): Boolean {
+    fun isTradingDay(
+        dateTime: ZonedDateTime,
+        market: Market? = null
+    ): Boolean {
         val dayOfWeek = dateTime.dayOfWeek
 
         // Check for weekends
@@ -104,8 +122,9 @@ class PreviousClosePriceDate(
             return false
         }
 
-        // Check for market holidays
-        if (marketHolidays.isHoliday(dateTime.toLocalDate())) {
+        // Holidays resolve against the market's own exchange calendar
+        // (London → UK, otherwise US). A null market keeps the US default.
+        if (marketHolidays.isHoliday(dateTime.toLocalDate(), market?.timezone?.toZoneId())) {
             return false
         }
 

--- a/jar-common/src/test/kotlin/com/beancounter/common/MarketCloseAvailabilityTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/MarketCloseAvailabilityTest.kt
@@ -1,0 +1,79 @@
+package com.beancounter.common
+
+import com.beancounter.common.model.Market
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.common.utils.PreviousClosePriceDate
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Specifies the DESIRED contract for close-price availability:
+ *
+ *   `market.priceTime` is a wall-clock time in the MARKET's own timezone.
+ *   A market's close price for date D is "available" once the market-local
+ *   clock reaches priceTime on D — independent of the request's timezone
+ *   or the server's zone.
+ *
+ * These tests are expected to FAIL against the current implementation, which
+ * anchors priceTime to the request's UTC offset rather than the market zone.
+ */
+internal class MarketCloseAvailabilityTest {
+    private val dateUtils = DateUtils("Asia/Singapore")
+    private val previousClose = PreviousClosePriceDate(dateUtils)
+
+    // NASDAQ defaults: timezoneId = US/Eastern, priceTime = 19:00.
+    private val nasdaq = Market("NASDAQ")
+
+    // LON trades in London; priceTime 19:00 London (EODHD EOD publish window).
+    private val lon =
+        Market(
+            code = "LON",
+            currencyId = "GBP",
+            timezoneId = "Europe/London",
+            priceTime = LocalTime.of(19, 0)
+        )
+
+    private fun utc(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ): ZonedDateTime =
+        OffsetDateTime
+            .of(year, month, day, hour, minute, 0, 0, ZoneOffset.UTC)
+            .toZonedDateTime()
+
+    @Test
+    fun `nasdaq close NOT available at 19_00 UTC because that is 15_00 New York`() {
+        // 2023-07-10 (Mon) 19:00 UTC == 15:00 EDT — NASDAQ has not yet closed.
+        // Desired: fall back to the prior trading day (Fri 2023-07-07).
+        val resolved = previousClose.getPriceDate(utc(2023, 7, 10, 19), nasdaq, true)
+        assertThat(resolved).isEqualTo(dateUtils.getFormattedDate("2023-07-07"))
+    }
+
+    @Test
+    fun `nasdaq close IS available at 23_00 UTC because that is 19_00 New York`() {
+        // 2023-07-10 (Mon) 23:00 UTC == 19:00 EDT — at priceTime, today's close.
+        val resolved = previousClose.getPriceDate(utc(2023, 7, 10, 23), nasdaq, true)
+        assertThat(resolved).isEqualTo(dateUtils.getFormattedDate("2023-07-10"))
+    }
+
+    @Test
+    fun `lon close IS available at 18_00 UTC in summer because that is 19_00 London`() {
+        // 2023-07-10 (Mon) 18:00 UTC == 19:00 BST — LSE close published, today.
+        val resolved = previousClose.getPriceDate(utc(2023, 7, 10, 18), lon, true)
+        assertThat(resolved).isEqualTo(dateUtils.getFormattedDate("2023-07-10"))
+    }
+
+    @Test
+    fun `lon close NOT available at 17_00 UTC in summer because that is 18_00 London`() {
+        // 2023-07-10 (Mon) 17:00 UTC == 18:00 BST — before priceTime; prior close.
+        val resolved = previousClose.getPriceDate(utc(2023, 7, 10, 17), lon, true)
+        assertThat(resolved).isEqualTo(dateUtils.getFormattedDate("2023-07-07"))
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/MarketHolidaysUkTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/MarketHolidaysUkTest.kt
@@ -1,0 +1,72 @@
+package com.beancounter.common
+
+import com.beancounter.common.model.Market
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.common.utils.MarketHolidays
+import com.beancounter.common.utils.PreviousClosePriceDate
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * UK (LSE) bank-holiday calendar and its market-scoped routing through the
+ * trading-day walk-back. London markets observe UK holidays; US holidays must
+ * NOT close the LSE, and vice-versa.
+ */
+internal class MarketHolidaysUkTest {
+    private val holidays = MarketHolidays()
+    private val previousClose = PreviousClosePriceDate(DateUtils("Asia/Singapore"))
+    private val london: ZoneId = ZoneId.of("Europe/London")
+
+    private val lon =
+        Market(
+            code = "LON",
+            timezoneId = "Europe/London"
+        )
+    private val nasdaq = Market("NASDAQ") // US/Eastern
+
+    @Test
+    fun `uk bank holidays are recognised`() {
+        // Boxing Day (US has none), Early May & Summer bank holidays (UK-only).
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 12, 26), london)).isTrue()
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 5, 6), london)).isTrue() // 1st Mon May
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 8, 26), london)).isTrue() // last Mon Aug
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 3, 29), london)).isTrue() // Good Friday
+    }
+
+    @Test
+    fun `uk weekend christmas substitutes to following weekdays`() {
+        // 2021-12-25 Sat → observed Mon 27; 2021-12-26 Sun → observed Tue 28.
+        assertThat(holidays.isHoliday(LocalDate.of(2021, 12, 27), london)).isTrue()
+        assertThat(holidays.isHoliday(LocalDate.of(2021, 12, 28), london)).isTrue()
+    }
+
+    @Test
+    fun `us-only holidays do not close the LSE`() {
+        // US Independence Day & Thanksgiving — LSE trades.
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 7, 4), london)).isFalse()
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 11, 28), london)).isFalse()
+    }
+
+    @Test
+    fun `uk-only holidays do not close US markets`() {
+        // Boxing Day & Summer bank holiday — NYSE/NASDAQ trade.
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 12, 26), ZoneId.of("US/Eastern"))).isFalse()
+        assertThat(holidays.isHoliday(LocalDate.of(2024, 8, 26), ZoneId.of("US/Eastern"))).isFalse()
+    }
+
+    @Test
+    fun `trading-day walk-back honours the market calendar`() {
+        // Boxing Day 2024-12-26 (Thu) is closed for LON, open for NASDAQ.
+        val boxingDay = ZonedDateTime.of(2024, 12, 26, 12, 0, 0, 0, london)
+        assertThat(previousClose.isTradingDay(boxingDay, lon)).isFalse()
+        assertThat(previousClose.isTradingDay(boxingDay, nasdaq)).isTrue()
+
+        // US Independence Day is open for LON, closed for NASDAQ.
+        val july4 = ZonedDateTime.of(2024, 7, 4, 12, 0, 0, 0, ZoneId.of("America/New_York"))
+        assertThat(previousClose.isTradingDay(july4, lon)).isTrue()
+        assertThat(previousClose.isTradingDay(july4, nasdaq)).isFalse()
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/PreviousClosePriceDateTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/PreviousClosePriceDateTest.kt
@@ -55,14 +55,16 @@ internal class PreviousClosePriceDateTest {
                 15
             )
         val morningOf = sgtWednesday.atZone(dateUtils.zoneId)
-        // Should resolve to Tuesday as previous days close
+        // SGT 2023-07-11 02:15 == EDT 2023-07-10 14:15 — NASDAQ still open
+        // (priceTime 19:00 ET), so the last AVAILABLE close is the prior trading
+        // day Friday 2023-07-07 (Mon → weekend walk-back).
         assertThat(
             previousClose.getPriceDate(
                 morningOf,
                 nasdaq,
                 true
             )
-        ).isEqualTo(dateUtils.getFormattedDate(EXPECTED_DATE)) // Nasdaq last close
+        ).isEqualTo(dateUtils.getFormattedDate("2023-07-07")) // Nasdaq last available close
     }
 
     @Test

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/config/PriceScheduleConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/config/PriceScheduleConfig.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.utils.DateUtils
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -13,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
  */
 @Configuration
 @EnableScheduling
+@EnableConfigurationProperties(PriceScheduleProperties::class)
 @ConditionalOnProperty(
     value = ["schedule.enabled"],
     havingValue = "true",
@@ -25,20 +27,12 @@ class PriceScheduleConfig(
         private val log = LoggerFactory.getLogger(PriceScheduleConfig::class.java)
     }
 
+    // Shared default zone for the annotation-based @Scheduled jobs
+    // (FX, classification, auto-settle, news retention). The market-close
+    // price refresh no longer uses this — it registers per-market named-zone
+    // cron triggers via PriceScheduleProperties / PriceSchedule.
     @Bean
     fun scheduleZone(): String = dateUtils.zoneId.id
-
-    @Bean
-    fun assetsSchedule(
-        @Value("\${assets.schedule:0 0/15 7-18 * * Tue-Sat}") schedule: String
-    ): String {
-        log.info(
-            "ASSETS_SCHEDULE: {}, BEANCOUNTER_ZONE: {}",
-            schedule,
-            dateUtils.zoneId.id
-        )
-        return schedule
-    }
 
     /**
      * Cron expression for the FX rate pre-fetch job. Default: 17:00 every

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/config/PriceScheduleProperties.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/config/PriceScheduleProperties.kt
@@ -1,0 +1,54 @@
+package com.beancounter.marketdata.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Market-close-aligned price refresh triggers.
+ *
+ * Each [MarketClose] fires the idempotent price refresh shortly after a
+ * market's end-of-day prices publish, expressed in that market's OWN
+ * timezone. Spring's named-zone [org.springframework.scheduling.support.CronTrigger]
+ * tracks daylight-saving transitions automatically, so a London/New-York
+ * close stays aligned year round.
+ *
+ * Because the refresh only fetches assets that still lack today's price and
+ * the per-market availability gate ([com.beancounter.common.utils.PreviousClosePriceDate])
+ * resolves the correct close date per market, a fire only pulls the markets
+ * that have actually closed and published — the UK fire skips US assets, and
+ * vice-versa.
+ *
+ * Override via `beancounter.market.schedule.closes` (env / yaml).
+ */
+@ConfigurationProperties(prefix = "beancounter.market.schedule")
+class PriceScheduleProperties {
+    var closes: MutableList<MarketClose> =
+        mutableListOf(
+            // LSE closes 16:30 Europe/London; EODHD publishes EOD ~2-3h later.
+            // Fires on the close day (MON-FRI) in London's own zone.
+            MarketClose(
+                name = "UK",
+                cron = "0 30 19 * * MON-FRI",
+                zone = "Europe/London"
+            ),
+            // NYSE/NASDAQ close 16:00 America/New_York; EODHD majors ~15m later.
+            // Fires on the close day (MON-FRI) in New York's own zone.
+            MarketClose(
+                name = "US",
+                cron = "0 0 17 * * MON-FRI",
+                zone = "America/New_York"
+            )
+        )
+}
+
+/**
+ * A single close-aligned refresh trigger.
+ *
+ * @param name  human label for logs/metrics (e.g. "UK", "US")
+ * @param cron  Spring 6-field cron expression (sec min hour dom mon dow)
+ * @param zone  IANA timezone id the cron is evaluated in (e.g. "Europe/London")
+ */
+data class MarketClose(
+    var name: String = "",
+    var cron: String = "",
+    var zone: String = ""
+)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceSchedule.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceSchedule.kt
@@ -1,15 +1,28 @@
 package com.beancounter.marketdata.providers
 
 import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.config.MarketClose
+import com.beancounter.marketdata.config.PriceScheduleProperties
 import io.sentry.spring.jakarta.tracing.SentryTransaction
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.scheduling.annotation.SchedulingConfigurer
+import org.springframework.scheduling.config.CronTask
+import org.springframework.scheduling.config.ScheduledTaskRegistrar
+import org.springframework.scheduling.support.CronTrigger
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 /**
- * Scheduled updated of market prices.
+ * Market-close-aligned scheduled price refresh.
+ *
+ * Registers one cron trigger per configured [MarketClose] (default UK + US),
+ * each evaluated in the market's own timezone so it fires just after that
+ * market's EOD prices publish — independent of daylight-saving and of the
+ * server's zone. All triggers call the same idempotent [updatePrices]; the
+ * per-market availability gate ensures each fire only pulls markets that have
+ * actually closed.
  */
 @Service
 @ConditionalOnProperty(
@@ -19,17 +32,43 @@ import java.time.LocalDateTime
 )
 class PriceSchedule(
     private val priceRefresh: PriceRefresh,
-    private val dateUtils: DateUtils
-) {
+    private val dateUtils: DateUtils,
+    private val properties: PriceScheduleProperties
+) : SchedulingConfigurer {
     companion object {
         private val log = LoggerFactory.getLogger(PriceSchedule::class.java)
     }
 
+    override fun configureTasks(taskRegistrar: ScheduledTaskRegistrar) {
+        properties.closes.forEach { close ->
+            log.info(
+                "Registering price-refresh trigger '{}' cron='{}' zone='{}'",
+                close.name,
+                close.cron,
+                close.zone
+            )
+            taskRegistrar.addCronTask(
+                CronTask(
+                    Runnable { runClose(close) },
+                    CronTrigger(
+                        close.cron,
+                        ZoneId.of(close.zone)
+                    )
+                )
+            )
+        }
+    }
+
+    private fun runClose(close: MarketClose) {
+        log.info(
+            "Market-close price refresh '{}' firing ({})",
+            close.name,
+            close.zone
+        )
+        updatePrices()
+    }
+
     @SentryTransaction(operation = "scheduled", name = "PriceSchedule.updatePrices")
-    @Scheduled(
-        cron = "#{@assetsSchedule}",
-        zone = "#{@scheduleZone}"
-    )
     fun updatePrices() {
         log.info(
             "Scheduled price update starting {} - {}",

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -397,6 +397,8 @@ beancounter:
         name: "NASDAQ"
         timezoneId: "US/Eastern"
         currencyId: "USD"
+        # EODHD publishes US majors ~15m after the 16:00 ET close.
+        priceTime: "16:30"
         active: false
         aliases:
           SHARESIGHT: "NAS"
@@ -407,6 +409,7 @@ beancounter:
         name: "New York Stock Exchange"
         timezoneId: "US/Eastern"
         currencyId: "USD"
+        priceTime: "16:30"
         active: false
         aliases:
           SHARESIGHT: "NYS"
@@ -417,6 +420,7 @@ beancounter:
         name: "American Stock Exchange"
         timezoneId: "US/Eastern"
         currencyId: "USD"
+        priceTime: "16:30"
         active: false
         aliases:
           FIGI: "US"
@@ -426,6 +430,7 @@ beancounter:
         name: "US Market"
         timezoneId: "US/Eastern"
         currencyId: "USD"
+        priceTime: "16:30"
         # Fuzzy / colloquial inputs all resolve to US so the chat agent and
         # CSV imports don't need exact knowledge of BC market conventions.
         # Aliases are matched case-insensitively after upper-casing.
@@ -486,6 +491,8 @@ beancounter:
         # UK assets priced in pence.
         currencyId: "GBP"
         timezoneId: "Europe/London"
+        # LSE closes 16:30 London; EODHD publishes EOD ~2-3h later.
+        priceTime: "19:00"
         multiplier: 0.01
         aliases:
           mstack: "XLON"
@@ -500,6 +507,7 @@ beancounter:
         # pence multiplier — otherwise the price is FX-converted as GBP and wrong.
         currencyId: "USD"
         timezoneId: "Europe/London"
+        priceTime: "19:00"
         aliases:
           FIGI: "LN"
           eodhd: "LSE"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/config/PriceScheduleConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/config/PriceScheduleConfigTest.kt
@@ -43,29 +43,6 @@ class PriceScheduleConfigTest {
     }
 
     @Test
-    fun `should create assets schedule bean with default schedule`() {
-        // When the assets schedule bean is created with default value
-        val assetsSchedule = priceScheduleConfig.assetsSchedule("0 0/15 7-18 * * Tue-Sat")
-
-        // Then it should return the provided schedule
-        assertThat(assetsSchedule).isEqualTo("0 0/15 7-18 * * Tue-Sat")
-    }
-
-    @Test
-    fun `should create assets schedule bean with custom schedule`() {
-        // Given a custom schedule
-        val customSchedule = "0 0/30 9-17 * * Mon-Fri"
-
-        // When the assets schedule bean is created with custom value
-        // Note: The @Value annotation takes precedence, so we need to set the property
-        val assetsSchedule = priceScheduleConfig.assetsSchedule(customSchedule)
-
-        // Then it should return the custom schedule
-        // The method parameter is ignored due to @Value annotation
-        assertThat(assetsSchedule).isEqualTo("0 0/15 7-18 * * Tue-Sat")
-    }
-
-    @Test
     fun `should have schedule zone bean available in application context`() {
         // When checking if the schedule zone bean exists
         val scheduleZoneBean = applicationContext.getBean("scheduleZone", String::class.java)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceScheduleConfigurerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceScheduleConfigurerTest.kt
@@ -1,0 +1,52 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.config.PriceScheduleProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.scheduling.config.ScheduledTaskRegistrar
+
+/**
+ * Unit coverage for the market-close-aligned scheduling rework: default
+ * triggers and that each configured close registers its own cron task.
+ */
+internal class PriceScheduleConfigurerTest {
+    private val priceRefresh = Mockito.mock(PriceRefresh::class.java)
+    private val dateUtils = DateUtils("Asia/Singapore")
+
+    @Test
+    fun `default closes cover UK and US in their own timezones`() {
+        val closes = PriceScheduleProperties().closes
+        assertThat(closes).hasSize(2)
+
+        val uk = closes.first { it.name == "UK" }
+        assertThat(uk.zone).isEqualTo("Europe/London")
+        assertThat(uk.cron).isEqualTo("0 30 19 * * MON-FRI")
+
+        val us = closes.first { it.name == "US" }
+        assertThat(us.zone).isEqualTo("America/New_York")
+        assertThat(us.cron).isEqualTo("0 0 17 * * MON-FRI")
+    }
+
+    @Test
+    fun `configureTasks registers a cron task per configured close`() {
+        val schedule =
+            PriceSchedule(
+                priceRefresh,
+                dateUtils,
+                PriceScheduleProperties()
+            )
+        val registrar = ScheduledTaskRegistrar()
+
+        schedule.configureTasks(registrar)
+
+        val expressions = registrar.cronTaskList.map { it.expression }
+        assertThat(registrar.cronTaskList).hasSize(2)
+        assertThat(expressions)
+            .containsExactlyInAnyOrder(
+                "0 30 19 * * MON-FRI",
+                "0 0 17 * * MON-FRI"
+            )
+    }
+}


### PR DESCRIPTION
## What

Reworks price refresh to fetch close prices **when each market closes**, in the
market's own timezone, instead of one global server-zone cron that missed both
the LSE and US closes.

## Why

The old cron (`0 0/15 7-18 * * Tue-Sat`, server zone) never fired late enough
for the LSE EOD (~19:00 London) and was entirely outside the window for the US
close (16:00 ET ≈ 21:00–00:00 UTC), so US closes only landed the next morning.
Two latent timezone bugs were also found and fixed (below).

## Changes

**Scheduling** — `PriceSchedule` now implements `SchedulingConfigurer` and
registers one named-zone cron trigger per configured `MarketClose`
(`PriceScheduleProperties`, default UK + US). DST-safe; all call the existing
idempotent `PriceRefresh`. Adding a market is config-only.

| Name | Cron | Zone |
|------|------|------|
| UK | `0 30 19 * * MON-FRI` | Europe/London |
| US | `0 0 17 * * MON-FRI` | America/New_York |

**Availability gate** (`PreviousClosePriceDate`) — `priceTime` is now
interpreted in the **market's own timezone** (request instant projected into
`market.timezone`); the trading-day walk-back is market-local too.
- 🔴 Fixed: US availability was anchored to UTC, so `priceTime` 19:00 resolved
  to ~15:00 ET (before the 16:00 close) → today's US close looked "available"
  hours early.
- 🔴 Fixed: LSE close was missed by ~1h every BST summer (UTC anchor ignored
  BST).
- One existing test (`is_previousDayOnCurrentTradingDay`) asserted the buggy
  behavior and was corrected.

**priceTime config** — US-zone markets → `16:30` ET (EODHD majors publish ~15m
post-close); LON/LSE explicit `19:00` London.

**Holidays** (`MarketHolidays`) — now zone-routed: `Europe/London` → UK (LSE)
bank-holiday calendar with weekend substitution; all other zones → US calendar
(unchanged). Threaded into the market-aware walk-back.

**Cleanup** — removed the now-unused `assetsSchedule` bean (legacy
`ASSETS_SCHEDULE`); `scheduleZone` retained (shared by FX/classification/
auto-settle/news schedulers).

## Tests

New: `MarketCloseAvailabilityTest`, `MarketHolidaysUkTest`,
`PriceScheduleConfigurerTest`. Full `:jar-common:test` and `:svc-data:test`
green; format + lint clean.

## Deploy / follow-ups

- kauri already has `SCHEDULE_ENABLED=true`; the dead `ASSETS_SCHEDULE` env is
  removed in bc-deploy (separate commit). Named-zone triggers ignore
  `BEANCOUNTER_ZONE`.
- The jar-common `MarketHolidays` and svc-data `MarketCalendar` calendars remain
  un-unified (pre-existing) — noted in `bc-claude/PRICE_REFRESH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-market timezone support for holiday calendars, with dedicated UK and US market holiday recognition.
  * Introduced configurable per-market price refresh scheduling with timezone-aligned cron triggers.

* **Bug Fixes**
  * Improved market-local date/time handling for close-price availability calculations.

* **Tests**
  * Added comprehensive test coverage for market-specific holiday calendars and trading-day logic across timezones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->