### PR TITLE
fix(position): accrue ADD sub-accounts onto composite position

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BuyBehaviour.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/accumulation/BuyBehaviour.kt
@@ -41,6 +41,18 @@ class BuyBehaviour(
             updatePurchases(moneyValues, trn.tradeAmount, rate, position)
         }
 
+        // ADD maps to BuyBehaviour (see TrnBehaviourFactory). A composite ADD —
+        // e.g. a CPF payslip contribution — carries a sub-account split that
+        // must accrue onto the position breakdown, otherwise the rolled-up
+        // total grows but the per-bucket balances (and the Medisave healthcare
+        // reserve) drift. Mirrors DepositBehaviour. No-op for a plain BUY.
+        if (!trn.subAccounts.isNullOrEmpty()) {
+            trn.subAccounts!!.forEach { (code, amount) ->
+                position.subAccounts[code] =
+                    (position.subAccounts[code] ?: BigDecimal.ZERO).add(amount)
+            }
+        }
+
         return position
     }
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/accumulation/BalanceBehaviourTest.kt
@@ -301,4 +301,76 @@ class BalanceBehaviourTest {
 
         assertThat(position.subAccounts).containsExactlyInAnyOrderEntriesOf(subAccounts)
     }
+
+    @Test
+    fun `composite ADD accrues sub-account balances onto the BALANCE snapshot`() {
+        // A CPF payslip contribution posts as an ADD carrying its own per-bucket
+        // split. ADD maps to BuyBehaviour, which must accrue that split onto the
+        // existing sub-account balances — not only the rolled-up total —
+        // otherwise the Medisave healthcare reserve under-reports.
+        val portfolio =
+            Portfolio(
+                Constants.TEST,
+                currency = SGD,
+                base = SGD
+            )
+        val cpfAsset =
+            Asset(
+                code = RUBY_CPF,
+                id = RUBY_CPF,
+                name = "Ruby CPF",
+                market = Market("PRIVATE"),
+                priceSymbol = RUBY_CPF,
+                category = AssetCategory.POLICY
+            )
+        val positions = Positions(portfolio)
+        accumulator.accumulate(
+            Trn(
+                trnType = TrnType.BALANCE,
+                asset = cpfAsset,
+                quantity = BigDecimal("68000"),
+                tradeAmount = BigDecimal("68000"),
+                cashCurrency = SGD,
+                tradeCurrency = SGD,
+                tradeCashRate = BigDecimal.ONE,
+                tradeBaseRate = BigDecimal.ONE,
+                tradePortfolioRate = BigDecimal.ONE,
+                portfolio = portfolio,
+                subAccounts =
+                    mapOf(
+                        "OA" to BigDecimal("30000"),
+                        "SA" to BigDecimal("20000"),
+                        "MA" to BigDecimal("18000")
+                    )
+            ),
+            positions
+        )
+        val position =
+            accumulator.accumulate(
+                Trn(
+                    trnType = TrnType.ADD,
+                    asset = cpfAsset,
+                    quantity = BigDecimal("2312.50"),
+                    tradeAmount = BigDecimal("2312.50"),
+                    cashCurrency = SGD,
+                    tradeCurrency = SGD,
+                    tradeCashRate = BigDecimal.ONE,
+                    tradeBaseRate = BigDecimal.ONE,
+                    tradePortfolioRate = BigDecimal.ONE,
+                    portfolio = portfolio,
+                    subAccounts =
+                        mapOf(
+                            "OA" to BigDecimal("1312.81"),
+                            "SA" to BigDecimal("437.29"),
+                            "MA" to BigDecimal("562.40")
+                        )
+                ),
+                positions
+            )
+
+        assertThat(position.subAccounts)
+            .containsEntry("OA", BigDecimal("31312.81"))
+            .containsEntry("SA", BigDecimal("20437.29"))
+            .containsEntry("MA", BigDecimal("18562.40"))
+    }
 }


### PR DESCRIPTION
## Problem
A CPF payslip contribution posts as an `ADD` leg carrying a sub-account split (OA/SA/MA). `ADD` maps to `BuyBehaviour`, which accrued the rolled-up total but **ignored `trn.subAccounts`**. So the CPF position total grew while the per-bucket balances stayed at the BALANCE snapshot — the **Medisave healthcare reserve under-reported**, and the difference leaked into spendable Net Worth.

Verified live: one payslip → position total 70,312.5 (= 68,000 + 2,312.50) but `subAccounts.MA` stuck at 18,000 (should be 18,562.40).

## Fix
`BuyBehaviour` now merges `trn.subAccounts` onto `position.subAccounts` (mirrors `DepositBehaviour`). No-op for a plain BUY (null sub-accounts). Completes #914 (which accrued the ADD total but not the split).

## Test
`BalanceBehaviourTest` — BALANCE-then-ADD asserts per-bucket accrual (OA 31,312.81 / SA 20,437.29 / MA 18,562.40). svc-position test + formatKotlin + lintKotlin green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction accumulation to properly handle sub-account balances, ensuring split transactions correctly add to existing per-account balances instead of replacing them.

* **Tests**
  * Added regression test verifying that composite ADD transactions with multiple sub-accounts correctly accrue balances onto existing position snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->