### PR TITLE
test(svc-data): use instance WireMock DSL to fix static-DSL flake

### DIFF
--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -14,7 +14,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
@@ -139,7 +138,7 @@ internal class EodhdApiTest {
         // fan-out. Bulk endpoint collapses N requests to 1; this asserts the routing
         // change holds AND both symbols' prices come back mapped to the right assets.
         val body = ClassPathResource("mock/eodhd/bulk-US-AAPL-MSFT.json").file.readText()
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo(BULK_LAST_DAY_US))
                 .willReturn(
                     aResponse()
@@ -194,7 +193,7 @@ internal class EodhdApiTest {
               "volume": 28481377
             }
         ]"""
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo(BULK_LAST_DAY_US))
                 .willReturn(
                     aResponse()
@@ -223,7 +222,7 @@ internal class EodhdApiTest {
         // Regression: a single Ticker-Not-Found used to propagate
         // HttpClientErrorException out of EodhdPriceService.getMarketData
         // and abort every other symbol in the same valuation cycle.
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo("/api/eod/MSFT.US"))
                 .willReturn(aResponse().withStatus(404).withBody("Ticker Not Found."))
         )
@@ -288,7 +287,7 @@ internal class EodhdApiTest {
         // through the real RestClient + WireMock, so all three layers see actual HTTP traffic
         // instead of unit-level mocks.
         val body = ClassPathResource("mock/eodhd/search-HYSA.json").file.readText()
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo("/api/search/HYSA"))
                 .willReturn(
                     aResponse()
@@ -316,7 +315,7 @@ internal class EodhdApiTest {
         // [EodhdBulkPrice[]]" — NOT an HttpClientErrorException, so the old catch
         // missed it and the entire valuation 500'd, zeroing every portfolio in the
         // cycle. Must fall back to per-symbol so good symbols still resolve.
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo(BULK_LAST_DAY_US))
                 .willReturn(
                     aResponse()
@@ -349,7 +348,7 @@ internal class EodhdApiTest {
         fixturePath: String
     ) {
         val body = ClassPathResource(fixturePath).file.readText()
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo("/api/eod/$symbol"))
                 .willReturn(
                     aResponse()

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
@@ -7,7 +7,6 @@ import com.beancounter.common.model.Market
 import com.beancounter.marketdata.MarketDataBoot
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
@@ -108,7 +107,7 @@ internal class EodhdEventApiTest {
         fixturePath: String
     ) {
         val body = ClassPathResource(fixturePath).file.readText()
-        stubFor(
+        wireMock.stubFor(
             get(urlPathEqualTo(path))
                 .willReturn(
                     aResponse()

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
@@ -23,7 +23,6 @@ import com.beancounter.marketdata.markets.MarketService
 import com.beancounter.marketdata.utils.ASSET_ROOT
 import com.beancounter.marketdata.utils.RegistrationUtils.registerUser
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -133,7 +132,7 @@ class FigiAssetApiTest {
         // Stub the /v3/search endpoint with mixed security types
         val filterResponse =
             ClassPathResource("mock/figi/filter-mixed-response.json").file.readText()
-        stubFor(
+        wireMock.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/v3/search"))
                 .withHeader(
@@ -166,7 +165,7 @@ class FigiAssetApiTest {
         // Stub the /v3/search endpoint with results from multiple exchanges
         val filterResponse =
             ClassPathResource("mock/figi/filter-global-response.json").file.readText()
-        stubFor(
+        wireMock.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/v3/search"))
                 .withHeader(
@@ -343,7 +342,7 @@ class FigiAssetApiTest {
             "BRK/B",
             "Common Stock"
         )
-        stubFor(
+        wireMock.stubFor(
             WireMock
                 .any(WireMock.anyUrl())
                 .atPriority(10)
@@ -397,7 +396,7 @@ class FigiAssetApiTest {
                     jsonFile,
                     object : TypeReference<Collection<FigiResponse>>() {}
                 )
-            stubFor(
+            wireMock.stubFor(
                 WireMock
                     .post(WireMock.urlEqualTo("/v3/mapping"))
                     .withRequestBody(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
@@ -17,7 +17,6 @@ import com.beancounter.marketdata.providers.marketstack.MarketStackService.Compa
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackData
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -260,7 +259,7 @@ internal class MarketStackApiTest {
         val gne = getTestAsset(NZX, "GNE")
         val jsonFile = ClassPathResource("$CONTRACTS/GNE-NZX-history.json").file
 
-        stubFor(
+        wireMock.stubFor(
             WireMock
                 .get(
                     WireMock.urlPathEqualTo("/v2/eod")
@@ -360,7 +359,7 @@ internal class MarketStackApiTest {
             if (overrideAsAt) {
                 response["date"] = asAt
             }
-            stubFor(
+            wireMock.stubFor(
                 WireMock
                     .get(
                         WireMock.urlEqualTo(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/AuthControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/AuthControllerTest.kt
@@ -6,7 +6,6 @@ import com.beancounter.auth.model.OpenIdResponse
 import com.beancounter.common.utils.BcJson.Companion.objectMapper
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
@@ -86,7 +85,7 @@ class AuthControllerTest {
             )
 
         // Stub Auth0 token endpoint
-        stubFor(
+        wireMock.stubFor(
             post(urlEqualTo("/oauth/token"))
                 .willReturn(
                     aResponse()


### PR DESCRIPTION
## Problem

`FigiAssetApiTest` and `EodhdEventApiTest` flaked under the full suite (8 failures), green in isolation. Cause: WireMock-tagged tests stubbed via the static DSL (`stubFor`), which writes the process-global `WireMock.defaultInstance` singleton. Cross-class, whichever extension last called `configureStaticDsl` owns the singleton, so stubs can land on the wrong (or stopped) server → 404 / connection refused.

## Fix

Stub through the per-class instance handle (`wireMock.stubFor(...)`) in the 5 directly-stubbing classes: EodhdApiTest, EodhdEventApiTest, FigiAssetApiTest, MarketStackApiTest, AuthControllerTest. No class reads the static singleton for stubbing anymore, so the race is gone.

`configureStaticDsl(true)` is kept — it is load-bearing: it forces eager server start so `wireMock.port` resolves before Spring binds `${wiremock.server.port}`. Removing it makes the port default to 8080 → connection refused.

## Not in scope

The Alpha family stubs via shared `AlphaMockUtils` (static DSL). It shares one Spring context, runs serially, and each test repoints the singleton in its own `beforeAll` — self-consistent and never in the failure set. Converting it safely needs an `AlphaMockUtils` signature change; deferred.

## Verification

- Full `:svc-data:test` green
- All affected classes green run together
- formatKotlin + lintKotlin clean

@coderabbitai ignore