### PR TITLE
feat(agent): non-thinking fast path for pre-canned prompts (DeepSeek)

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -13,6 +13,7 @@ import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.metadata.Usage
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -45,6 +46,9 @@ import java.util.concurrent.atomic.AtomicReference
 @Tag(name = "Agent", description = "Natural-language Beancounter assistant")
 class AgentController(
     @Autowired(required = false) private val chatClient: ChatClient?,
+    @Autowired(required = false)
+    @Qualifier("fastChatClient")
+    private val fastChatClient: ChatClient? = null,
     @Autowired(required = false) private val anthropicCacheOptions: AnthropicCacheOptions?,
     private val healthChecker: ServiceHealthChecker,
     private val toolSelector: ToolSelector,
@@ -159,7 +163,7 @@ class AgentController(
             val modelId = chatModelSelector.selectFor(request.context, request.deepThink)
             val startMs = System.currentTimeMillis()
             val promptSpec =
-                chatClient
+                clientFor(request)
                     .prompt()
                     .system(systemPrompt)
                     .user(userMessage)
@@ -341,13 +345,23 @@ class AgentController(
         return tokenEvents.concatWith(doneEvent)
     }
 
+    /**
+     * Pick the LLM client for this request. Pre-canned prompts (the default,
+     * `think=false`) use the non-thinking [fastChatClient] for lowest latency;
+     * the interactive Chat FAB sets `think=true` to keep DeepSeek thinking mode.
+     * Falls back to the thinking client if no fast client is configured.
+     * Callers guard `chatClient != null` first, so the result is non-null.
+     */
+    private fun clientFor(request: AgentQuery): ChatClient =
+        (if (request.think) chatClient else fastChatClient ?: chatClient)!!
+
     private fun buildStreamSpec(
         request: AgentQuery,
         tools: Array<Any>,
         modelId: String
     ): ChatClient.StreamResponseSpec {
         val promptSpec =
-            chatClient!!
+            clientFor(request)
                 .prompt()
                 .system(systemPromptSelector.selectFor(request.context))
                 .user(buildUserMessage(request))
@@ -487,6 +501,13 @@ class AgentController(
 data class AgentQuery(
     val query: String,
     val context: Map<String, Any>? = null,
+    /**
+     * Enable DeepSeek thinking mode for this request. Defaults to `false` so
+     * pre-canned prompts get the fastest (non-thinking) response; the interactive
+     * Chat FAB sets `true`. Orthogonal to [deepThink] (which escalates the model
+     * tier). Routes to the non-thinking `fastChatClient` when `false`.
+     */
+    val think: Boolean = false,
     /**
      * Caller-driven escalation to the deep tier (typically `deepseek-v4-pro`
      * or `claude-opus-*`). Off by default; flips model selection regardless of

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/ChatClientConfiguration.kt
@@ -1,5 +1,7 @@
 package com.beancounter.agent
 
+import com.beancounter.agent.clients.DeepSeekNonThinking
+import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.ai.anthropic.AnthropicCacheOptions
 import org.springframework.ai.anthropic.AnthropicCacheStrategy
@@ -10,12 +12,19 @@ import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.deepseek.DeepSeekChatModel
+import org.springframework.ai.deepseek.DeepSeekChatOptions
+import org.springframework.ai.deepseek.api.DeepSeekApi
+import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.ai.ollama.OllamaChatModel
 import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+import tools.jackson.databind.ObjectMapper
 
 /**
  * Wires a [ChatClient] from whichever [ChatModel] the active Spring profile
@@ -65,6 +74,58 @@ class ChatClientConfiguration {
     fun deepSeekChatClient(chatModel: DeepSeekChatModel): ChatClient {
         log.info("Building DeepSeek ChatClient ({})", chatModel.javaClass.simpleName)
         return build(chatModel)
+    }
+
+    /**
+     * Non-thinking ("fast") DeepSeek ChatClient for pre-canned prompts.
+     *
+     * DeepSeek v4-flash defaults to thinking mode (big latency + reasoning-token
+     * cost). Spring AI 2.0 exposes no option to disable it, so this builds a
+     * second DeepSeek model whose RestClient (sync) + WebClient (streaming) inject
+     * `thinking: {type: disabled}` into the request body — see [DeepSeekNonThinking].
+     * The default [deepSeekChatClient] keeps thinking on for the interactive Chat
+     * FAB; [com.beancounter.agent.AgentController] routes per request via the
+     * `think` flag.
+     */
+    @Bean("fastChatClient")
+    @Profile("deepseek")
+    fun fastDeepSeekChatClient(
+        @Value($$"${spring.ai.deepseek.api-key:}") apiKey: String,
+        @Value($$"${spring.ai.deepseek.base-url:https://api.deepseek.com}") baseUrl: String,
+        @Value($$"${spring.ai.deepseek.chat.options.model:deepseek-v4-flash}") model: String,
+        @Value($$"${spring.ai.deepseek.chat.options.temperature:0.2}") temperature: Double,
+        @Value($$"${spring.ai.deepseek.chat.options.max-tokens:4096}") maxTokens: Int,
+        objectMapper: ObjectMapper,
+        toolCallingManager: ToolCallingManager,
+        observationRegistry: ObservationRegistry
+    ): ChatClient {
+        log.info("Building DeepSeek non-thinking (fast) ChatClient for pre-canned prompts")
+        val fastApi =
+            DeepSeekApi
+                .builder()
+                .apiKey(apiKey)
+                .baseUrl(baseUrl)
+                .restClientBuilder(
+                    RestClient.builder().requestInterceptor(DeepSeekNonThinking.interceptor(objectMapper))
+                ).webClientBuilder(
+                    WebClient.builder().clientConnector(DeepSeekNonThinking.connector(objectMapper))
+                ).build()
+        val options =
+            DeepSeekChatOptions
+                .builder()
+                .model(model)
+                .temperature(temperature)
+                .maxTokens(maxTokens)
+                .build()
+        val fastModel =
+            DeepSeekChatModel
+                .builder()
+                .deepSeekApi(fastApi)
+                .options(options)
+                .toolCallingManager(toolCallingManager)
+                .observationRegistry(observationRegistry)
+                .build()
+        return build(fastModel)
     }
 
     /**

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/clients/DeepSeekNonThinking.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/clients/DeepSeekNonThinking.kt
@@ -1,0 +1,97 @@
+package com.beancounter.agent.clients
+
+import org.reactivestreams.Publisher
+import org.slf4j.LoggerFactory
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+import org.springframework.http.client.reactive.ClientHttpConnector
+import org.springframework.http.client.reactive.ClientHttpRequestDecorator
+import org.springframework.http.client.reactive.JdkClientHttpConnector
+import reactor.core.publisher.Mono
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.ObjectNode
+import java.net.URI
+
+/**
+ * Forces DeepSeek **non-thinking** mode by injecting `"thinking": {"type":
+ * "disabled"}` into the outgoing chat-completion request body.
+ *
+ * DeepSeek v4-flash defaults to thinking mode, which adds large latency and
+ * reasoning-token cost. Spring AI 2.0's `DeepSeekChatOptions` / request record
+ * carry no field for it, so we mutate the serialized JSON body at the HTTP
+ * layer. The mutation is applied to a **dedicated** "fast" DeepSeek client only;
+ * the default (thinking) client is untouched.
+ *
+ * Body mutation is the same for the sync (RestClient) and streaming (WebClient)
+ * transports — see [interceptor] and the WebClient connector that both call
+ * [disableThinking].
+ */
+object DeepSeekNonThinking {
+    private val log = LoggerFactory.getLogger(DeepSeekNonThinking::class.java)
+
+    const val THINKING = "thinking"
+    const val TYPE = "type"
+    const val DISABLED = "disabled"
+
+    /**
+     * Return [body] with `thinking: {type: disabled}` added (or overwritten).
+     * On any parse failure the original body is returned unchanged — never fail
+     * a request over telemetry-shaping.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun disableThinking(
+        body: ByteArray,
+        mapper: ObjectMapper
+    ): ByteArray =
+        try {
+            val root = mapper.readTree(body)
+            if (root is ObjectNode) {
+                root.set(THINKING, mapper.createObjectNode().put(TYPE, DISABLED))
+                mapper.writeValueAsBytes(root)
+            } else {
+                body
+            }
+        } catch (e: Exception) {
+            log.warn("Could not inject non-thinking flag, sending original body: {}", e.message)
+            body
+        }
+
+    /** RestClient interceptor for the sync `/chat/completions` call. */
+    fun interceptor(mapper: ObjectMapper): ClientHttpRequestInterceptor =
+        ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
+            val mutated = disableThinking(body, mapper)
+            if (mutated !== body) {
+                request.headers.contentLength = mutated.size.toLong()
+            }
+            execution.execute(request, mutated)
+        }
+
+    /**
+     * Reactive connector for the streaming `/chat/completions` call (WebClient).
+     * Buffers the outgoing request body, applies [disableThinking], and re-emits
+     * it. Delegates to a stock [JdkClientHttpConnector] (no reactor-netty needed).
+     */
+    fun connector(mapper: ObjectMapper): ClientHttpConnector =
+        ClientHttpConnector { method: HttpMethod, uri: URI, requestCallback ->
+            JdkClientHttpConnector().connect(method, uri) { request ->
+                requestCallback.apply(
+                    object : ClientHttpRequestDecorator(request) {
+                        override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> =
+                            DataBufferUtils.join(body).flatMap { joined ->
+                                val bytes = ByteArray(joined.readableByteCount())
+                                joined.read(bytes)
+                                DataBufferUtils.release(joined)
+                                val mutated = disableThinking(bytes, mapper)
+                                headers.contentLength = mutated.size.toLong()
+                                super.writeWith(Mono.just(bufferFactory().wrap(mutated)))
+                            }
+                    }
+                )
+            }
+        }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -85,6 +85,7 @@ class AgentControllerTest {
     ): AgentController =
         AgentController(
             chatClient,
+            null, // fastChatClient (non-thinking) — routing not exercised by these unit tests
             // anthropicCacheOptions is optional; null is fine — the controller
             // gracefully omits .cacheOptions when the bean isn't present.
             null,
@@ -395,6 +396,7 @@ class AgentControllerTest {
         val ctrl =
             AgentController(
                 null,
+                null, // fastChatClient
                 null,
                 stubChecker(),
                 toolSelector,
@@ -419,6 +421,7 @@ class AgentControllerTest {
         val ctrl =
             AgentController(
                 null,
+                null, // fastChatClient
                 null,
                 stubChecker(),
                 toolSelector,
@@ -475,6 +478,7 @@ class AgentControllerTest {
         val ctrl =
             AgentController(
                 null,
+                null, // fastChatClient
                 null,
                 stubChecker(),
                 toolSelector,

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/FastChatClientWiringTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/FastChatClientWiringTest.kt
@@ -1,0 +1,35 @@
+package com.beancounter.agent
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Boot-safety guard for the non-thinking "fast" DeepSeek client. The fast model
+ * is hand-built (custom DeepSeekApi with the thinking-disabled RestClient/WebClient).
+ * This proves that wiring constructs cleanly alongside the autoconfigured thinking
+ * client — i.e. both `chatClient` and `fastChatClient` beans exist under the
+ * `deepseek` profile. Makes no LLM call.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.ai.deepseek.api-key=dummy-key-for-construction",
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://beancounter.eu.auth0.com/",
+        "auth.audience=https://holdsworth.app"
+    ]
+)
+@ActiveProfiles("deepseek")
+class FastChatClientWiringTest {
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `both thinking and non-thinking DeepSeek clients are wired`() {
+        assertThat(context.containsBean("chatClient")).isTrue()
+        assertThat(context.containsBean("fastChatClient")).isTrue()
+    }
+}

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/clients/DeepSeekNonThinkingTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/clients/DeepSeekNonThinkingTest.kt
@@ -1,0 +1,37 @@
+package com.beancounter.agent.clients
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+
+class DeepSeekNonThinkingTest {
+    private val mapper = JsonMapper.builder().build()
+
+    @Test
+    fun `injects thinking disabled into the request body`() {
+        val body = """{"model":"deepseek-v4-flash","messages":[],"stream":true}""".toByteArray()
+
+        val result = mapper.readTree(DeepSeekNonThinking.disableThinking(body, mapper))
+
+        assertThat(result.get("thinking").get("type").asString()).isEqualTo("disabled")
+        // Original fields preserved.
+        assertThat(result.get("model").asString()).isEqualTo("deepseek-v4-flash")
+        assertThat(result.get("stream").asBoolean()).isTrue()
+    }
+
+    @Test
+    fun `overwrites an existing thinking flag`() {
+        val body = """{"model":"x","thinking":{"type":"enabled"}}""".toByteArray()
+
+        val result = mapper.readTree(DeepSeekNonThinking.disableThinking(body, mapper))
+
+        assertThat(result.get("thinking").get("type").asString()).isEqualTo("disabled")
+    }
+
+    @Test
+    fun `returns the original body unchanged when it is not JSON`() {
+        val body = "not json".toByteArray()
+
+        assertThat(DeepSeekNonThinking.disableThinking(body, mapper)).isEqualTo(body)
+    }
+}


### PR DESCRIPTION
Pre-canned prompts should return as fast as possible; the interactive Chat FAB can keep thinking. DeepSeek v4-flash defaults to **thinking mode** (~8.8s answer calls + reasoning-token cost in the traces). Spring AI 2.0 (`DeepSeekChatOptions`/request record) exposes **no** thinking toggle, so this injects it at the HTTP body layer on a dedicated client.

## How
`DeepSeekNonThinking` mutates the outgoing `/chat/completions` body to add `"thinking":{"type":"disabled"}`:
- **sync** (`/agent/query`) — `ClientHttpRequestInterceptor`.
- **streaming** (`/agent/query/stream`, what the chat uses) — a `ClientHttpConnector` decorator over a stock `JdkClientHttpConnector` that buffers + rewrites the body. Same byte-level helper for both (unit-tested).

`ChatClientConfiguration` builds a second **`fastChatClient`** DeepSeek model using that injection; the default `chatClient` keeps thinking on.

## Routing
`AgentQuery.think` (default **false**) — `AgentController.clientFor()` picks `fastChatClient` (non-thinking) by default; **the Chat FAB sends `think=true`** for thinking mode. Orthogonal to `deepThink` (model tier).

⚠️ **Pairs with a bc-view change**: since the backend now defaults to non-thinking, the FAB must send `think:true` or it loses thinking. (separate PR)

## Tests
- `DeepSeekNonThinkingTest`: body injection (adds/overwrites `thinking`, passthrough on non-JSON).
- `FastChatClientWiringTest`: both `chatClient` + `fastChatClient` boot under the deepseek profile (hand-built model constructs cleanly).
- `formatKotlin`/`lintKotlin`/`testSmart` green.

## Verify on kauri
`think=false` (canned) → no `reasoning_content`, lower latency; `think=true` (FAB) → thinking. I have an AI-scoped token and will verify both paths post-deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a faster, non-thinking chat mode alongside the standard thinking-enabled variant, providing users with flexibility to optimize for response speed when advanced reasoning is not needed or desired.
  * New `think` request parameter enables per-request switching between the standard thinking-enabled mode and the faster variant, operating independently of existing thinking-depth control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->