### PR TITLE
fix(news): resolve EODHD news symbol via asset.priceSymbol

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -1,6 +1,8 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.common.input.AssetInput
 import com.beancounter.common.telemetry.runBlockingTraced
+import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.providers.NewsProvider
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
 import com.beancounter.marketdata.providers.eodhd.news.NewsArticle
@@ -42,7 +44,8 @@ class EodhdNewsService(
     private val eodhdConfig: EodhdConfig,
     private val newsProperties: EodhdNewsProperties,
     private val newsArticleRepo: NewsArticleRepo,
-    private val newsFetchRepo: NewsFetchRepo
+    private val newsFetchRepo: NewsFetchRepo,
+    private val assetFinder: AssetFinder
 ) : NewsProvider {
     private val log = LoggerFactory.getLogger(EodhdNewsService::class.java)
 
@@ -286,12 +289,34 @@ class EodhdNewsService(
                     market
                 }
             }
+        val bcMarket = if (market.isNullOrBlank()) "US" else market
         return tickers
             .split(",")
             .map { it.trim().uppercase() }
             .filter { it.matches(TICKER_PATTERN) }
-            .map { "$it.$exchange" }
+            .map { "${priceSymbolFor(it, bcMarket)}.$exchange" }
     }
+
+    /**
+     * Map a BC asset code to the symbol EODHD actually indexes news under. BC stores the canonical
+     * EODHD ticker in `Asset.priceSymbol` (e.g. code `BRK.B` → priceSymbol `BRK-B`, since EODHD uses
+     * a hyphen for US class shares). Without this, a naive `code.exchange` build (`BRK.B.US`) has no
+     * EODHD coverage and the agent wrongly falls back to general knowledge. Unknown tickers (not held
+     * locally) and lookup failures fall back to the raw code so ad-hoc queries still work.
+     */
+    private fun priceSymbolFor(
+        code: String,
+        bcMarket: String
+    ): String =
+        try {
+            assetFinder.findLocally(AssetInput(bcMarket, code))?.priceSymbol?.takeIf { it.isNotBlank() } ?: code
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.debug("No local asset for {}/{}: {}", bcMarket, code, e.message)
+            code
+        }
 
     private fun matchesTopic(
         article: NewsArticle,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -1,6 +1,9 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
+import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.providers.eodhd.model.EodhdArticleSentiment
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
@@ -55,7 +58,8 @@ internal class EodhdNewsServiceTest {
             ReflectionTestUtils.setField(it, "apiKey", "demo")
             ReflectionTestUtils.setField(it, "markets", "")
         }
-    private val service = EodhdNewsService(proxy, config, props, articleRepo, fetchRepo)
+    private val assetFinder = mock<AssetFinder>()
+    private val service = EodhdNewsService(proxy, config, props, articleRepo, fetchRepo, assetFinder)
 
     @Test
     fun `cache-miss triggers a refresh against EODHD for US tickers`() {
@@ -142,6 +146,23 @@ internal class EodhdNewsServiceTest {
 
         verify(proxy, never()).getNews(any(), any(), anyOrNull(), any())
         verify(fetchRepo, never()).save(any<NewsFetch>())
+    }
+
+    @Test
+    fun `resolves ticker to the asset priceSymbol for EODHD class shares`() {
+        // BC stores Berkshire-B as code "BRK.B" with priceSymbol "BRK-B" (EODHD uses a hyphen for
+        // US class shares). News must query EODHD as "BRK-B.US", not the naive "BRK.B.US" — the
+        // latter has no EODHD coverage, so the agent wrongly falls back to general knowledge.
+        whenever(assetFinder.findLocally(AssetInput("US", "BRK.B")))
+            .thenReturn(Asset(code = "BRK.B", market = Market(code = "US"), priceSymbol = "BRK-B"))
+        whenever(fetchRepo.findById("BRK-B.US")).thenReturn(Optional.empty())
+        whenever(proxy.getNews(eq("BRK-B.US"), any(), anyOrNull(), any())).thenReturn(listOf(eodhArticle(0.5)))
+        whenever(articleRepo.findByExternalId(any())).thenReturn(Optional.empty())
+        whenever(articleRepo.findByTickersAfter(any(), any())).thenReturn(emptyList())
+
+        service.getNewsSentiment("BRK.B")
+
+        verify(proxy).getNews(eq("BRK-B.US"), any(), anyOrNull(), any())
     }
 
     @Test


### PR DESCRIPTION
Class shares (e.g. BRK.B) are stored with priceSymbol BRK-B (EODHD uses a
hyphen for US class shares). News resolution built BRK.B.US naively, which
has no EODHD coverage, so the agent fell back to general knowledge. Now
maps code->priceSymbol via AssetFinder, falling back to the raw code for
unknown tickers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol resolution for market and sector news queries to more accurately map ticker symbols (including class shares) to their corresponding upstream format before fetching results.

* **Tests**
  * Added test coverage for enhanced ticker symbol resolution in news queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->