### PR TITLE
fix(svc-data): idempotent bulk delete for portfolios/brokers on offboarding

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerRepository.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.broker
 import com.beancounter.common.model.Broker
 import com.beancounter.common.model.SystemUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -32,4 +33,18 @@ interface BrokerRepository : JpaRepository<Broker, String> {
         @Param("name") name: String,
         @Param("owner") owner: SystemUser
     ): Optional<Broker>
+
+    /**
+     * Bulk idempotent delete of every broker owned by [ownerId]. Must be called
+     * AFTER [BrokerSettlementAccountRepository.deleteByBrokerOwnerId] to satisfy
+     * the broker_settlement_account.broker_id FK. Safe to call when no rows
+     * match (0-row delete, no exception) — concurrent offboarding calls cannot
+     * trigger StaleObjectStateException. Mirrors the pattern in
+     * TrnRepository.deleteByPortfolioId (Sentry DATA-5P / DATA-5Q).
+     */
+    @Modifying
+    @Query("delete from Broker b where b.owner.id = :ownerId")
+    fun deleteByOwnerId(
+        @Param("ownerId") ownerId: String
+    ): Long
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerSettlementAccountRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerSettlementAccountRepository.kt
@@ -25,4 +25,15 @@ interface BrokerSettlementAccountRepository : JpaRepository<BrokerSettlementAcco
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM BrokerSettlementAccount b WHERE b.account.id = :accountId")
     fun deleteByAccountId(accountId: String)
+
+    /**
+     * Bulk idempotent delete of all settlement accounts for brokers owned by [ownerId].
+     * Must be called before [BrokerRepository.deleteByOwnerId] to satisfy the
+     * broker_settlement_account.broker_id FK constraint.
+     */
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM BrokerSettlementAccount b WHERE b.broker.owner.id = :ownerId")
+    fun deleteByBrokerOwnerId(
+        @Param("ownerId") ownerId: String
+    )
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioRepository.kt
@@ -3,8 +3,10 @@ package com.beancounter.marketdata.portfolio
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 import java.util.Optional
 
@@ -43,4 +45,18 @@ interface PortfolioRepository : CrudRepository<Portfolio, String> {
         assetId: String,
         tradeDate: LocalDate
     ): Collection<Portfolio>
+
+    /**
+     * Bulk idempotent delete of every portfolio owned by [ownerId]. Issued as a
+     * single SQL DELETE rather than a select-then-remove loop, so concurrent or
+     * repeated offboarding calls (e.g. the bc-view wizard firing /offboard/wealth
+     * and /offboard/account in parallel) affect 0 rows instead of raising
+     * StaleObjectStateException. Matches the pattern used by
+     * TrnRepository.deleteByPortfolioId (Sentry DATA-5P / DATA-5Q).
+     */
+    @Modifying
+    @Query("delete from Portfolio p where p.owner.id = :ownerId")
+    fun deleteByOwnerId(
+        @Param("ownerId") ownerId: String
+    ): Long
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.registration
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.marketdata.assets.AssetRepository
 import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.portfolio.PortfolioRepository
 import com.beancounter.marketdata.providers.MarketDataRepo
 import com.beancounter.marketdata.tax.TaxRateRepository
@@ -33,6 +34,7 @@ class OffboardingService(
     private val assetRepository: AssetRepository,
     private val trnRepository: TrnRepository,
     private val brokerRepository: BrokerRepository,
+    private val brokerSettlementAccountRepository: BrokerSettlementAccountRepository,
     private val marketDataRepo: MarketDataRepo,
     private val taxRateRepository: TaxRateRepository,
     private val userPreferencesRepository: UserPreferencesRepository
@@ -113,17 +115,15 @@ class OffboardingService(
             )
         }
 
-        var deletedCount = 0
         portfolios.forEach { portfolio ->
             trnRepository.deleteByPortfolioId(portfolio.id)
-            portfolioRepository.delete(portfolio)
-            deletedCount++
         }
+        portfolioRepository.deleteByOwnerId(user.id)
 
-        log.info("Deleted {} portfolios for user {}", deletedCount, user.id)
+        log.info("Deleted {} portfolios for user {}", portfolios.size, user.id)
         return OffboardingResult(
             success = true,
-            deletedCount = deletedCount,
+            deletedCount = portfolios.size,
             type = "portfolios"
         )
     }
