### PR TITLE
chore(renovate): minimumReleaseAge gate + action bump

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v43.0.14
+        uses: renovatebot/github-action@v46.1.15
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
         "monowai"
     ],
     "configMigration": true,
+    "minimumReleaseAge": "7 days",
     "packageRules": [
         {
             "description": "Auto-merge patch updates for non-major dependencies",
@@ -27,6 +28,7 @@
             ],
             "automerge": true,
             "automergeType": "pr",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "!org.springframework.boot",
                 "!org.springframework.cloud",
@@ -37,6 +39,7 @@
         {
             "description": "Group Spring Boot packages together",
             "groupName": "Spring Boot",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/^org\\.springframework\\.boot/",
                 "/^org\\.springframework\\./"
@@ -45,6 +48,7 @@
         {
             "description": "Group Spring Cloud packages together",
             "groupName": "Spring Cloud",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/^org\\.springframework\\.cloud/"
             ]
@@ -52,6 +56,7 @@
         {
             "description": "Group Kotlin packages together",
             "groupName": "Kotlin",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/^org\\.jetbrains\\.kotlin/",
                 "/^org\\.jetbrains\\.kotlinx/"
@@ -60,6 +65,7 @@
         {
             "description": "Group testing packages together",
             "groupName": "testing packages",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/junit/",
                 "/mockito/",
@@ -71,6 +77,7 @@
         {
             "description": "Group OpenTelemetry packages together",
             "groupName": "OpenTelemetry packages",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/^io\\.opentelemetry/"
             ]
@@ -78,6 +85,7 @@
         {
             "description": "Group Google Cloud packages together",
             "groupName": "Google Cloud",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "/^com\\.google\\.cloud/",
                 "/^com\\.google\\.api/"
@@ -85,6 +93,7 @@
         },
         {
             "description": "Separate major updates for critical packages",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "org.springframework.boot",
                 "org.springframework.cloud",
@@ -105,10 +114,12 @@
                 "minor",
                 "patch"
             ],
+            "minimumReleaseAge": "7 days",
             "automerge": true
         },
         {
             "description": "Ignore specific problematic versions from Dependabot config",
+            "minimumReleaseAge": "7 days",
             "matchPackageNames": [
                 "com.google.apis:google-api-services-sheets",
                 "com.google.api-client:google-api-client",


### PR DESCRIPTION
Hardens Renovate to match the gate now applied to svc-retire / svc-rebalance.

## Changes
- **`minimumReleaseAge: "7 days"`** (global + per packageRule) — Renovate won't propose a freshly-published version until it's aged 7 days. Supply-chain protection against malicious/yanked releases, important given automerge is enabled. Flagged by semgrep (`renovate-missing-minimum-release-age`).
- **`renovatebot/github-action` `v43.0.14` → `v46.1.15`** (latest).

No change to grouping, automerge targets, or schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate dependency management tool to a newer version for improved automation and reliability.
  * Enhanced dependency update safety by enforcing a 7-day minimum release age before auto-merging updates across all configuration scopes, reducing risk from untested releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->