### PR TITLE
fix(svc-data): trusted private-asset enrich + resilient EODHD events

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricher.kt
@@ -24,7 +24,15 @@ class PrivateMarketEnricher(
         market: Market,
         assetInput: AssetInput
     ): Asset {
-        val systemUser = systemUserService.getOrThrow()
+        // Trusted callers (e.g. the RabbitMQ CSV-import consumer) supply the owner on the
+        // AssetInput and run on a thread with no JWT in scope. Prefer that owner so the
+        // resolution doesn't hit getOrThrow → "Not authorised" (DATA-4Z). The interactive
+        // HTTP path leaves owner blank and falls back to the authenticated caller.
+        val systemUser =
+            assetInput.owner
+                .takeIf { it.isNotBlank() }
+                ?.let { systemUserService.findById(it) }
+                ?: systemUserService.getOrThrow()
         val currencyCode =
             assetInput.currency
                 ?: throw BusinessException("Currency required for private asset ${assetInput.code}")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricher.kt
@@ -25,14 +25,20 @@ class PrivateMarketEnricher(
         assetInput: AssetInput
     ): Asset {
         // Trusted callers (e.g. the RabbitMQ CSV-import consumer) supply the owner on the
-        // AssetInput and run on a thread with no JWT in scope. Prefer that owner so the
-        // resolution doesn't hit getOrThrow → "Not authorised" (DATA-4Z). The interactive
-        // HTTP path leaves owner blank and falls back to the authenticated caller.
+        // AssetInput and run on a thread with no JWT in scope. Use that owner so the
+        // resolution doesn't hit getOrThrow → "Not authorised" (DATA-4Z). A supplied-but-
+        // unknown owner must fail fast — never silently fall back to the JWT user, or the
+        // asset would persist under the wrong account. The interactive HTTP path leaves
+        // owner blank and uses the authenticated caller.
         val systemUser =
-            assetInput.owner
-                .takeIf { it.isNotBlank() }
-                ?.let { systemUserService.findById(it) }
-                ?: systemUserService.getOrThrow()
+            if (assetInput.owner.isNotBlank()) {
+                systemUserService.findById(assetInput.owner)
+                    ?: throw BusinessException(
+                        "Owner ${assetInput.owner} not found for private asset ${assetInput.code}"
+                    )
+            } else {
+                systemUserService.getOrThrow()
+            }
         val currencyCode =
             assetInput.currency
                 ?: throw BusinessException("Currency required for private asset ${assetInput.code}")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
@@ -8,6 +8,7 @@ import com.beancounter.marketdata.providers.MarketDataRepo
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientException
 import java.math.BigDecimal
 
 /**
@@ -40,9 +41,17 @@ class EodhdEventService(
             return PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
         }
         val symbol = eodhdConfig.getPriceCode(asset)
-        val divs = eodhdProxy.getDividends(symbol, eodhdConfig.apiKey).map { toDividendRow(asset, it) }
-        val splits = eodhdProxy.getSplits(symbol, eodhdConfig.apiKey).map { toSplitRow(asset, it) }
-        return PriceResponse(divs + splits)
+        return try {
+            val divs = eodhdProxy.getDividends(symbol, eodhdConfig.apiKey).map { toDividendRow(asset, it) }
+            val splits = eodhdProxy.getSplits(symbol, eodhdConfig.apiKey).map { toSplitRow(asset, it) }
+            PriceResponse(divs + splits)
+        } catch (e: RestClientException) {
+            // A provider I/O blip must not 500 the events endpoint — bc-event consumes it on
+            // a RabbitMQ listener, and a 500 exhausts the retry policy and drops the message
+            // (EVENT-1F). Degrade to repository-cached events like the unsupported-market path.
+            log.warn("EODHD events fetch failed for {} — falling back to stored events: {}", asset.code, e.message)
+            PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
+        }
     }
 
     private fun isMarketSupported(marketCode: String): Boolean {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventService.kt
@@ -6,7 +6,9 @@ import com.beancounter.common.model.MarketData
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.providers.MarketDataRepo
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClientException
 import java.math.BigDecimal
@@ -31,28 +33,46 @@ class EodhdEventService(
     private val eodhdConfig: EodhdConfig,
     private val marketDataRepo: MarketDataRepo
 ) {
-    @Cacheable("eodhd.asset.event")
+    // Cache-aware self-invocation: getEvents must call fetchProviderEvents through the Spring
+    // proxy or @Cacheable is bypassed. Defaults to `this` for plain unit tests; Spring injects
+    // the @Lazy proxy at startup (the setter), breaking the construction cycle.
+    @set:Autowired
+    @set:Lazy
+    internal var self: EodhdEventService = this
+
     fun getEvents(assetId: String): PriceResponse = getEvents(assetFinder.find(assetId))
 
-    @Cacheable("eodhd.asset.event", key = "#asset.id")
     fun getEvents(asset: Asset): PriceResponse {
         if (!isMarketSupported(asset.market.code)) {
             log.debug("Market {} not supported by EODHD; falling back to repo for {}", asset.market.code, asset.code)
-            return PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
+            return repoFallback(asset)
         }
-        val symbol = eodhdConfig.getPriceCode(asset)
         return try {
-            val divs = eodhdProxy.getDividends(symbol, eodhdConfig.apiKey).map { toDividendRow(asset, it) }
-            val splits = eodhdProxy.getSplits(symbol, eodhdConfig.apiKey).map { toSplitRow(asset, it) }
-            PriceResponse(divs + splits)
+            self.fetchProviderEvents(asset)
         } catch (e: RestClientException) {
             // A provider I/O blip must not 500 the events endpoint — bc-event consumes it on
             // a RabbitMQ listener, and a 500 exhausts the retry policy and drops the message
-            // (EVENT-1F). Degrade to repository-cached events like the unsupported-market path.
+            // (EVENT-1F). Degrade to stored events — and crucially do NOT cache this fallback,
+            // so a brief outage can't pin stale events for the cache TTL.
             log.warn("EODHD events fetch failed for {} — falling back to stored events: {}", asset.code, e.message)
-            PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
+            repoFallback(asset)
         }
     }
+
+    /**
+     * Provider fetch — cached on success only. The [RestClientException] on a provider I/O
+     * error propagates out (caches never store exceptions), so the caller's repo fallback is
+     * never cached under this key.
+     */
+    @Cacheable("eodhd.asset.event", key = "#asset.id")
+    fun fetchProviderEvents(asset: Asset): PriceResponse {
+        val symbol = eodhdConfig.getPriceCode(asset)
+        val divs = eodhdProxy.getDividends(symbol, eodhdConfig.apiKey).map { toDividendRow(asset, it) }
+        val splits = eodhdProxy.getSplits(symbol, eodhdConfig.apiKey).map { toSplitRow(asset, it) }
+        return PriceResponse(divs + splits)
+    }
+
+    private fun repoFallback(asset: Asset): PriceResponse = PriceResponse(marketDataRepo.findEventsByAssetId(asset.id))
 
     private fun isMarketSupported(marketCode: String): Boolean {
         val supported = eodhdConfig.markets ?: return false

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/EnrichmentTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/EnrichmentTest.kt
@@ -122,8 +122,9 @@ class EnrichmentTest {
         val systemUserService = Mockito.mock(SystemUserService::class.java)
         val enricher: AssetEnricher = PrivateMarketEnricher(systemUserService, accountingTypeService, currencyService)
 
-        // And mocked dependencies
-        Mockito.`when`(systemUserService.getOrThrow()).thenReturn(SystemUser(testSystemUserId))
+        // And mocked dependencies. The AssetInput supplies owner "test-user", so the enricher
+        // resolves it via findById (not getOrThrow) — matching the trusted/no-JWT path.
+        Mockito.`when`(systemUserService.findById("test-user")).thenReturn(SystemUser(testSystemUserId))
         Mockito.`when`(keyGenUtils.id).thenReturn(testKeyGenId)
         Mockito.`when`(currencyService.getCode("USD")).thenReturn(USD)
         Mockito

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricherTest.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.assets
 
+import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.model.AccountingType
 import com.beancounter.common.model.Currency
@@ -8,6 +9,7 @@ import com.beancounter.common.model.SystemUser
 import com.beancounter.marketdata.currency.CurrencyService
 import com.beancounter.marketdata.registration.SystemUserService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -59,5 +61,27 @@ class PrivateMarketEnricherTest {
 
         assertThat(asset.systemUser).isEqualTo(owner)
         assertThat(asset.code).isEqualTo("owner-1.DBS")
+    }
+
+    @Test
+    fun `fails fast when a supplied owner cannot be resolved`() {
+        val enricher = PrivateMarketEnricher(systemUserService, accountingTypeService, currencyService)
+        // A supplied-but-unknown owner must not silently fall back to the JWT user, which
+        // would persist the asset under the wrong account.
+        whenever(systemUserService.findById("ghost")).thenReturn(null)
+
+        assertThatThrownBy {
+            enricher.enrich(
+                "asset-1",
+                Market(PrivateMarketEnricher.ID),
+                AssetInput(
+                    market = PrivateMarketEnricher.ID,
+                    code = "DBS",
+                    currency = "SGD",
+                    category = "ACCOUNT",
+                    owner = "ghost"
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateMarketEnricherTest.kt
@@ -1,0 +1,63 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.model.AccountingType
+import com.beancounter.common.model.Currency
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.currency.CurrencyService
+import com.beancounter.marketdata.registration.SystemUserService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * The RabbitMQ CSV-import consumer runs on a thread with no JWT in scope and supplies the
+ * owner on the AssetInput. Enriching a private asset there must use that owner instead of
+ * the security context, or it throws UnauthorizedException → AMQP retries exhausted (DATA-4Z).
+ */
+@ExtendWith(MockitoExtension::class)
+class PrivateMarketEnricherTest {
+    @Mock
+    private lateinit var systemUserService: SystemUserService
+
+    @Mock
+    private lateinit var accountingTypeService: AccountingTypeService
+
+    @Mock
+    private lateinit var currencyService: CurrencyService
+
+    @Test
+    fun `enriches a private asset from the AssetInput owner without a JWT in scope`() {
+        val enricher = PrivateMarketEnricher(systemUserService, accountingTypeService, currencyService)
+        val owner = SystemUser(id = "owner-1", email = "owner@test.com")
+        // getOrThrow is intentionally NOT stubbed: on the stream thread it has no JWT and
+        // would fail. The enricher must resolve the owner via findById instead.
+        whenever(systemUserService.findById("owner-1")).thenReturn(owner)
+        whenever(currencyService.getCode("SGD")).thenReturn(Currency("SGD"))
+        // getOrCreate has two defaulted params; Kotlin dispatches the 4-arg form.
+        whenever(accountingTypeService.getOrCreate(any(), any(), any(), any()))
+            .thenReturn(mock<AccountingType>())
+
+        val asset =
+            enricher.enrich(
+                "asset-1",
+                Market(PrivateMarketEnricher.ID),
+                AssetInput(
+                    market = PrivateMarketEnricher.ID,
+                    code = "DBS",
+                    currency = "SGD",
+                    category = "ACCOUNT",
+                    owner = "owner-1"
+                )
+            )
+
+        assertThat(asset.systemUser).isEqualTo(owner)
+        assertThat(asset.code).isEqualTo("owner-1.DBS")
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
@@ -126,6 +126,30 @@ internal class EodhdEventApiTest {
         assertThat(response.data).isEmpty()
     }
 
+    @Test
+    fun `does not cache the fallback so events return once the provider recovers`() {
+        val recovering =
+            Asset(
+                id = "asset-recover",
+                code = "RECOV",
+                market = Market("LON"),
+                category = AssetCategory.INDEX
+            )
+        // First call: provider drops the connection → empty fallback. Must NOT be cached.
+        wireMock.stubFor(
+            get(urlPathEqualTo("/api/div/RECOV.LSE"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+        assertThat(eodhdEventService.getEvents(recovering).data).isEmpty()
+
+        // Provider recovers — a cached empty fallback would still answer empty here.
+        wireMock.resetAll()
+        stubArrayEndpoint("/api/div/RECOV.LSE", "mock/eodhd/AAPL-US-div.json")
+        stubArrayEndpoint("/api/splits/RECOV.LSE", "mock/eodhd/AAPL-US-splits.json")
+
+        assertThat(eodhdEventService.getEvents(recovering).data).hasSize(3)
+    }
+
     private fun stubArrayEndpoint(
         path: String,
         fixturePath: String

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdEventApiTest.kt
@@ -9,6 +9,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -99,6 +100,29 @@ internal class EodhdEventApiTest {
 
         val response = eodhdEventService.getEvents(empty)
 
+        assertThat(response.data).isEmpty()
+    }
+
+    @Test
+    fun `getEvents degrades to stored events when EODHD drops the connection`() {
+        // bc-event consumes this on a RabbitMQ listener; a provider I/O error must not 500
+        // (which exhausts the retry policy and drops the message — EVENT-1F). Degrade to the
+        // repository instead. Distinct asset id keeps the @Cacheable result isolated.
+        val flaky =
+            Asset(
+                id = "asset-flaky",
+                code = "FLAKY",
+                market = Market("LON"),
+                category = AssetCategory.INDEX
+            )
+        wireMock.stubFor(
+            get(urlPathEqualTo("/api/div/FLAKY.LSE"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+
+        val response = eodhdEventService.getEvents(flaky)
+
+        // No stored events for this asset → empty, but crucially no exception propagated.
         assertThat(response.data).isEmpty()
     }
 


### PR DESCRIPTION
Resolves two Sentry issues.

## DATA-4Z — CSV import "Not authorised" (87 events, 3 weeks)
The RabbitMQ `bc-trn-csv-demo` consumer runs with **no JWT in scope**. When a CSV row creates a **private** asset (e.g. a cash/account asset under a portfolio), `PrivateMarketEnricher.enrich` called `systemUserService.getOrThrow()` → `UnauthorizedException` → AMQP retry policy exhausted → message dropped. (The earlier auto-settle `findOrNull` fix handled one such leak; this is the second.)

**Fix:** the enricher prefers the owner already supplied on `AssetInput` (the trusted CSV adapter sets `owner = portfolio.owner.id`) via the JWT-free `findById`, falling back to `getOrThrow` only on the interactive HTTP path.

## EVENT-1F / DATA-5N — EODHD events 500 (72 events)
`EodhdEventService.getEvents` let a provider `RestClientException` propagate → 500 on `/prices/{id}/events`. bc-event consumes that on a RabbitMQ listener, so the 500 exhausted its retry policy. The DNS trigger is addressed by #980, but a genuine provider outage would still 500.

**Fix:** catch `RestClientException` and degrade to repository-cached events (same fallback the unsupported-market branch already uses).

## Tests
- `PrivateMarketEnricherTest`: enrich from `AssetInput.owner` with no JWT in scope ⇒ correct owner + namespaced code (`owner-1.DBS`). RED before (NPE via unstubbed `getOrThrow`).
- `EodhdEventApiTest`: EODHD div endpoint drops the connection (WireMock `CONNECTION_RESET`) ⇒ no exception, degrades to stored events.
- Full `:svc-data:test` green; format + lint clean.

## Note
DATA-4Z's auto-settle leak was already fixed/deployed; this closes the remaining private-asset-enrichment leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Private assets can now be enriched using the provided asset owner, allowing imports to work even without an active sign-in context.

* **Bug Fixes**
  * Improved resilience when provider requests fail: EODHD dividend/split errors now fall back to stored event data instead of interrupting the flow.
  * Added fail-fast validation when an owner ID cannot be resolved.
  * Refined event caching so empty fallback results aren’t reused after provider recovery.

* **Tests**
  * Expanded coverage for owner-based enrichment and EODHD provider failure/degradation scenarios, including caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->