@@ -143,9 +143,9 @@ class OffboardingService(
         val portfolios = portfolioRepository.findByOwner(user).toList()
         portfolios.forEach { portfolio ->
             trnRepository.deleteByPortfolioId(portfolio.id)
-            portfolioRepository.delete(portfolio)
-            totalDeleted++
         }
+        portfolioRepository.deleteByOwnerId(user.id)
+        totalDeleted += portfolios.size
 
         // 2. Delete assets and their data
         val assets = assetRepository.findBySystemUserId(user.id)
@@ -185,8 +185,8 @@ class OffboardingService(
         val portfolios = portfolioRepository.findByOwner(user).toList()
         portfolios.forEach { portfolio ->
             trnRepository.deleteByPortfolioId(portfolio.id)
-            portfolioRepository.delete(portfolio)
         }
+        portfolioRepository.deleteByOwnerId(user.id)
 
         // 2. Delete assets and their data
         val assets = assetRepository.findBySystemUserId(user.id)
@@ -196,11 +196,11 @@ class OffboardingService(
             assetRepository.delete(asset)
         }
 
-        // 3. Delete brokers — safe to do AFTER trns are gone (trn.broker_id FK).
-        //    findByOwner returns this owner's brokers only; deleteAll respects
-        //    the per-owner unique-name + settlement-account cascades.
-        val brokers = brokerRepository.findByOwner(user)
-        brokerRepository.deleteAll(brokers)
+        // 3. Delete brokers — safe AFTER trns are gone (trn.broker_id FK).
+        //    Settlement accounts must be cleared first (broker_settlement_account.broker_id FK)
+        //    before the bulk broker delete. Both deletes are idempotent bulk operations.
+        brokerSettlementAccountRepository.deleteByBrokerOwnerId(user.id)
+        val brokerCount = brokerRepository.deleteByOwnerId(user.id)
 
         // 4. Delete tax rates
         taxRateRepository.deleteAllByOwnerId(user.id)
@@ -221,7 +221,7 @@ class OffboardingService(
             user.id,
             portfolios.size,
             assets.size,
-            brokers.size
+            brokerCount
         )
 
         return OffboardingResult(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
@@ -5,6 +5,7 @@ import com.beancounter.auth.model.Registration
 import com.beancounter.common.contracts.AssetRequest
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.model.Broker
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
@@ -12,6 +13,7 @@ import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.SpringMvcDbTest
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerRepository
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.tax.TaxRateRequest
 import com.beancounter.marketdata.tax.TaxRateService
@@ -49,6 +51,9 @@ class OffboardingServiceTest {
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    private lateinit var brokerRepository: BrokerRepository
 
     @Autowired
     private lateinit var mockAuthConfig: MockAuthConfig
@@ -342,5 +347,57 @@ class OffboardingServiceTest {
         assertThat(result.success).isTrue()
         assertThat(result.deletedCount).isEqualTo(0)
         assertThat(result.message).isEqualTo("No portfolios to delete")
+    }
+
+    @Test
+    fun `should delete brokers on account deletion`() {
+        val user = SystemUser(id = "offboard-broker-user", email = "offboard-broker@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        brokerRepository.save(Broker(name = "Test Broker", owner = user))
+
+        val summaryBefore = offboardingService.getSummary()
+        assertThat(summaryBefore.brokerCount).isEqualTo(1)
+
+        val result = offboardingService.deleteUserAccount()
+
+        assertThat(result.success).isTrue()
+        assertThat(result.message).isEqualTo("Account and all data deleted")
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
+    }
+
+    // Regression guard: bc-view offboarding wizard fires /offboard/wealth and /offboard/account
+    // in parallel. The second call used to hit a StaleObjectStateException because entity-based
+    // portfolio and broker deletes fail on already-removed rows. The bulk idempotent deletes
+    // (deleteByOwnerId) must return success on a second pass with 0 matching rows.
+    @Test
+    fun `should delete account idempotently when wealth already deleted`() {
+        val user = SystemUser(id = "offboard-idempotent-user", email = "offboard-idempotent@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        portfolioService.save(
+            listOf(
+                PortfolioInput(
+                    code = "OFFBOARD-IDEM",
+                    name = "Idempotent Portfolio",
+                    currency = USD.code
+                )
+            )
+        )
+        brokerRepository.save(Broker(name = "Idempotent Broker", owner = user))
+
+        // Simulate the wizard's first call (/offboard/wealth)
+        val wealthResult = offboardingService.deleteUserWealth()
+        assertThat(wealthResult.success).isTrue()
+
+        // Re-login: deleteUserWealth evicted cache but left the SystemUser row; the account
+        // delete call re-resolves the user from the DB via the mock security context.
+        mockAuthConfig.login(user, systemUserService)
+
+        // Simulate the wizard's second call (/offboard/account) — portfolios already gone
+        val accountResult = offboardingService.deleteUserAccount()
+
+        assertThat(accountResult.success).isTrue()
+        assertThat(accountResult.message).isEqualTo("Account and all data deleted")
     }
 }


### PR DESCRIPTION
## Problem
Closing an account could delete the user's independence plan (separate svc-retire txn) but leave portfolios + brokers + the SystemUser intact.

Root cause (svc-data side): `deleteUserAccount()` / `deleteUserWealth()` deleted portfolios and brokers with **entity** deletes (optimistic-locked). The bc-view wizard fires `/offboard/wealth` and `/offboard/account` in parallel — two txns delete the same portfolio rows → `StaleObjectStateException` → the account txn rolls back.

## Fix
- Bulk `@Modifying` delete-by-owner for portfolios and brokers (idempotent — 0-row delete instead of stale-entity throw). Mirrors the existing `TrnRepository.deleteByPortfolioId` hardening (Sentry DATA-5P / DATA-5Q).
- `BrokerSettlementAccount.broker_id` is a no-cascade FK → clear settlement accounts before the bulk broker delete.
- Assets unchanged (JPA cascade children handled by entity delete).

## Tests
- `should delete brokers on account deletion` — closes the coverage gap for the reported survivor.
- `should delete account idempotently when wealth already deleted` — regression guard for the parallel-wizard StaleState rollback.

`OffboardingServiceTest` + `lintKotlin` green.

The frontend half (stops the parallel race) is bc-view PR `fix/offboard-race-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account offboarding so related portfolios, brokers, and linked records are removed more reliably.
  * Made repeated offboarding actions safe, reducing failures when cleanup is run more than once.
  * Added safer cleanup ordering to avoid deletion errors during account removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->