### PR TITLE
fix(auth): nullable repo finder params for Spring Data 4 Kotlin null-safety

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserCache.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserCache.kt
@@ -23,9 +23,9 @@ class SystemUserCache(
         val result =
             when {
                 email != null -> systemUserRepository.findByEmail(email)
-                tokenService.isAuth0() -> systemUserRepository.findByAuth0(subject!!)
-                tokenService.isGoogle() -> systemUserRepository.findByGoogleId(subject!!)
-                else -> Optional.ofNullable(null)
+                tokenService.isAuth0() -> systemUserRepository.findByAuth0(subject)
+                tokenService.isGoogle() -> systemUserRepository.findByGoogleId(subject)
+                else -> Optional.empty()
             }
         return result.orElse(null)
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/SystemUserRepository.kt
@@ -6,11 +6,20 @@ import java.util.Optional
 
 /**
  * CRUD repo for SystemUser.  A SystemUser can own portfolios in BC.
+ *
+ * Finder parameters are nullable by design. Spring Data 4 introspects Kotlin
+ * nullability metadata via kotlin-reflect and enforces it at invocation time;
+ * a smart-cast non-null value (e.g. `email` after an `email != null` check) is
+ * still seen as `String?` across the reflective repository call and a non-null
+ * parameter throws `argument type mismatch: actual type 'String?', but 'String'
+ * was expected`. Declaring the parameters nullable aligns the metadata. The
+ * callers in [SystemUserCache] only ever pass non-null values, so the derived
+ * query semantics are unchanged.
  */
 interface SystemUserRepository : CrudRepository<SystemUser, String> {
-    fun findByEmail(email: String): Optional<SystemUser>
+    fun findByEmail(email: String?): Optional<SystemUser>
 
-    fun findByAuth0(auto0: String): Optional<SystemUser>
+    fun findByAuth0(auth0: String?): Optional<SystemUser>
 
-    fun findByGoogleId(google: String): Optional<SystemUser>
+    fun findByGoogleId(google: String?): Optional<SystemUser>
 }


### PR DESCRIPTION
## Problem

After the Boot 4 / Spring Data 4 migration (#958), **every user login** fails with HTTP 403 `User is authenticated but not registered` even for a valid token whose email + subject match an existing `SystemUser` row. Runtime stack trace points at `SystemUserCache` calling `findByEmail`:

```
argument type mismatch: actual type is 'String?', but 'String' was expected
```

## Root cause

Spring Data 4 introspects Kotlin nullability metadata via `kotlin-reflect` and **enforces it at repository-invocation time** ([null-handling reference](https://docs.spring.io/spring-data/commons/reference/repositories/null-handling.html)). `SystemUserCache.find(email: String?, …)` smart-casts `email` to non-null and passes it to `findByEmail(email: String)`, but the smart-cast does not survive into the reflective call — Spring Data sees `String?` against a non-null param and rejects it. The `subject!!` branches escaped this only because `!!` emits a hard `checkNotNull`.

This does **not** surface in the H2 + mock-JWT test harness (registration tests pass on both old and fixed code); it triggers only under the real Nimbus-decoded token + Spring Data 4 reflective path. Verified fixed against the running service.

## Fix

- `SystemUserRepository`: `findByEmail` / `findByAuth0` / `findByGoogleId` params → `String?`, aligning the metadata. Callers only ever pass non-null values, so derived-query semantics are unchanged.
- `SystemUserCache`: dropped the now-redundant `subject!!`; `Optional.ofNullable(null)` → `Optional.empty()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety in user authentication lookups to prevent potential runtime exceptions during Auth0 and Google sign-in flows.

* **Refactor**
  * Enhanced Spring Data repository integration with improved parameter type compatibility for more reliable user registration queries and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->