### PR TITLE
fix(svc-data): apply broker-null splits to broker-scoped holdings

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
@@ -42,9 +42,10 @@ interface TrnBrokerRepository {
     ): Collection<Trn>
 
     /**
-     * Find ALL settled transactions for a specific broker for position building.
-     * Includes all transaction types (BUY, SELL, SPLIT, DIVI, etc.) up to a given date.
-     * Used by svc-position to build holdings with correct split-adjusted quantities.
+     * Find settled trades (BUY/SELL/ADD/REDUCE etc.) for a specific broker for position
+     * building, up to a given date. Note: SPLIT corporate actions carry no broker and
+     * are NOT returned here — callers must also fetch [findBrokerSplits] and merge, or
+     * the Accumulator builds split-unadjusted (negative) quantities.
      * Excludes PRIVATE market assets as they don't have brokers.
      * Excludes cash assets (CASH, ACCOUNT, TRADE, BANK ACCOUNT categories).
      */
@@ -64,6 +65,41 @@ interface TrnBrokerRepository {
             "order by t.tradeDate, t.asset.code"
     )
     fun findAllByBrokerIdForPositions(
+        brokerId: String,
+        owner: SystemUser,
+        tradeDate: LocalDate,
+        status: TrnStatus
+    ): Collection<Trn>
+
+    /**
+     * Find broker-null SPLIT corporate actions that apply to the (portfolio, asset)
+     * combinations a broker actually trades. Split rows carry no broker, so the
+     * broker-scoped queries silently drop them — leaving a sold-out holding negative
+     * because the split that grew it was never applied. The EXISTS clause scopes each
+     * split to a portfolio+asset where this broker holds the asset, so a split in an
+     * unrelated portfolio is not pulled in.
+     */
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset " +
+            "join fetch t.tradeCurrency " +
+            "join fetch t.portfolio " +
+            "left join fetch t.cashAsset " +
+            "left join fetch t.cashCurrency " +
+            "where t.broker is null " +
+            "and t.trnType = 'SPLIT' " +
+            "and t.portfolio.owner = ?2 " +
+            "and t.tradeDate <= ?3 " +
+            "and t.status = ?4 " +
+            "and exists (" +
+            "select 1 from Trn b " +
+            "where b.broker.id = ?1 " +
+            "and b.portfolio = t.portfolio " +
+            "and b.asset = t.asset" +
+            ") " +
+            "order by t.tradeDate, t.asset.code"
+    )
+    fun findBrokerSplits(
         brokerId: String,
         owner: SystemUser,
         tradeDate: LocalDate,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -173,11 +173,22 @@ class TrnBrokerService(
             )
         }
 
