### PR TITLE
fix(svc-data): clear settlement accounts before assets on offboard delete

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -188,7 +188,14 @@ class OffboardingService(
         }
         portfolioRepository.deleteByOwnerId(user.id)
 
-        // 2. Delete assets and their data
+        // 2. Clear settlement accounts BEFORE assets and brokers.
+        //    broker_settlement_account has NO-ACTION FKs to BOTH the cash asset
+        //    (fk_settlement_account) and the broker (fk_settlement_broker), so the
+        //    asset and broker bulk deletes below trip those constraints unless the
+        //    settlement rows are gone first.
+        brokerSettlementAccountRepository.deleteByBrokerOwnerId(user.id)
+
+        // 3. Delete assets and their data
         val assets = assetRepository.findBySystemUserId(user.id)
         assets.forEach { asset ->
             trnRepository.deleteByAssetId(asset.id)
@@ -196,10 +203,8 @@ class OffboardingService(
             assetRepository.delete(asset)
         }
 
-        // 3. Delete brokers — safe AFTER trns are gone (trn.broker_id FK).
-        //    Settlement accounts must be cleared first (broker_settlement_account.broker_id FK)
-        //    before the bulk broker delete. Both deletes are idempotent bulk operations.
-        brokerSettlementAccountRepository.deleteByBrokerOwnerId(user.id)
+        // 4. Delete brokers — safe AFTER trns (trn.broker_id FK) and settlement
+        //    accounts are gone. Idempotent bulk delete.
         val brokerCount = brokerRepository.deleteByOwnerId(user.id)
 
         // 4. Delete tax rates

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
@@ -12,8 +12,11 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetRepository
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccount
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.tax.TaxRateRequest
 import com.beancounter.marketdata.tax.TaxRateService
@@ -54,6 +57,12 @@ class OffboardingServiceTest {
 
     @Autowired
     private lateinit var brokerRepository: BrokerRepository
+
+    @Autowired
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
+
+    @Autowired
+    private lateinit var assetRepository: AssetRepository
 
     @Autowired
     private lateinit var mockAuthConfig: MockAuthConfig
@@ -399,5 +408,44 @@ class OffboardingServiceTest {
 
         assertThat(accountResult.success).isTrue()
         assertThat(accountResult.message).isEqualTo("Account and all data deleted")
+    }
+
+    // Regression guard (kauri 409): broker_settlement_account FKs to BOTH broker and the cash
+    // asset (fk_settlement_account). Deleting the user's assets before clearing settlement
+    // accounts trips that NO-ACTION constraint, rolling back the whole account delete. The
+    // settlement-account clear must run before the asset delete.
+    @Test
+    fun `should delete account when a settlement account references a user asset`() {
+        val user = SystemUser(id = "offboard-settlement-user", email = "offboard-settlement@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "test" to
+                                AssetInput.toRealEstate(
+                                    currency = USD,
+                                    code = "OFFBOARD-SETTLE-CASH",
+                                    name = "Settlement Cash Asset",
+                                    owner = user.id
+                                )
+                        )
+                    )
+                ).data["test"]!!
+        val broker = brokerRepository.save(Broker(name = "Settlement Broker", owner = user))
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = asset)
+        )
+
+        val result = offboardingService.deleteUserAccount()
+
+        // Assert via repositories, not getSummary — the SystemUser is gone after the
+        // account delete, so getSummary can no longer resolve the caller.
+        assertThat(result.success).isTrue()
+        assertThat(result.message).isEqualTo("Account and all data deleted")
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
+        assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
     }
 }


### PR DESCRIPTION
## Problem
Closing an account on kauri still failed after #977 — now with HTTP **409** instead of a silent rollback:
```
delete from "asset" … violates fk_settlement_account on broker_settlement_account
Key (id)=(…) is still referenced
```

`broker_settlement_account` has **two** NO-ACTION FKs: `fk_settlement_broker` → broker (handled by #977) **and `fk_settlement_account` → the cash asset**. #977 cleared settlement accounts in the broker section — *after* the asset delete. So a user whose broker has a settlement account (cash asset) trips the asset FK, and the whole `deleteUserAccount` txn rolls back.

Confirmed on live kauri data (dry-run): deleting the settlement account first, then the asset, succeeds.

## Fix
Move `brokerSettlementAccountRepository.deleteByBrokerOwnerId()` to **after portfolios, before assets** — settlement rows reference both assets and brokers, so they must go before either. (Placing it first tripped a `flushAutomatically` transient-flush in the existing tests; after the portfolio step is the correct, test-clean spot.)

## Test
`should delete account when a settlement account references a user asset` — seeds broker + cash asset + settlement account; the entity-mapped `account_id` FK is enforced by H2, so this reproduces the 409 on the old order and passes on the new one. Full suite 12/12, format + lint clean.

## Note
`deleteUserWealth` deletes assets but not settlement accounts, so a *wealth-only* delete of a cash asset still referenced by a kept broker would hit the same FK. Out of scope here (the wizard's account path doesn't call wealth); flagging for a follow-up if wealth-only delete needs it.

Follow-up to #977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deletion so broker settlement records are removed before assets, preventing failures when settlement accounts reference user-owned assets.
  * Confirmed cleanup now completes in the expected order for portfolios, settlement accounts, assets, and brokers.
  * Added regression coverage for this deletion scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->