### PR TITLE
fix(offboard): idempotent bulk trn deletes to prevent StaleStateException

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -45,9 +45,30 @@ interface TrnRepository :
         status: TrnStatus
     ): Collection<Trn>
 
-    fun deleteByPortfolioId(portfolioId: String): Long
+    /**
+     * Bulk delete of a portfolio's transactions. Issued as a single SQL
+     * DELETE (not a select-then-remove) so it is idempotent: if the rows are
+     * already gone — e.g. removed by the legacy `ON DELETE CASCADE` on
+     * `trn.portfolio_id` when the portfolio itself is deleted — it simply
+     * affects 0 rows instead of raising StaleStateException. See offboarding
+     * (Sentry DATA-5P / DATA-5Q).
+     */
+    @Modifying
+    @Query("DELETE FROM Trn t WHERE t.portfolio.id = :portfolioId")
+    fun deleteByPortfolioId(
+        @Param("portfolioId") portfolioId: String
+    ): Long
 
-    fun deleteByAssetId(assetId: String): Long
+    /**
+     * Bulk delete of every transaction whose trade asset is [assetId].
+     * Idempotent for the same reason as [deleteByPortfolioId]; cash-asset
+     * references (a different column) are untouched — see [existsByCashAssetId].
+     */
+    @Modifying
+    @Query("DELETE FROM Trn t WHERE t.asset.id = :assetId")
+    fun deleteByAssetId(
+        @Param("assetId") assetId: String
+    ): Long
 
     /**
      * True if any transaction holds the asset as its trade asset.

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
@@ -6,6 +6,8 @@ import com.beancounter.common.contracts.AssetRequest
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.PortfolioInput
 import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.SpringMvcDbTest
@@ -13,9 +15,11 @@ import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.tax.TaxRateRequest
 import com.beancounter.marketdata.tax.TaxRateService
+import com.beancounter.marketdata.trn.TrnRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.math.BigDecimal
@@ -39,6 +43,12 @@ class OffboardingServiceTest {
 
     @Autowired
     private lateinit var taxRateService: TaxRateService
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
 
     @Autowired
     private lateinit var mockAuthConfig: MockAuthConfig
@@ -220,6 +230,94 @@ class OffboardingServiceTest {
         assertThat(result.success).isTrue()
         assertThat(result.type).isEqualTo("account")
         assertThat(result.message).isEqualTo("Account and all data deleted")
+    }
+
+    // Regression guard for Sentry DATA-5P / DATA-5Q. Offboarding deletes a
+    // portfolio's transactions and then the portfolio itself; production
+    // Postgres carries a legacy `ON DELETE CASCADE` on `trn.portfolio_id`
+    // (not declared on the entity and never rewritten by `ddl-auto: update`),
+    // so the portfolio delete cascade-removed the trn rows out from under the
+    // explicit per-row delete -> StaleStateException. The fix makes the trn
+    // deletes idempotent bulk operations. These tests install the same cascade
+    // FK on the H2 schema and assert offboarding completes for a user whose
+    // transaction references both a user-owned asset and their portfolio.
+    private fun installPortfolioCascade() {
+        val existing =
+            jdbcTemplate.queryForList(
+                "SELECT constraint_name FROM information_schema.key_column_usage " +
+                    "WHERE table_name = 'trn' AND column_name = 'portfolio_id'",
+                String::class.java
+            )
+        if (existing.contains("fk_trn_pf_cascade")) return
+        existing.forEach { jdbcTemplate.execute("ALTER TABLE \"trn\" DROP CONSTRAINT \"$it\"") }
+        jdbcTemplate.execute(
+            "ALTER TABLE \"trn\" ADD CONSTRAINT \"fk_trn_pf_cascade\" " +
+                "FOREIGN KEY (\"portfolio_id\") REFERENCES \"portfolio\"(\"id\") ON DELETE CASCADE"
+        )
+    }
+
+    private fun seedWealthWithOverlappingTrn(user: SystemUser) {
+        installPortfolioCascade()
+        val portfolios =
+            portfolioService.save(
+                listOf(
+                    PortfolioInput(
+                        code = "OFFBOARD-OVERLAP",
+                        name = "Overlap Portfolio",
+                        currency = NZD.code
+                    )
+                )
+            )
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "test" to
+                                AssetInput.toRealEstate(
+                                    currency = NZD,
+                                    code = "OFFBOARD-OVERLAP-HOUSE",
+                                    name = "Overlap House",
+                                    owner = user.id
+                                )
+                        )
+                    )
+                ).data["test"]!!
+
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.BUY,
+                asset = asset,
+                quantity = BigDecimal("1"),
+                portfolio = portfolios.first()
+            )
+        )
+    }
+
+    @Test
+    fun `should delete wealth when a transaction links a user-owned asset and portfolio`() {
+        val user = SystemUser(id = "offboard-overlap-wealth", email = "offboard-overlap-wealth@test.com")
+        mockAuthConfig.login(user, systemUserService)
+        seedWealthWithOverlappingTrn(user)
+
+        val result = offboardingService.deleteUserWealth()
+
+        assertThat(result.success).isTrue()
+        val summary = offboardingService.getSummary()
+        assertThat(summary.portfolioCount).isEqualTo(0)
+        assertThat(summary.assetCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `should delete account when a transaction links a user-owned asset and portfolio`() {
+        val user = SystemUser(id = "offboard-overlap-account", email = "offboard-overlap-account@test.com")
+        mockAuthConfig.login(user, systemUserService)
+        seedWealthWithOverlappingTrn(user)
+
+        val result = offboardingService.deleteUserAccount()
+
+        assertThat(result.success).isTrue()
+        assertThat(result.type).isEqualTo("account")
     }
 
     @Test


### PR DESCRIPTION
## Problem

Offboarding (`DELETE /offboard/wealth`, `/offboard/account`) returns 500 → bc-view "Oops!". Sentry **DATA-5P / DATA-5Q**:

```
StaleStateException: Unexpected row count (expected row count 1 but was 0)
  [delete from "trn" where "id"=?]  — OffboardingService.deleteUserWealth
```

## Root cause

Production Postgres carries a legacy `ON DELETE CASCADE` on `trn.portfolio_id` (not declared on the entity; never rewritten by `ddl-auto: update`). `OffboardingService` deletes a portfolio's transactions and then the portfolio; the portfolio delete cascade-removes the trn rows, so the per-row managed delete that Hibernate still has queued hits 0 rows → `StaleStateException`. Only users with transactions on user-owned assets hit it (global market assets don't overlap), which is why it surfaced late.

## Fix

`deleteByPortfolioId` / `deleteByAssetId` → bulk `@Modifying @Query` deletes. A single SQL DELETE has no per-row count check, so it is idempotent and immune to the cascade/flush-ordering race. Covers `deleteUserWealth`, `deleteUserAccount`, `deleteUserAssets`, `deleteUserPortfolios`, plus `PortfolioService.delete` and `TrnService.purge` (same latent path).

## Tests

Two integration tests install the prod cascade FK on the H2 schema and assert offboarding completes for a user whose transaction links a user-owned asset and their portfolio.

Note: the exact StaleState is Postgres delete-ordering specific and does not reproduce pre-fix under H2 (deletes flush child-first there), so the tests are guards rather than a strict red→green; the authoritative repro is the live Sentry trace.

Verified: `:svc-data:test` green · `formatKotlin` · `lintKotlin` clean.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)