+    // Same-day tie-breaker for split-adjusted accumulation: buys/adds, then split, then sells.
+    private fun sameDayOrder(type: TrnType): Int =
+        when (type) {
+            TrnType.BUY, TrnType.ADD -> 0
+            TrnType.SPLIT -> 1
+            else -> 2
+        }
+
     private fun aggregateByAsset(transactions: Collection<Trn>): Map<String, AssetAggregation> {
         val assetMap = mutableMapOf<String, AssetAggregation>()
         // Chronological order matters: a SPLIT multiplies whatever quantity is held at
         // that point, so earlier buys scale up and later sells draw down the scaled total.
-        for (trn in transactions.sortedBy { it.tradeDate }) {
+        // Same-day events have no intra-day timestamp, so apply a deterministic order:
+        // buys/adds first, then the split, then sells/reduces — matching a broker ex-date
+        // where same-day trades settle against post-split share counts.
+        for (trn in transactions.sortedWith(compareBy({ it.tradeDate }, { sameDayOrder(it.trnType) }))) {
             val asset = trn.asset
             val agg =
                 assetMap.getOrPut(asset.id) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.broker.BrokerService
 import com.beancounter.marketdata.registration.SystemUserService
@@ -57,12 +58,20 @@ class TrnBrokerService(
                     brokerService.findById(brokerId, user).orElseThrow {
                         NotFoundException("Broker not found: $brokerId")
                     }
+                // Splits carry no broker; merge them so the Accumulator applies the
+                // split adjustment to the broker-scoped position.
                 trnRepository.findAllByBrokerIdForPositions(
                     broker.id,
                     user,
                     tradeDate,
                     TrnStatus.SETTLED
-                )
+                ) +
+                    trnRepository.findBrokerSplits(
+                        broker.id,
+                        user,
+                        tradeDate,
+                        TrnStatus.SETTLED
+                    )
             }
         log.trace("trns: ${results.size}, broker: $brokerId, asAt: $tradeDate")
         return postProcess(results.toList())
@@ -153,16 +162,22 @@ class TrnBrokerService(
                 brokerService.findById(brokerId, user).orElseThrow {
                     NotFoundException("Broker not found: $brokerId")
                 }
+            // Splits carry no broker; merge them so the quantity aggregation below is
+            // split-adjusted instead of reading negative on a sold-out holding.
+            val trades = trnRepository.findByBrokerIdAndOwner(brokerId, user, TrnStatus.SETTLED)
+            val splits = trnRepository.findBrokerSplits(brokerId, user, DateUtils().date, TrnStatus.SETTLED)
             Triple(
                 broker.id,
                 broker.name,
-                trnRepository.findByBrokerIdAndOwner(brokerId, user, TrnStatus.SETTLED)
+                trades + splits
             )
         }
 
     private fun aggregateByAsset(transactions: Collection<Trn>): Map<String, AssetAggregation> {
         val assetMap = mutableMapOf<String, AssetAggregation>()
-        for (trn in transactions) {
+        // Chronological order matters: a SPLIT multiplies whatever quantity is held at
+        // that point, so earlier buys scale up and later sells draw down the scaled total.
+        for (trn in transactions.sortedBy { it.tradeDate }) {
             val asset = trn.asset
             val agg =
                 assetMap.getOrPut(asset.id) {
@@ -184,9 +199,22 @@ class TrnBrokerService(
 
             val quantityDelta =
                 when (trn.trnType) {
-                    TrnType.BUY, TrnType.ADD -> trn.quantity
-                    TrnType.SELL, TrnType.REDUCE -> trn.quantity.negate()
-                    else -> BigDecimal.ZERO
+                    TrnType.BUY, TrnType.ADD -> {
+                        trn.quantity
+                    }
+                    TrnType.SELL, TrnType.REDUCE -> {
+                        trn.quantity.negate()
+                    }
+                    // SPLIT quantity is the ratio (e.g. 4 = 4:1). The delta scales the
+                    // running holding: newQty = qty * ratio, so delta = qty * (ratio - 1).
+                    TrnType.SPLIT -> {
+                        portfolioTrns.quantity
+                            .multiply(trn.quantity)
+                            .subtract(portfolioTrns.quantity)
+                    }
+                    else -> {
+                        BigDecimal.ZERO
+                    }
                 }
             agg.quantity = agg.quantity.add(quantityDelta)
             portfolioTrns.quantity = portfolioTrns.quantity.add(quantityDelta)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BrokerHoldingsSplitTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BrokerHoldingsSplitTest.kt
@@ -1,0 +1,155 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.auth.model.Registration
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.model.Broker
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.portfolio.PortfolioService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Broker-scoped holdings must apply corporate-action SPLIT transactions even though
+ * those rows carry no broker (broker_id is null). Otherwise a position that was sold
+ * out at the broker reads negative: the split that grew the holding is silently dropped.
+ *
+ * Repro (real incident): VO at DBS — BUY 12, a 4:1 SPLIT (no broker), SELL of the
+ * post-split shares. Without the split the broker view computes BUY - SELL and goes
+ * negative.
+ */
+@SpringMvcDbTest
+class BrokerHoldingsSplitTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var trnBrokerService: TrnBrokerService
+
+    @Autowired
+    private lateinit var brokerRepository: BrokerRepository
+
+    @Autowired
+    private lateinit var portfolioService: PortfolioService
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @Autowired
+    private lateinit var systemUserService: Registration
+
+    private fun seedSplitScenario(
+        user: SystemUser,
+        brokerName: String,
+        portfolioCode: String,
+        assetCode: String,
+        sellQty: String
+    ): Broker {
+        val broker = brokerRepository.save(Broker(name = brokerName, owner = user))
+        val portfolio =
+            portfolioService
+                .save(
+                    listOf(
+                        PortfolioInput(
+                            code = portfolioCode,
+                            name = portfolioCode,
+                            currency = USD.code
+                        )
+                    )
+                ).first()
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        AssetInput(NASDAQ.code, assetCode),
+                        assetCode
+                    )
+                ).data[assetCode]!!
+
+        // BUY 12 at the broker
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.BUY,
+                asset = asset,
+                quantity = BigDecimal("12"),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = LocalDate.of(2026, 1, 1)
+            )
+        )
+        // 4:1 SPLIT — corporate action, carries NO broker
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SPLIT,
+                asset = asset,
+                quantity = BigDecimal("4"),
+                portfolio = portfolio,
+                broker = null,
+                tradeDate = LocalDate.of(2026, 4, 21)
+            )
+        )
+        // SELL post-split shares at the broker
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SELL,
+                asset = asset,
+                quantity = BigDecimal(sellQty),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = LocalDate.of(2026, 6, 23)
+            )
+        )
+        return broker
+    }
+
+    @Test
+    fun `broker holdings apply broker-null split so position is not negative`() {
+        val user = SystemUser(id = "broker-split-user", email = "broker-split@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        // 12 shares, 4:1 split -> 48, sell 40 -> net 8 (not 12 - 40 = -28)
+        val broker = seedSplitScenario(user, "DBS", "BSPLIT-P1", "BSPL", sellQty = "40")
+
+        val holdings = trnBrokerService.getBrokerHoldings(broker.id)
+
+        val position = holdings.holdings.firstOrNull { it.assetCode == "BSPL" }
+        assertThat(position)
+            .describedAs("split-adjusted position must be present and positive")
+            .isNotNull
+        assertThat(position!!.quantity).isEqualByComparingTo("8")
+    }
+
+    @Test
+    fun `findForBroker includes broker-null split for downstream accumulation`() {
+        val user = SystemUser(id = "broker-split-pos-user", email = "broker-split-pos@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        val broker = seedSplitScenario(user, "IBKR", "BSPLIT-P2", "BSPL", sellQty = "48")
+
+        val trns = trnBrokerService.findForBroker(broker.id, LocalDate.of(2026, 6, 23))
+
+        assertThat(trns.map { it.trnType })
+            .describedAs("split must be returned so the Accumulator can apply it")
+            .contains(TrnType.SPLIT)
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BrokerHoldingsSplitTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BrokerHoldingsSplitTest.kt
@@ -140,6 +140,62 @@ class BrokerHoldingsSplitTest {
     }
 
     @Test
+    fun `broker holdings apply same-day split before same-day sell`() {
+        val user = SystemUser(id = "broker-split-sameday", email = "broker-split-sameday@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        val broker = brokerRepository.save(Broker(name = "DBS", owner = user))
+        val portfolio =
+            portfolioService
+                .save(listOf(PortfolioInput(code = "BSPLIT-SD", name = "BSPLIT-SD", currency = USD.code)))
+                .first()
+        val asset =
+            assetService
+                .handle(AssetRequest(AssetInput(NASDAQ.code, "BSPLSD"), "BSPLSD"))
+                .data["BSPLSD"]!!
+
+        val sameDay = LocalDate.of(2026, 4, 21)
+        // BUY, 4:1 SPLIT, and SELL all on the same date — split must apply before the sell.
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.BUY,
+                asset = asset,
+                quantity = BigDecimal("12"),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = sameDay
+            )
+        )
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SPLIT,
+                asset = asset,
+                quantity = BigDecimal("4"),
+                portfolio = portfolio,
+                broker = null,
+                tradeDate = sameDay
+            )
+        )
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SELL,
+                asset = asset,
+                quantity = BigDecimal("40"),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = sameDay
+            )
+        )
+
+        val holdings = trnBrokerService.getBrokerHoldings(broker.id)
+
+        // 12 -> *4 = 48, sell 40 -> 8. A pre-split sell would yield (12-40)*4 = -112.
+        val position = holdings.holdings.firstOrNull { it.assetCode == "BSPLSD" }
+        assertThat(position).isNotNull
+        assertThat(position!!.quantity).isEqualByComparingTo("8")
+    }
+
+    @Test
     fun `findForBroker includes broker-null split for downstream accumulation`() {
         val user = SystemUser(id = "broker-split-pos-user", email = "broker-split-pos@test.com")
         mockAuthConfig.login(user, systemUserService)


### PR DESCRIPTION
## Problem
Broker reconciliation showed a **negative** quantity for a position that was bought, split, then fully sold (real case: VO at DBS read **-36**). SPLIT corporate actions carry no `broker_id`, so every broker-scoped query (`findAllByBrokerIdForPositions`, `findByBrokerIdAndOwner`) dropped them. The split that grew the holding was never applied, so the view computed `BUY 12 − SELL 48 = −36`.

Two paths were affected:
- **`getBrokerHoldings`** (reconciliation drill-down): excluded SPLIT by `trnType` filter, and `aggregateByAsset` treated SPLIT as `else → 0`.
- **`findForBroker`** (valued positions via svc-position Accumulator): query excluded the SPLIT, so the Accumulator never saw it.

## Fix
- New query `findBrokerSplits` returns broker-null SPLIT rows scoped (via `EXISTS`) to the `(portfolio, asset)` combinations the broker actually trades — so an unrelated portfolio's split is not pulled in.
- Both broker paths merge those splits into their transaction set.
- `aggregateByAsset` is now split-aware: processes in trade-date order and applies the split as a ratio multiply (`newQty = qty × ratio`) on the running per-portfolio quantity.
- The `NO_BROKER` path already included splits (`where t.broker is null`) and is unchanged.

## Test
`BrokerHoldingsSplitTest` (real persistence, `@SpringMvcDbTest`) reproduces the incident: BUY 12 → 4:1 SPLIT (no broker) → SELL 40 ⇒ net **8**, not the bug's −28. Second case asserts `findForBroker` returns the SPLIT for the Accumulator. Both were RED before the fix, GREEN after; full `:svc-data:test` passes.

## Known limitation
Path A (svc-position) accumulates broker positions keyed by asset across portfolios. A broker holding the *same* asset in *multiple* portfolios, each with its own split, could double-apply — out of scope here; the reconciliation view (Path B) is per-portfolio correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker holdings now include applicable split transactions, improving position calculations for portfolios with corporate actions.

* **Bug Fixes**
  * Split adjustments are now applied in the correct transaction order, helping keep quantities accurate after later buys or sells.
  * Broker transaction results now include split-related entries when relevant, so downstream holdings can reflect the full history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->