### PR TITLE
fix(position): anchor IRR opening investment to cost basis for BALANCE-funded positions

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
@@ -237,6 +237,7 @@ class PositionValuationService(
         moneyValuesGroup: MoneyValuesGroup
     ) {
         val roi = calculationSupport.calculateRoi(moneyValuesGroup.tradeMoneyValues)
+        anchorOpeningCostBasis(positionContext.position, moneyValuesGroup.tradeMoneyValues)
         positionContext.position.periodicCashFlows.add(positionContext.position, positionContext.asAtDate)
         positionContext.positions.periodicCashFlows.addAll(positionContext.position.periodicCashFlows.cashFlows)
 
@@ -245,6 +246,42 @@ class PositionValuationService(
         calculationSupport.updateTotals(totalsGroup.tradeTotals, moneyValuesGroup.tradeMoneyValues, roi, irr)
         calculationSupport.updateTotals(totalsGroup.baseTotals, moneyValuesGroup.baseMoneyValues, roi, irr)
         calculationSupport.updateTotals(totalsGroup.refTotals, moneyValuesGroup.portfolioMoneyValues, roi, irr)
+    }
+
+    /**
+     * Anchor the IRR investment to the position's cost basis.
+     *
+     * A `BALANCE` snapshot (CPF, pensions) records its opening principal as a
+     * cost-basis entry, NOT a cash transaction — so it is absent from the IRR
+     * cash flows, while the terminal market value (added next) DOES include it.
+     * That asymmetry makes the opening principal look like pure return (e.g. a
+     * property-less CPF balance reporting a 3805% IRR). Cost basis is tracked
+     * correctly (snapshot-aware) by BalanceBehaviour, so when the recorded
+     * investment (sum of negative cash flows) falls short of it, prepend the
+     * shortfall as an opening investment cash flow at the holding's open date.
+     * For ordinary traded positions the cash flows already equal cost basis, so
+     * the shortfall is ~0 and this is a no-op.
+     */
+    private fun anchorOpeningCostBasis(
+        position: com.beancounter.common.model.Position,
+        tradeMoneyValues: com.beancounter.common.model.MoneyValues
+    ) {
+        val costBasis = tradeMoneyValues.costValue.toDouble()
+        if (costBasis <= 0.0) return
+        val recordedInvestment =
+            position.periodicCashFlows.cashFlows
+                .filter { it.amount < 0.0 }
+                .sumOf { -it.amount }
+        val shortfall = costBasis - recordedInvestment
+        if (shortfall > 0.01) {
+            position.periodicCashFlows.cashFlows.add(
+                0,
+                com.beancounter.common.model.CashFlow(
+                    -shortfall,
+                    position.dateValues.opened ?: position.dateValues.firstTransaction ?: return
+                )
+            )
+        }
     }
 
     /**

--- a/svc-position/src/test/kotlin/com/beancounter/position/irr/IrrCalculatorTests.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/irr/IrrCalculatorTests.kt
@@ -37,6 +37,54 @@ class IrrCalculatorTests {
     private val dateUtils = DateUtils()
 
     @Test
+    fun `opening cost basis must be present or terminal value reads as pure return`() {
+        // Mary's SGD portfolio CPF (Retirement Fund) position, on kauri:
+        //   BALANCE 88,000 (06-22)  -> excluded from cashflows (shouldAddToCashFlows drops BALANCE)
+        //   ADD     2,312.5 (06-22) -> cashflow -2312.5 (cash=0 => -tradeAmount)
+        //   terminal market value   -> +90,312.5 (06-24), which INCLUDES the 88,000 balance
+        // The 88,000 opening balance shows up as pure return with no matching
+        // investment -> simpleRoi = (90312.5 - 2312.5)/2312.5 = 38.054054 (3805%).
+        val polluted = PeriodicCashFlows()
+        polluted.addAll(
+            listOf(
+                com.beancounter.common.model
+                    .CashFlow(-2312.5, java.time.LocalDate.of(2026, 6, 22)),
+                com.beancounter.common.model
+                    .CashFlow(90312.5, java.time.LocalDate.of(2026, 6, 24))
+            )
+        )
+        assertThat(irrService.calculate(polluted))
+            .`as`("reproduces the live 3805% bug")
+            .isEqualTo(
+                38.054054,
+                org.assertj.core.api.Assertions
+                    .within(0.0001)
+            )
+
+        // If the opening BALANCE is counted as the cost basis (-88,000), the
+        // position's IRR collapses to ~0 — the expected money-weighted return
+        // for a balance-funded holding with no real gain.
+        val corrected = PeriodicCashFlows()
+        corrected.addAll(
+            listOf(
+                com.beancounter.common.model
+                    .CashFlow(-88000.0, java.time.LocalDate.of(2026, 6, 22)),
+                com.beancounter.common.model
+                    .CashFlow(-2312.5, java.time.LocalDate.of(2026, 6, 22)),
+                com.beancounter.common.model
+                    .CashFlow(90312.5, java.time.LocalDate.of(2026, 6, 24))
+            )
+        )
+        assertThat(irrService.calculate(corrected))
+            .`as`("opening balance as cost basis -> IRR ~ 0")
+            .isEqualTo(
+                0.0,
+                org.assertj.core.api.Assertions
+                    .within(0.0005)
+            )
+    }
+
+    @Test
     fun `should handle empty cash flows without failing`() {
         // Given empty cash flows
         val cashFlows = listOf<Pair<String, Double>>()

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
@@ -193,6 +193,56 @@ class PositionValuationServiceTest {
     }
 
     @Test
+    fun `BALANCE-established position anchors IRR opening investment to cost basis`() {
+        // Mary's CPF (Retirement Fund, non-cash): opening BALANCE 88,000 sets
+        // cost basis but is NOT a cash flow, while the terminal market value
+        // includes it -> the principal looked like pure return (3805% IRR).
+        // The valuation must prepend the cost-basis shortfall as an opening
+        // investment cash flow. Cost basis 90,312.5, recorded ADD -2,312.5 ->
+        // expected anchor -88,000.
+        whenever(tokenService.bearerToken).thenReturn("Token Value")
+        val asset = TestHelpers.createTestAsset("CPF_LIKE", US.code)
+        val assetInputs = setOf(TestHelpers.createTestAssetInput(US.code, asset.code))
+        val position = TestHelpers.createTestPosition(asset, portfolio)
+        position.dateValues.opened = LocalDate.now().minusDays(400)
+        position.quantityValues.purchased = BigDecimal.TEN
+        // Only the small contribution was recorded as a cash flow; the 88,000
+        // opening balance is missing (BALANCE is excluded from cash flows).
+        position.periodicCashFlows.cashFlows.add(
+            com.beancounter.common.model
+                .CashFlow(-2312.5, LocalDate.now().minusDays(400))
+        )
+        val positions = TestHelpers.createTestPositions(portfolio, listOf(position))
+
+        whenever(fxUtils.buildRequest(any(), any())).thenReturn(FxRequest())
+        whenever(priceService.getPrices(any(), any())).thenReturn(
+            PriceResponse(listOf(TestHelpers.createTestMarketData(asset)))
+        )
+        whenever(fxRateService.getRates(any(), any())).thenReturn(FxResponse())
+
+        val mockMoneyValues = MoneyValues(portfolio.currency)
+        mockMoneyValues.costValue = BigDecimal("90312.5")
+        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+            .thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateRoi(any())).thenReturn(BigDecimal("0.38"))
+        whenever(irrCalculator.calculate(any())).thenReturn(0.0)
+
+        valuationService.value(positions, assetInputs)
+
+        val captor = org.mockito.kotlin.argumentCaptor<com.beancounter.common.model.PeriodicCashFlows>()
+        verify(irrCalculator, org.mockito.kotlin.atLeastOnce()).calculate(captor.capture())
+        val anchored =
+            captor.allValues.any { pcf ->
+                pcf.cashFlows.any { kotlin.math.abs(it.amount - (-88000.0)) < 0.01 }
+            }
+        assertThat(anchored)
+            .`as`("opening cost-basis shortfall (-88000) prepended as investment cash flow")
+            .isTrue()
+    }
+
+    @Test
     fun `should use IRR calculator for positions held longer than minHoldingDays`() {
         // Given - position opened 400 days ago (more than 365 day threshold)
         whenever(tokenService.bearerToken).thenReturn("Token Value")


### PR DESCRIPTION
## Problem
Mary's SGD portfolio reported **IRR 3805.41%** (expected ~0). Live data showed every per-position IRR was 0, but the **portfolio aggregate** was 38.05.

## Root cause
- The 4 bank accounts are **Cash-category** → already excluded from the IRR aggregate (`processCashPosition` never touches `periodicCashFlows`). Not the cause.
- **CPF** (Retirement Fund, non-cash) is the polluter. Its opening **`BALANCE` (88,000)** records cost basis but is **excluded** from IRR cash flows (`Accumulator.shouldAddToCashFlows` drops BALANCE — "no cash movement"), while the **terminal market value (+90,312.5) includes it**. The opening principal thus reads as pure return:
  `simpleRoi = (90312.5 − 2312.5) / 2312.5 = 38.054054`.
- `BalanceBehaviour` already fixes this for cost-based ROI (pins cost = market on first snapshot); the cash-flow-based IRR didn't use that cost basis.

## Fix
In `PositionValuationService.processNonCashPosition`, anchor the IRR investment to cost basis: when recorded negative cash flows fall short of the position's cost basis (the BALANCE principal gap), prepend the shortfall as an opening investment cash flow at the holding's open date. Cost basis is already tracked snapshot-aware by `BalanceBehaviour`, so this is robust to multiple BALANCE re-statements and a **no-op for ordinary traded positions** (cash flows already equal cost basis).

## Tests
- `IrrCalculatorTests`: cash flows missing the opening cost → 38.054054 (reproduces live); with opening cost basis → ~0.
- `PositionValuationServiceTest`: BALANCE-funded position (cost 90,312.5, recorded −2,312.5) → the −88,000 cost-basis shortfall is prepended as an opening investment cash flow.
- Full svc-position suite + format + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced calculation accuracy for investment returns on non-cash positions by ensuring recorded cost basis is properly reflected in return metrics. The system now automatically adjusts for any investment shortfalls to align calculations with actual recorded amounts.

* **Tests**
  * Added comprehensive test coverage for investment return calculations and cost basis validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->