### PR TITLE
perf(telemetry): cut per-request tracing span noise (security + Transaction.commit)

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryOtelConfig.kt
@@ -123,19 +123,28 @@ class SentryOtelConfig {
         }
 
     /**
-     * Suppress Spring's Micrometer HTTP observations so they don't duplicate the
-     * agent's spans once Micrometer tracing is bridged to the agent pipeline.
+     * Suppress low-value Micrometer observations so the bridged tracing handler
+     * only emits spans that add information beyond what the agent already covers.
      *
-     * The agent already instruments HTTP server + client (spans + trace-context
-     * propagation). If the matching Micrometer observations also produced spans we
-     * would get a duplicate `http.server` transaction and duplicate `http.client`
-     * spans — the same double-instrumentation seen in bc-view. `gen_ai.*` and all
-     * non-HTTP observations are unaffected and keep flowing to Sentry.
+     * - `http.server.requests` / `http.client.requests`: the Sentry OTel javaagent
+     *   already instruments HTTP server + client (spans + trace-context
+     *   propagation). Tracing the matching Micrometer observations would dup the
+     *   `http.server` transaction and `http.client` spans (the bc-view double-
+     *   instrumentation).
+     * - `spring.security.*`: the per-request filter-chain / authentication /
+     *   authorization observations add ~5 spans to every request (`secured
+     *   request`, `authenticate bearertoken`, `authorize request`, `security
+     *   filterchain before` / `after`) with no diagnostic value — pure ingest
+     *   noise once Micrometer tracing is on.
+     *
+     * `gen_ai.*` and other observations are unaffected and keep flowing to Sentry.
      */
     @Bean
     fun suppressHttpObservationsHandledByAgent(): ObservationPredicate =
         ObservationPredicate { name, _ ->
-            name != "http.server.requests" && name != "http.client.requests"
+            name != "http.server.requests" &&
+                name != "http.client.requests" &&
+                !name.startsWith("spring.security.")
         }
 
     @PreDestroy

