### PR TITLE
fix(svc-data): pool external HTTP client + DNS resilience for price refresh

### DIFF
--- a/svc-data/build.gradle.kts
+++ b/svc-data/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
     implementation(project(":jar-auth"))
     implementation(project(":jar-client"))
     implementation(libs.spring.boot.starter.web)
+    // Pooled HTTP client for external RestClients (ExternalApiRestClientConfig): keep-alive
+    // connection reuse avoids a fresh DNS lookup per request during the price-refresh burst.
+    // Version managed by the Spring Boot BOM.
+    implementation("org.apache.httpcomponents.client5:httpclient5")
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.logging)
     implementation(libs.spring.doc)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfig.kt
@@ -1,47 +1,90 @@
 package com.beancounter.marketdata.config
 
+import org.apache.hc.client5.http.config.ConnectionConfig
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import org.apache.hc.core5.util.TimeValue
+import org.apache.hc.core5.util.Timeout
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import java.security.Security
 
 /**
- * Configuration for RestClients used by external API integrations.
+ * RestClients for external market-data / FX APIs.
+ *
+ * All clients use a pooled Apache HttpClient5 connection manager with keep-alive, so a
+ * connection — and its already-resolved DNS — is reused across calls instead of opening a
+ * fresh socket and re-resolving the host on every request. The price-refresh scheduler
+ * fires a burst of ~50 per-symbol EODHD calls; with the previous JDK request factory each
+ * one re-resolved the host, and under k8s `ndots:5` search expansion that storm overwhelmed
+ * CoreDNS, yielding UnknownHostException for the whole batch.
  */
 @Configuration
 class ExternalApiRestClientConfig {
+    init {
+        // A single transient DNS miss must not poison every later lookup: the JVM
+        // negative-DNS cache (default ~10s) turned one CoreDNS UDP drop into a whole batch
+        // of UnknownHostException. Disable negative caching so each call re-resolves.
+        Security.setProperty("networkaddress.cache.negative.ttl", "0")
+    }
+
     companion object {
-        private const val CONNECT_TIMEOUT_MS = 5000
-        private const val READ_TIMEOUT_MS = 30000
+        private const val CONNECT_TIMEOUT_MS = 5000L
+        private const val READ_TIMEOUT_MS = 30000L
 
         // Interactive asset-search calls (header bar). withTimeoutOrNull in the coroutine
         // fan-out can't cancel a blocking RestClient call cooperatively, so the only way to
         // cap user-visible latency is to set the underlying HTTP timeouts low. EODHD search
         // returns a small JSON array — 2s connect / 3s read is plenty when the provider is
         // healthy and forces a fast failure when it isn't.
-        private const val SEARCH_CONNECT_TIMEOUT_MS = 2000
-        private const val SEARCH_READ_TIMEOUT_MS = 3000
+        private const val SEARCH_CONNECT_TIMEOUT_MS = 2000L
+        private const val SEARCH_READ_TIMEOUT_MS = 3000L
+
+        private const val MAX_CONN_TOTAL = 40
+        private const val MAX_CONN_PER_ROUTE = 20
+        private const val CONNECTION_TTL_MINUTES = 5L
+        private const val IDLE_EVICT_SECONDS = 30L
     }
 
-    private fun createRequestFactory(
-        connectTimeoutMs: Int = CONNECT_TIMEOUT_MS,
-        readTimeoutMs: Int = READ_TIMEOUT_MS
-    ): SimpleClientHttpRequestFactory =
-        SimpleClientHttpRequestFactory().apply {
-            setConnectTimeout(connectTimeoutMs)
-            setReadTimeout(readTimeoutMs)
-        }
+    private fun pooledRequestFactory(
+        connectTimeoutMs: Long,
+        readTimeoutMs: Long
+    ): HttpComponentsClientHttpRequestFactory {
+        val connectionManager =
+            PoolingHttpClientConnectionManagerBuilder
+                .create()
+                .setDefaultConnectionConfig(
+                    ConnectionConfig
+                        .custom()
+                        .setConnectTimeout(Timeout.ofMilliseconds(connectTimeoutMs))
+                        .setSocketTimeout(Timeout.ofMilliseconds(readTimeoutMs))
+                        .setTimeToLive(TimeValue.ofMinutes(CONNECTION_TTL_MINUTES))
+                        .build()
+                ).setMaxConnTotal(MAX_CONN_TOTAL)
+                .setMaxConnPerRoute(MAX_CONN_PER_ROUTE)
+                .build()
+        val httpClient =
+            HttpClients
+                .custom()
+                .setConnectionManager(connectionManager)
+                .evictIdleConnections(TimeValue.ofSeconds(IDLE_EVICT_SECONDS))
+                .evictExpiredConnections()
+                .build()
+        return HttpComponentsClientHttpRequestFactory(httpClient)
+    }
 
     private fun buildRestClient(
         baseUrl: String,
-        connectTimeoutMs: Int = CONNECT_TIMEOUT_MS,
-        readTimeoutMs: Int = READ_TIMEOUT_MS
+        connectTimeoutMs: Long = CONNECT_TIMEOUT_MS,
+        readTimeoutMs: Long = READ_TIMEOUT_MS
     ): RestClient =
         RestClient
             .builder()
             .baseUrl(baseUrl)
-            .requestFactory(createRequestFactory(connectTimeoutMs, readTimeoutMs))
+            .requestFactory(pooledRequestFactory(connectTimeoutMs, readTimeoutMs))
             .build()
 
     @Bean

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -77,17 +77,67 @@ class EodhdPriceService(
         // A 4xx for one symbol must not abort the whole batch — bc-position
         // schedules valuations across every portfolio, so one bad ticker would
         // otherwise halt every portfolio sequenced after it.
-        val rows =
-            try {
-                eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey)
-            } catch (e: RestClientException) {
-                // Broad RestClientException, not just 4xx: also covers body-extraction
-                // failures when EODHD returns a non-array error payload for a bad or
-                // mis-tagged symbol. One bad ticker must never abort the valuation cycle.
+        return fetchSymbolRows(symbol, priceDate).fold(
+            onSuccess = { rows -> eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows) },
+            onFailure = { e ->
                 log.warn("EODHD error for {} on {} — skipping: {}", symbol, priceDate, e.message)
-                return emptyList()
+                emptyList()
             }
-        return eodhdAdapter.toMarketData(asset, LocalDate.parse(priceDate), rows)
+        )
+    }
+
+    /**
+     * Fetch one symbol's rows, capturing a [RestClientException] as a failed [Result] rather
+     * than logging here — callers decide whether to log per-symbol (true single fetch) or as
+     * one batch summary (bulk fallback). Broad RestClientException, not just 4xx: also covers
+     * body-extraction failures when EODHD returns a non-array error payload, and transient
+     * I/O (e.g. a DNS/connection blip during the refresh burst).
+     */
+    private fun fetchSymbolRows(
+        symbol: String,
+        priceDate: String
+    ): Result<List<com.beancounter.marketdata.providers.eodhd.model.EodhdPrice>> =
+        try {
+            Result.success(eodhdProxy.getPrice(symbol, priceDate, eodhdConfig.apiKey))
+        } catch (e: RestClientException) {
+            Result.failure(e)
+        }
+
+    /**
+     * Per-symbol fallback for a failed bulk call. Collapses what used to be one WARN per
+     * failed symbol into a single batch summary — a transient I/O blip during the refresh
+     * burst previously emitted ~50 identical warnings (one per US symbol).
+     */
+    private fun fetchPerSymbol(
+        providerArguments: ProviderArguments,
+        symbols: List<String>,
+        priceDate: String
+    ): List<MarketData> {
+        val parsedDate = LocalDate.parse(priceDate)
+        val results = mutableListOf<MarketData>()
+        val failures = mutableListOf<String>()
+        var lastError: String? = null
+        for (symbol in symbols) {
+            val asset = providerArguments.getAsset(symbol)
+            fetchSymbolRows(symbol, priceDate).fold(
+                onSuccess = { rows -> results.addAll(eodhdAdapter.toMarketData(asset, parsedDate, rows)) },
+                onFailure = { e ->
+                    failures.add(symbol)
+                    lastError = e.message
+                }
+            )
+        }
+        if (failures.isNotEmpty()) {
+            log.warn(
+                "EODHD per-symbol fallback on {}: {}/{} symbols failed ({}): {}",
+                priceDate,
+                failures.size,
+                symbols.size,
+                lastError,
+                failures.joinToString(",")
+            )
+        }
+        return results
     }
 
     /**
@@ -124,7 +174,7 @@ class EodhdPriceService(
                     priceDate,
                     e.message
                 )
-                return symbols.flatMap { fetchSingle(providerArguments, it, priceDate) }
+                return fetchPerSymbol(providerArguments, symbols, priceDate)
             }
 
         val rowsByCode = bulkRows.groupBy { it.code.uppercase() }

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -586,7 +586,11 @@ beancounter:
       # Operators enable per-env via BEANCOUNTER_MARKET_PROVIDERS_EODHD_MARKETS.
       # Plan reference: https://eodhd.com/pricing
       eodhd:
-        url: https://eodhd.com
+        # Trailing-dot FQDN: bypasses the k8s `ndots:5` search-domain expansion (which
+        # otherwise issues 4 cluster-local lookups before the real one), cutting DNS load
+        # during the price-refresh burst. TLS still validates (cert CN matched after the
+        # resolver strips the trailing dot).
+        url: https://eodhd.com.
         # batchSize > 1 routes through `/api/eod-bulk-last-day/{exchange}` so the
         # nightly PortfolioValuationSchedule collapses N per-symbol round-trips
         # into a single HTTP call (per-symbol quota is unchanged at 1 call each).

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/config/ExternalApiRestClientConfigTest.kt
@@ -1,0 +1,29 @@
+package com.beancounter.marketdata.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.Security
+
+/**
+ * Guards the DNS-resilience side effects of the external API client config.
+ */
+class ExternalApiRestClientConfigTest {
+    @Test
+    fun `disables JVM negative-DNS caching so one miss does not poison the batch`() {
+        // Constructing the config applies the side effect.
+        ExternalApiRestClientConfig()
+
+        assertThat(Security.getProperty("networkaddress.cache.negative.ttl"))
+            .describedAs("negative-DNS cache must be off so a transient miss isn't cached")
+            .isEqualTo("0")
+    }
+
+    @Test
+    fun `builds pooled RestClients for external providers`() {
+        val config = ExternalApiRestClientConfig()
+
+        // A pooled HttpComponents-backed client builds without error for each provider URL.
+        assertThat(config.eodhdRestClient("http://localhost:0")).isNotNull
+        assertThat(config.alphaVantageRestClient("http://localhost:0")).isNotNull
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdApiTest.kt
@@ -1,5 +1,9 @@
 package com.beancounter.marketdata.providers.eodhd
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.beancounter.auth.AutoConfigureMockAuth
 import com.beancounter.common.contracts.PriceAsset
 import com.beancounter.common.contracts.PriceRequest
@@ -16,11 +20,13 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource
@@ -341,6 +347,50 @@ internal class EodhdApiTest {
         val byCode = result.associateBy { it.asset.code }
         assertThat(byCode["AAPL"]?.close).isEqualByComparingTo(BigDecimal("237.33"))
         assertThat(byCode["MSFT"]?.close).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `bulk I-O failure with failing per-symbol fallback logs one summary not per-symbol warnings`() {
+        // Bulk endpoint and both per-symbol endpoints drop the connection (transient I/O —
+        // e.g. a DNS/connection blip during the refresh burst). Bulk fails, falls back to
+        // per-symbol, every per-symbol call also fails. This must emit ONE batch-summary
+        // WARN, not one WARN per symbol — the burst previously logged ~50 identical lines.
+        wireMock.stubFor(
+            get(urlPathEqualTo(BULK_LAST_DAY_US))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+        wireMock.stubFor(
+            get(urlPathEqualTo("/api/eod/AAPL.US"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+        wireMock.stubFor(
+            get(urlPathEqualTo("/api/eod/MSFT.US"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        val logger = LoggerFactory.getLogger(EodhdPriceService::class.java) as Logger
+        logger.addAppender(appender)
+        try {
+            val result =
+                eodhdPriceService.getMarketData(
+                    PriceRequest(
+                        "2024-11-29",
+                        listOf(PriceAsset(AAPL), PriceAsset(MSFT))
+                    )
+                )
+            assertThat(result).isEmpty()
+        } finally {
+            logger.detachAppender(appender)
+        }
+
+        val warnings = appender.list.filter { it.level == Level.WARN }.map { it.formattedMessage }
+        assertThat(warnings.filter { it.contains("per-symbol fallback") })
+            .describedAs("one batch summary covering all failed symbols")
+            .hasSize(1)
+        assertThat(warnings.filter { it.contains("EODHD error for ") })
+            .describedAs("no per-symbol warnings")
+            .isEmpty()
     }
 
     private fun stubEod(


### PR DESCRIPTION
## Problem
The market-close price refresh logged ~50 `WARN`s per run — every US symbol failing at once with:
```
I/O error on GET … "https://eodhd.com/api/eod/ADBE.US": eodhd.com
```
Not too early, not an EODHD outage (host reachable at rest). Root cause was a **DNS storm**: `SimpleClientHttpRequestFactory` (JDK `HttpURLConnection`) opens a fresh connection — and re-resolves the host — per request. The refresh fires a ~50-symbol burst, and under k8s `ndots:5` each bare-host lookup expands to ~4 cluster-local queries before the real one. That overwhelmed CoreDNS → a lost UDP packet → `UnknownHostException`, then the JVM negative-DNS cache (~10s) poisoned every remaining symbol in the window.

## Fixes (all four)
1. **Pooled HTTP client** — Apache HttpClient5 `PoolingHttpClientConnectionManager` with keep-alive in `ExternalApiRestClientConfig` (all external providers). Connections (and their resolved DNS) are reused instead of re-opened/re-resolved per call.
2. **Batch-summary log** — `EodhdPriceService` bulk-fallback now aggregates per-symbol failures into **one** WARN listing the failed symbols, instead of one WARN each.
3. **FQDN** — `eodhd.url` → `https://eodhd.com.` (trailing dot) bypasses the `ndots:5` search-domain expansion. TLS still validates (verified: cert matches after the resolver strips the dot).
4. **Negative-DNS TTL = 0** — one transient miss no longer gets cached and poison the batch.

## Tests
- `EodhdApiTest`: bulk + per-symbol all fail (WireMock `CONNECTION_RESET`) ⇒ exactly **one** batch-summary WARN, **zero** per-symbol WARNs (RED before, since the old fallback logged per symbol). Also exercises the new pooled client end-to-end.
- `ExternalApiRestClientConfigTest`: negative-DNS TTL set to `0`; pooled clients build.
- Full `:svc-data:test` green — pooled factory regressed no provider (alpha/marketstack/figi/fx/eodhd).

## Live-verify on kauri
FQDN trailing-dot SNI and the connection-pool behaviour are worth a glance on the next scheduled run after deploy (the 21:00 UTC US refresh) — expect no DNS-storm WARNs, or at most a single batch summary.