### PR TITLE
fix(telemetry): register tracing observation handler so gen_ai becomes Sentry spans

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
@@ -1,7 +1,9 @@
 package com.beancounter.common.telemetry
 
 import io.micrometer.observation.ObservationPredicate
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.tracing.Tracer
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler
 import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext
 import io.micrometer.tracing.otel.bridge.OtelTracer
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -9,6 +11,8 @@ import io.opentelemetry.api.OpenTelemetry
 import io.sentry.spring7.SentryTaskDecorator
 import jakarta.annotation.PreDestroy
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.SmartInitializingSingleton
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -88,6 +92,35 @@ class SentryOtelConfig {
             OtelCurrentTraceContext(),
             OtelTracer.EventPublisher { }
         )
+
+    /**
+     * Register the span-producing tracing observation handler on the registry.
+     *
+     * Supplying a [Tracer] bean ([micrometerTracer]) flips Spring AI's
+     * `TracerPresentObservationConfiguration` to matched, but under the javaagent
+     * Boot's own tracing auto-config stays dormant, so **no tracing
+     * `ObservationHandlerGroup` is contributed** — verified live: the registry
+     * carried only meter handlers, so `gen_ai.client.operation` was still only a
+     * metric. Add [DefaultTracingObservationHandler] directly to the registry
+     * (bypasses the missing group) so each observation becomes a span on the
+     * agent's OpenTelemetry, parented under the agent's current transaction.
+     * `http.*` observations are already filtered out
+     * by [suppressHttpObservationsHandledByAgent], so only `gen_ai.*` and other
+     * non-HTTP observations are traced — no duplication of the agent's HTTP spans.
+     */
+    @Bean
+    fun tracingObservationHandlerInitializer(
+        observationRegistry: ObjectProvider<ObservationRegistry>,
+        tracer: Tracer
+    ): SmartInitializingSingleton =
+        SmartInitializingSingleton {
+            // Add the handler after all singletons exist — injecting the registry
+            // directly would deadlock (Boot wires handler beans into the registry
+            // while it is still being created). ObjectProvider defers the lookup.
+            observationRegistry.ifAvailable
+                ?.observationConfig()
+                ?.observationHandler(DefaultTracingObservationHandler(tracer))
+        }
 
     /**
      * Suppress Spring's Micrometer HTTP observations so they don't duplicate the

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/SentryTracingWiringTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/SentryTracingWiringTest.kt
@@ -1,7 +1,10 @@
 package com.beancounter.agent
 
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.tracing.Tracer
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -32,8 +35,25 @@ class SentryTracingWiringTest {
     @Autowired
     private lateinit var context: ApplicationContext
 
+    @Autowired
+    private lateinit var observationRegistry: ObservationRegistry
+
     @Test
     fun `context exposes a Micrometer Tracer so gen_ai observations are traced`() {
         assertThat(context.getBeanNamesForType(Tracer::class.java)).isNotEmpty()
+    }
+
+    @Test
+    fun `registers the tracing observation handler on the registry`() {
+        assertThat(context.containsBean("tracingObservationHandlerInitializer")).isTrue()
+    }
+
+    @Test
+    fun `a gen_ai observation flows through the tracing handler without error`() {
+        assertThatCode {
+            Observation
+                .createNotStarted("gen_ai.client.operation", observationRegistry)
+                .observe { /* handler opens + closes a span scope */ }
+        }.doesNotThrowAnyException()
     }
 }


### PR DESCRIPTION
Follow-up to #964. After #964 deployed, `gen_ai.*` spans **still** did not appear. Diagnosed live on the pod (`/actuator/conditions` + `/beans`).

## Root cause (the third layer)
#964's `micrometerTracer` bean is present and flips `ChatObservationAutoConfiguration.TracerPresentObservationConfiguration` to **matched** — but the registry still carried **only meter handlers** (`chatModelMeterObservationHandler`, `defaultMeterObservationHandler`), no tracing handler. Under the Sentry javaagent, Boot's own tracing auto-config stays dormant, so it never contributes a tracing `ObservationHandlerGroup`. Result: `gen_ai.client.operation` was recorded as a **metric**, never a span.

## Fix
Register `DefaultTracingObservationHandler(tracer)` directly on the `ObservationRegistry` via a `SmartInitializingSingleton` (bypasses the missing handler group). `ObjectProvider<ObservationRegistry>` defers the lookup to after all singletons exist — injecting the registry directly deadlocks, because Boot wires handler beans into the registry while it's still being created.

`http.*` observations remain suppressed (#963 `ObservationPredicate`), so only `gen_ai.*` / non-HTTP observations are traced — no duplication of the agent's HTTP spans.

## Tests
- `SentryTracingWiringTest` (svc-agent, `sentry.enabled=true`): context boots (no cycle), `tracingObservationHandlerInitializer` present, and a `gen_ai.client.operation` observation flows through the registry without error.
- `SentryOtelConfigTest`: Tracer + predicate beans. `formatKotlin`/`lintKotlin`/`testSmart` green.

## Verify on kauri (post-deploy)
`gen_ai.client.operation` spans under `POST /agent/query` with `gen_ai.usage.*` tokens + model. Then the token baseline.