--- a/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryTransactionFilter.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/common/telemetry/SentryTransactionFilter.kt
@@ -50,7 +50,28 @@ class SentryTransactionFilter : SentryOptions.BeforeSendTransactionCallback {
     override fun execute(
         transaction: SentryTransaction,
         hint: Hint
-    ): SentryTransaction? = filterTransaction(transaction)
+    ): SentryTransaction? {
+        val kept = filterTransaction(transaction) ?: return null
+        stripNoisySpans(kept)
+        return kept
+    }
+
+    /**
+     * Drop high-volume, low-value child spans from a kept transaction.
+     *
+     * `Transaction.commit` is emitted by sentry-jdbc on every DB commit (thousands
+     * per day on svc-data) and carries no diagnostic value beyond the query spans
+     * already present. It is a Sentry-SDK span, not a Micrometer observation, so it
+     * cannot be dropped by the observation predicate — strip it here instead.
+     */
+    @Suppress("TooGenericExceptionCaught") // span list may be immutable depending on SDK internals
+    fun stripNoisySpans(transaction: SentryTransaction) {
+        try {
+            transaction.spans.removeIf { it.op in NOISY_SPAN_OPS }
+        } catch (_: Exception) {
+            // Unmodifiable span list — leave as-is rather than fail the send.
+        }
+    }
 
     /**
      * Filters transaction based on HTTP target path or transaction name.
@@ -79,6 +100,10 @@ class SentryTransactionFilter : SentryOptions.BeforeSendTransactionCallback {
     }
 
     private fun shouldFilter(httpTarget: String): Boolean = filterPatterns.any { it.containsMatchIn(httpTarget) }
+
+    private companion object {
+        val NOISY_SPAN_OPS = setOf("Transaction.commit")
+    }
 
     @Suppress("TooGenericExceptionCaught") // Defensive extraction - return null on any error
     private fun extractHttpTarget(transaction: SentryTransaction): String? {

--- a/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryOtelConfigTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryOtelConfigTest.kt
@@ -53,6 +53,14 @@ class SentryOtelConfigTest {
     }
 
     @Test
+    fun `should suppress Spring Security per-request observation noise`() {
+        val predicate: ObservationPredicate = sentryOtelConfig.suppressHttpObservationsHandledByAgent()
+        assertThat(predicate.test("spring.security.filterchains", Observation.Context())).isFalse()
+        assertThat(predicate.test("spring.security.authentications", Observation.Context())).isFalse()
+        assertThat(predicate.test("spring.security.authorizations", Observation.Context())).isFalse()
+    }
+
+    @Test
     fun `should keep gen_ai and other observations flowing to Sentry`() {
         val predicate: ObservationPredicate = sentryOtelConfig.suppressHttpObservationsHandledByAgent()
         assertThat(predicate.test("gen_ai.client.operation", Observation.Context())).isTrue()

--- a/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryTransactionFilterTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/telemetry/SentryTransactionFilterTest.kt
@@ -1,6 +1,7 @@
 package com.beancounter.common.telemetry
 
 import io.sentry.protocol.Contexts
+import io.sentry.protocol.SentrySpan
 import io.sentry.protocol.SentryTransaction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -89,6 +90,28 @@ class SentryTransactionFilterTest {
 
         assertThat(result).isNotNull
         assertThat(result).isSameAs(transaction)
+    }
+
+    @Test
+    fun `should strip Transaction commit child spans but keep the rest`() {
+        val spans =
+            mutableListOf(
+                mockSpan("Transaction.commit"),
+                mockSpan("db"),
+                mockSpan("http.client")
+            )
+        val transaction = createMockTransaction("/api/things")
+        `when`(transaction.spans).thenReturn(spans)
+
+        filter.stripNoisySpans(transaction)
+
+        assertThat(spans.map { it.op }).containsExactly("db", "http.client")
+    }
+
+    private fun mockSpan(op: String): SentrySpan {
+        val span = mock(SentrySpan::class.java)
+        `when`(span.op).thenReturn(op)
+        return span
     }
 
     private fun createMockTransaction(path: String): SentryTransaction {


### PR DESCRIPTION
Reduces Sentry ingest noise introduced once Micrometer tracing was bridged to the agent (#965). The agent already instruments HTTP, so the bridged handler should only add spans that carry new information.

## Removed
1. **`spring.security.*` observations** — ~5 spans on **every request** (`secured request`, `authenticate bearertoken`, `authorize request`, `security filterchain before` / `after`) with no diagnostic value. Dropped via the existing `ObservationPredicate` (`startsWith("spring.security.")`).
2. **`Transaction.commit` child spans** — emitted by sentry-jdbc on every DB commit (~3,400/day on svc-data). It's a Sentry-SDK span, not a Micrometer observation, so the predicate can't reach it — stripped from the transaction's `spans` in `beforeSendTransaction` (`SentryTransactionFilter`).

## Kept
`gen_ai.*`, `http.server`, `http.client`, and `db` query spans — the spans that actually carry info.

## Impact
Measured on a sample `/agent/query`: 12 spans/request, **5 of them Spring Security noise** → ~40% fewer spans per agent request, plus the per-commit DB spans across all DB services. Shared jar-common → applies to every service.

## Tests
- `SentryOtelConfigTest`: predicate drops `spring.security.*`, keeps `gen_ai.*`/http.
- `SentryTransactionFilterTest`: `Transaction.commit` stripped, `db`/`http.client` kept; immutable-list path is defensive.
- `formatKotlin`/`lintKotlin`/`testSmart` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry filtering to suppress Spring Security observation noise in error tracking
  * Improved filtering to remove low-value transaction spans from monitoring data

* **Bug Fixes**
  * Reduced duplicate HTTP observations in telemetry collection

* **Tests**
  * Added tests to validate observation and span filtering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->