### PR TITLE
fix(telemetry): provide Micrometer Tracer so gen_ai observations become Sentry spans

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
@@ -1,6 +1,9 @@
 package com.beancounter.common.telemetry
 
 import io.micrometer.observation.ObservationPredicate
+import io.micrometer.tracing.Tracer
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext
+import io.micrometer.tracing.otel.bridge.OtelTracer
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.sentry.spring7.SentryTaskDecorator
@@ -59,6 +62,32 @@ class SentryOtelConfig {
     @Bean
     @ConditionalOnMissingBean(OpenTelemetry::class)
     fun openTelemetry(): OpenTelemetry = GlobalOpenTelemetry.get()
+
+    /**
+     * Provide the Micrometer [Tracer] that bridges observations to the agent's
+     * OpenTelemetry SDK.
+     *
+     * Under the Sentry OTel javaagent, Spring Boot never builds a Micrometer
+     * `Tracer` bean (its own OTel-tracing auto-config does not fire in agent
+     * mode). Without it, `ChatObservationAutoConfiguration`'s
+     * `TracerPresentObservationConfiguration` backs off — verified live via
+     * `/actuator/conditions`: *"@ConditionalOnBean io.micrometer.tracing.Tracer
+     * did not find any beans"* — so Spring AI's `gen_ai.client.operation`
+     * observation only reaches the **meter** handler (a metric) and never
+     * becomes a span. Supplying an [OtelTracer] over the agent's OpenTelemetry
+     * registers the tracing observation handler, so `gen_ai.*` spans (with token
+     * usage + model) flow to Sentry. HTTP observations are still suppressed by
+     * [suppressHttpObservationsHandledByAgent] so the agent stays the sole HTTP
+     * span source.
+     */
+    @Bean
+    @ConditionalOnMissingBean(Tracer::class)
+    fun micrometerTracer(openTelemetry: OpenTelemetry): Tracer =
+        OtelTracer(
+            openTelemetry.getTracer("bc-micrometer-tracing"),
+            OtelCurrentTraceContext(),
+            OtelTracer.EventPublisher { }
+        )
 
     /**
      * Suppress Spring's Micrometer HTTP observations so they don't duplicate the

--- a/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryOtelConfigTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryOtelConfigTest.kt
@@ -40,6 +40,12 @@ class SentryOtelConfigTest {
     }
 
     @Test
+    fun `should provide a Micrometer Tracer so gen_ai observations become spans`() {
+        val tracer = sentryOtelConfig.micrometerTracer(sentryOtelConfig.openTelemetry())
+        assertThat(tracer).isInstanceOf(io.micrometer.tracing.Tracer::class.java)
+    }
+
+    @Test
     fun `should suppress HTTP observations the agent already instruments`() {
         val predicate: ObservationPredicate = sentryOtelConfig.suppressHttpObservationsHandledByAgent()
         assertThat(predicate.test("http.server.requests", Observation.Context())).isFalse()

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/SentryTracingWiringTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/SentryTracingWiringTest.kt
@@ -1,0 +1,39 @@
+package com.beancounter.agent
+
+import io.micrometer.tracing.Tracer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+
+/**
+ * Boot-safety guard for the Sentry tracing wiring. With `sentry.enabled=true`
+ * the SentryOtelConfig beans (OpenTelemetry + Micrometer Tracer + observation
+ * predicate) activate. This proves the context starts cleanly — i.e. supplying
+ * the Micrometer [Tracer] doesn't leave Boot's observation auto-config needing a
+ * bean it can't find (the kind of failure that would CrashLoop on kauri) — and
+ * that the Tracer bean Spring AI's gen_ai tracing handler depends on is present.
+ *
+ * Does NOT call an LLM; `GlobalOpenTelemetry.get()` is a no-op without the agent,
+ * so the bridged spans are inert locally — the export itself is verified on kauri.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "sentry.enabled=true",
+        "sentry.dsn=https://test@test.ingest.de.sentry.io/1",
+        "sentry.environment=test",
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://beancounter.eu.auth0.com/",
+        "auth.audience=https://holdsworth.app"
+    ]
+)
+class SentryTracingWiringTest {
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `context exposes a Micrometer Tracer so gen_ai observations are traced`() {
+        assertThat(context.getBeanNamesForType(Tracer::class.java)).isNotEmpty()
+    }
+}


### PR DESCRIPTION
Follow-up to #963. After deploy, `gen_ai.*` spans still did not appear in Sentry (token data missing), while the dedup half (#963 B) is confirmed live.

## Root cause (proven on the deployed pod via `/actuator/conditions`)
```
ChatObservationAutoConfiguration.TracerPresentObservationConfiguration:
  @ConditionalOnBean io.micrometer.tracing.Tracer did not find any beans
```
The `io.micrometer.tracing.Tracer` **class is on the classpath**, but under the Sentry OTel javaagent Spring Boot never builds a `Tracer` **bean** (its OTel-tracing auto-config does not fire in agent mode). So Spring AI's `gen_ai.client.operation` observation only reached the **meter** handler (`chatModelMeterObservationHandler` — a metric) and never became a span. #963's `GlobalOpenTelemetry` bean is correct but inert without a `Tracer` consuming it.

(Confirmed `openTelemetry` resolves to the agent's `ApplicationOpenTelemetry127`, and the observationRegistry had only meter handlers, no tracing handler.)

## Fix
Provide an `OtelTracer` (over the agent's OpenTelemetry) as the Micrometer `Tracer` bean → `ChatObservationAutoConfiguration.TracerPresentObservationConfiguration` matches → the gen_ai tracing observation handler registers → `gen_ai.*` spans (token usage + model) export to Sentry. HTTP observations stay suppressed (#963's `ObservationPredicate`) so the agent remains the sole HTTP span source.

## Tests
- `SentryOtelConfigTest`: Tracer bean constructs.
- `SentryTracingWiringTest` (svc-agent, `sentry.enabled=true`): **boot-safety** — context starts with the new Tracer + a `io.micrometer.tracing.Tracer` bean present (guards against a missing-Propagator CrashLoop). No LLM call.
- `formatKotlin`/`lintKotlin`/`testSmart` green.

## Verify on kauri (post-deploy)
`gen_ai.client.operation` spans under `POST /agent/query` with `gen_ai.usage.input_tokens`/`output_tokens` + model → AI dashboard + token baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tracing capabilities with Micrometer bridge integration, enabling improved trace collection and observability.

* **Tests**
  * Added integration tests to validate tracing system configuration and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->