### PR TITLE
fix(agent): retry transient connect failures in streaming chat path

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -25,8 +25,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.HtmlUtils
 import reactor.core.publisher.Flux
+import reactor.util.retry.Retry
 import tools.jackson.databind.ObjectMapper
+import java.net.ConnectException
+import java.nio.channels.UnresolvedAddressException
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -63,6 +67,14 @@ class AgentController(
     private val clock: Clock = Clock.systemUTC()
 ) {
     private val log = LoggerFactory.getLogger(AgentController::class.java)
+
+    private companion object {
+        // Two retries with exponential backoff (+jitter) cover the common
+        // sub-second connectivity blip without holding the request open long
+        // enough to outlast a real outage — that surfaces as the error envelope.
+        const val STREAM_RETRY_ATTEMPTS = 2L
+        val STREAM_RETRY_MIN_BACKOFF: Duration = Duration.ofMillis(250)
+    }
 
     /**
      * Anthropic-only feature: the per-call model override uses
@@ -342,7 +354,37 @@ class AgentController(
                     requestSpan = requestSpan
                 )
             }
-        return tokenEvents.concatWith(doneEvent)
+        // Transient connectivity blips (e.g. a sub-second DNS failure resolving
+        // api.deepseek.com) surface as WebClientRequestException at connect time
+        // — before any token is emitted. Retry those rather than failing the
+        // user's request. The `totalChars == 0` guard makes retries safe: once
+        // content has streamed to the client, re-running would duplicate it, so
+        // a later drop is allowed to propagate to the error envelope.
+        val retriedTokens =
+            tokenEvents.retryWhen(
+                Retry
+                    .backoff(STREAM_RETRY_ATTEMPTS, STREAM_RETRY_MIN_BACKOFF)
+                    .filter { e -> totalChars.get() == 0L && isTransientConnectivity(e) }
+                    // Surface the original cause, not Reactor's RetryExhausted
+                    // wrapper, so classifyError still maps it accurately.
+                    .onRetryExhaustedThrow { _, signal -> signal.failure() }
+            )
+        return retriedTokens.concatWith(doneEvent)
+    }
+
+    /**
+     * True when the failure is a transient network/connectivity error worth
+     * retrying — a connection or DNS-resolution failure anywhere in the cause
+     * chain. Deterministic provider errors (4xx, rate limits) are excluded so
+     * we don't retry the inevitable.
+     */
+    internal fun isTransientConnectivity(error: Throwable): Boolean {
+        var cause: Throwable? = error
+        while (cause != null) {
+            if (cause is ConnectException || cause is UnresolvedAddressException) return true
+            cause = cause.cause
+        }
+        return false
     }
 
     /**

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -35,6 +35,23 @@ private const val OPAQUE_ERROR = "agent-error"
 private fun textResponse(chunk: String): ChatResponse = ChatResponse(listOf(Generation(AssistantMessage(chunk))))
 
 /**
+ * Reproduce the production transient-DNS failure shape: a Spring
+ * [org.springframework.web.reactive.function.client.WebClientRequestException]
+ * whose cause chain ends in [java.nio.channels.UnresolvedAddressException] —
+ * exactly what bc-agent logged when api.deepseek.com briefly failed to resolve.
+ */
+private fun transientConnectError(): Throwable {
+    val dns = java.nio.channels.UnresolvedAddressException()
+    val connect = java.net.ConnectException("Connection failed").apply { initCause(dns) }
+    return org.springframework.web.reactive.function.client.WebClientRequestException(
+        connect,
+        org.springframework.http.HttpMethod.POST,
+        java.net.URI.create("https://api.deepseek.com/chat/completions"),
+        org.springframework.http.HttpHeaders()
+    )
+}
+
+/**
  * Unit tests for [AgentController]. The agent's actual behaviour is provided by
  * Spring AI tool calling, which is exercised end-to-end against a real LLM —
  * not in a unit test. Here we only check the controller's contract: health
@@ -388,6 +405,113 @@ class AgentControllerTest {
         assertThat(last.event()).isEqualTo(EVENT_ERROR)
         assertThat(last.data()).isEqualTo(OPAQUE_ERROR)
         assertThat(last.data()).doesNotContain("boom")
+    }
+
+    @Test
+    fun `stream retries a transient connect failure then emits the recovered tokens`() {
+        // The DeepSeek WebClient occasionally fails to resolve api.deepseek.com
+        // (UnresolvedAddressException) for a sub-second DNS blip. Such a failure
+        // happens at connection time — before any token is emitted — so the
+        // stream must retry rather than surface a user-facing error.
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        val attempts =
+            java.util.concurrent.atomic
+                .AtomicInteger(0)
+        whenever(streamResponse.chatResponse())
+            .thenReturn(
+                Flux.defer {
+                    if (attempts.getAndIncrement() == 0) {
+                        Flux.error(transientConnectError())
+                    } else {
+                        Flux.just(textResponse("recovered"))
+                    }
+                }
+            )
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(attempts.get()).isEqualTo(2)
+        assertThat(events.map { it.event() }).containsExactly(EVENT_TOKEN, EVENT_DONE)
+        assertThat(events[0].data()).isEqualTo("recovered")
+    }
+
+    @Test
+    fun `stream does not retry a non-transient error`() {
+        // A provider-side 4xx is deterministic — retrying only delays the
+        // inevitable error envelope and wastes provider quota.
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        val attempts =
+            java.util.concurrent.atomic
+                .AtomicInteger(0)
+        whenever(streamResponse.chatResponse())
+            .thenReturn(
+                Flux.defer {
+                    attempts.getAndIncrement()
+                    Flux.error<ChatResponse>(RuntimeException("HTTP 400 invalid_request"))
+                }
+            )
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(attempts.get()).isEqualTo(1)
+        assertThat(events).hasSize(1)
+        assertThat(events[0].event()).isEqualTo(EVENT_ERROR)
+    }
+
+    @Test
+    fun `stream does not retry a transient failure once tokens have been emitted`() {
+        // Retrying after content has already streamed to the client would
+        // duplicate the emitted tokens. Once the first token is out, a later
+        // connectivity drop must surface as an error, not a silent re-run.
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        val attempts =
+            java.util.concurrent.atomic
+                .AtomicInteger(0)
+        whenever(streamResponse.chatResponse())
+            .thenReturn(
+                Flux.defer {
+                    attempts.getAndIncrement()
+                    Flux
+                        .just(textResponse("partial"))
+                        .concatWith(Flux.error(transientConnectError()))
+                }
+            )
+
+        val events =
+            controller(chatClient = client)
+                .stream(AgentQuery("hi"))
+                .collectList()
+                .block()!!
+
+        assertThat(attempts.get()).isEqualTo(1)
+        assertThat(events.map { it.event() }).containsExactly(EVENT_TOKEN, EVENT_ERROR)
+        assertThat(events[0].data()).isEqualTo("partial")
     }
 
     @Test


### PR DESCRIPTION
## Problem

AI Summary on the holdings page failed on kauri. bc-agent log:

```
AgentController : Agent stream failed: null
WebClientRequestException → ConnectException → UnresolvedAddressException
  *__checkpoint ⇢ POST https://api.deepseek.com/chat/completions
```

A sub-second DNS-resolution blip for `api.deepseek.com` (cluster dual-stack, `ndots:5`, DeepSeek has A-only/no AAAA) failed the LLM call at connect time. Two failures in one ~20s window; resolves fine otherwise. The streaming path had no retry, so the first transient hiccup surfaced straight to the user.

## Fix

Retry connect/DNS failures (`ConnectException` / `UnresolvedAddressException` anywhere in the cause chain) on the streaming token flux:

- Bounded: 2 attempts, 250ms exponential backoff + jitter — covers the common blip, won't outlast a real outage.
- Guarded by `totalChars == 0`: only retry before any token has streamed, so a recovery can never duplicate already-sent content.
- `onRetryExhaustedThrow` surfaces the original cause so `classifyError` still maps a sustained outage correctly.

## Tests

3 new `AgentControllerTest` cases (behaviour, not mock-verify):
- retries a transient connect failure, then emits the recovered tokens
- does not retry a non-transient (4xx) error
- does not retry once tokens have already been emitted

`./gradlew :svc-agent:test :svc-agent:formatKotlin :svc-agent:lintKotlin` green.

Not browser-verified live (the test account lacks the `ai` permission, so the button doesn't render); change is server-side resilience covered by unit tests.

@coderabbitai ignore