### PR TITLE
fix(auth): resilient JWKS — don't crash startup when Auth0 unreachable

### DIFF
--- a/jar-auth/src/main/kotlin/com/beancounter/auth/OAuthConfig.kt
+++ b/jar-auth/src/main/kotlin/com/beancounter/auth/OAuthConfig.kt
@@ -108,7 +108,13 @@ class OAuthConfig {
                 }
             }
         } catch (ex: KeySourceException) {
-            throw IllegalStateException("Failed to retrieve JWK keys", ex)
+            // Auth0 unreachable during startup must NOT crash the context: enumerating
+            // algorithms is an optimisation, not a hard requirement. Fall back to the
+            // standard RSA/EC families; the keys themselves are still fetched lazily
+            // (retrying + caching jwkSource) when the first token is validated.
+            log.warn("JWKS unavailable at startup, defaulting to RSA/EC algorithms: {}", ex.message)
+            algorithms.addAll(JWSAlgorithm.Family.RSA)
+            algorithms.addAll(JWSAlgorithm.Family.EC)
         }
         check(algorithms.isNotEmpty()) { "Failed to find any algorithms from the JWK set" }
         return algorithms

--- a/jar-auth/src/test/kotlin/com/beancounter/auth/OAuthConfigTest.kt
+++ b/jar-auth/src/test/kotlin/com/beancounter/auth/OAuthConfigTest.kt
@@ -160,4 +160,17 @@ class OAuthConfigTest {
         val decoder = OAuthConfig().jwtDecoder(authConfig)
         assertThat(decoder).isNotNull
     }
+
+    @Test
+    fun `should build decoder when JWKS unreachable at startup`() {
+        // Auth0 down during boot must not crash the context: the decoder still
+        // builds (falling back to RSA/EC), keys are fetched lazily on first token.
+        WireMock.stubFor(
+            WireMock
+                .get("/.well-known/jwks.json")
+                .willReturn(WireMock.aResponse().withStatus(503))
+        )
+        val decoder = OAuthConfig().jwtDecoder(authConfig)
+        assertThat(decoder).isNotNull
+    }
 }


### PR DESCRIPTION
## Problem
`OAuthConfig.jwtDecoder` eagerly fetches the Auth0 JWKS at bean-creation (`getJwsAlgorithms` → `jwkSource[...]`) to enumerate JWS algorithms. If Auth0 isn't reachable during the pod's startup window, it throws `IllegalStateException("Failed to retrieve JWK keys")`, the bean fails, the context fails, and the pod **CrashLoopBackOffs**.

Surfaced when svc-rebalance was rebuilt for Spring Boot 4 and picked up the current `jar-auth` (the eager fetch predates Boot 4). bc-data — on older jar-auth — was unaffected.

## Fix
On `KeySourceException`, fall back to the standard RSA/EC algorithm families instead of throwing. Algorithm enumeration is an optimisation, not a hard requirement — the keys themselves are still fetched **lazily** via the retrying + caching `jwkSource` on the first token validation. Startup no longer hard-depends on Auth0 reachability.

## Test
- New `should build decoder when JWKS unreachable at startup` — stubs JWKS → 503, asserts the decoder still builds (no throw).
- Existing success-path test unchanged. jar-auth: test + format + lint green.

## Rollout
Affects every service via `jar-auth`. On merge, CI republishes `jar-auth` SNAPSHOT; rebuild/redeploy svc-rebalance (and others) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup resilience by gracefully handling JWT key retrieval failures, allowing the app to continue running with fallback authentication algorithms instead of failing.

* **Tests**
  * Added test coverage for JWT decoder initialization when the key service is temporarily unavailable during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->