### PR TITLE
feat(agent): add LLM token usage to gen_ai spans

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentObservationConfig.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentObservationConfig.kt
@@ -1,0 +1,50 @@
+package com.beancounter.agent
+
+import io.micrometer.common.KeyValue
+import io.micrometer.observation.ObservationFilter
+import org.springframework.ai.chat.observation.ChatModelObservationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Adds LLM token usage to the `gen_ai.client.operation` span.
+ *
+ * Spring AI records token counts only on the `gen_ai.client.token.usage`
+ * **meter** — its observation convention does not put usage on the span, so the
+ * `chat <model>` span carried model/system/finish-reason but no tokens, and
+ * Sentry's AI monitoring (and any cost baseline) had nothing to read. This
+ * [ObservationFilter] runs at observation stop (response present) and copies the
+ * usage onto the context as `gen_ai.*` high-cardinality key-values, which the
+ * tracing observation handler then writes as span attributes.
+ *
+ * Names follow the OpenTelemetry GenAI semantic conventions
+ * (`gen_ai.usage.input_tokens` / `output_tokens`), which Sentry's AI dashboard
+ * keys off.
+ */
+@Configuration
+class AgentObservationConfig {
+    @Bean
+    fun genAiTokenUsageObservationFilter(): ObservationFilter =
+        ObservationFilter { context ->
+            if (context is ChatModelObservationContext) {
+                context.response?.metadata?.usage?.let { usage ->
+                    usage.promptTokens?.let {
+                        context.addHighCardinalityKeyValue(KeyValue.of(INPUT_TOKENS, it.toString()))
+                    }
+                    usage.completionTokens?.let {
+                        context.addHighCardinalityKeyValue(KeyValue.of(OUTPUT_TOKENS, it.toString()))
+                    }
+                    usage.totalTokens?.let {
+                        context.addHighCardinalityKeyValue(KeyValue.of(TOTAL_TOKENS, it.toString()))
+                    }
+                }
+            }
+            context
+        }
+
+    companion object {
+        private const val INPUT_TOKENS = "gen_ai.usage.input_tokens"
+        private const val OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+        private const val TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentObservationConfigTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentObservationConfigTest.kt
@@ -1,0 +1,47 @@
+package com.beancounter.agent
+
+import io.micrometer.common.KeyValue
+import io.micrometer.observation.Observation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.metadata.ChatResponseMetadata
+import org.springframework.ai.chat.metadata.DefaultUsage
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.observation.ChatModelObservationContext
+import org.springframework.ai.chat.prompt.Prompt
+
+class AgentObservationConfigTest {
+    private val filter = AgentObservationConfig().genAiTokenUsageObservationFilter()
+
+    @Test
+    fun `copies token usage from the chat response onto the span`() {
+        val context =
+            ChatModelObservationContext
+                .builder()
+                .prompt(Prompt("hi"))
+                .provider("deepseek")
+                .build()
+        context.setResponse(
+            ChatResponse(
+                listOf(Generation(AssistantMessage("pong"))),
+                ChatResponseMetadata.builder().usage(DefaultUsage(12, 7, 19)).build()
+            )
+        )
+
+        filter.map(context)
+
+        assertThat(context.highCardinalityKeyValues).contains(
+            KeyValue.of("gen_ai.usage.input_tokens", "12"),
+            KeyValue.of("gen_ai.usage.output_tokens", "7"),
+            KeyValue.of("gen_ai.usage.total_tokens", "19")
+        )
+    }
+
+    @Test
+    fun `leaves a non-chat observation untouched`() {
+        val context = Observation.Context()
+        assertThat(filter.map(context)).isSameAs(context)
+    }
+}


### PR DESCRIPTION
Completes the AI-query token outcome. After #965, `gen_ai.client.operation` spans reach Sentry as `chat <model>` with `gen_ai.request.model` / `gen_ai.system` / `gen_ai.response.finish_reasons` — **but no token counts**. Spring AI records usage only on the `gen_ai.client.token.usage` **meter**; its observation convention never puts usage on the span. Verified on kauri: the chat spans had model + finish-reason, `gen_ai.usage.*` empty.

## Fix
An `ObservationFilter` (`AgentObservationConfig`) that runs at observation stop, reads `ChatModelObservationContext.response.metadata.usage`, and adds:
- `gen_ai.usage.input_tokens`
- `gen_ai.usage.output_tokens`
- `gen_ai.usage.total_tokens`

as high-cardinality key-values — the tracing handler (#965) then writes them as span attributes. Names follow OTel GenAI semconv, which Sentry's AI monitoring keys off.

## Tests
- `AgentObservationConfigTest`: builds a `ChatModelObservationContext` with a usage-bearing `ChatResponse`, runs the filter, asserts the three `gen_ai.usage.*` key-values land — **fully verified locally** (no deploy needed). Plus a non-chat passthrough case.
- `formatKotlin`/`lintKotlin`/`testSmart` green.

## Verify on kauri (post-deploy)
`chat <model>` spans now carry `gen_ai.usage.input_tokens`/`output_tokens`/`total_tokens` → AI dashboard + token/cost baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tracking and collection of AI model token consumption metrics across the system.

* **Tests**
  * Added test coverage for token usage tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->