### PR TITLE
fix(svc-data): deterministic same-day trn ordering via createdAt tie-break

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisRepository.kt
@@ -53,7 +53,7 @@ interface TrnAnalysisRepository {
             "and t.tradeDate >= ?2 " +
             "and t.tradeDate <= ?3 " +
             "and t.status = ?4 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findInvestmentsByOwnerAndDateRange(
         owner: SystemUser,
@@ -79,7 +79,7 @@ interface TrnAnalysisRepository {
             "and t.tradeDate >= ?2 " +
             "and t.tradeDate <= ?3 " +
             "and t.status = ?4 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findInvestmentsByPortfoliosAndDateRange(
         portfolioIds: List<String>,
@@ -104,7 +104,7 @@ interface TrnAnalysisRepository {
             "and t.tradeDate >= ?2 " +
             "and t.tradeDate <= ?3 " +
             "and t.status = ?4 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findIncomeByOwnerAndDateRange(
         owner: SystemUser,
@@ -129,7 +129,7 @@ interface TrnAnalysisRepository {
             "and t.tradeDate >= ?2 " +
             "and t.tradeDate <= ?3 " +
             "and t.status = ?4 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findIncomeByPortfoliosAndDateRange(
         portfolioIds: List<String>,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
@@ -33,7 +33,7 @@ interface TrnBrokerRepository {
             "and t.trnType in ('BUY', 'SELL', 'ADD', 'REDUCE') " +
             "and t.asset.marketCode not in ('PRIVATE', 'CASH') " +
             "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
-            "order by t.asset.code, t.tradeDate"
+            "order by t.asset.code, t.tradeDate, t.createdAt"
     )
     fun findByBrokerIdAndOwner(
         brokerId: String,
@@ -62,7 +62,7 @@ interface TrnBrokerRepository {
             "and t.status = ?4 " +
             "and t.asset.marketCode not in ('PRIVATE', 'CASH') " +
             "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
-            "order by t.tradeDate, t.asset.code"
+            "order by t.tradeDate, t.asset.code, t.createdAt"
     )
     fun findAllByBrokerIdForPositions(
         brokerId: String,
@@ -97,7 +97,7 @@ interface TrnBrokerRepository {
             "and b.portfolio = t.portfolio " +
             "and b.asset = t.asset" +
             ") " +
-            "order by t.tradeDate, t.asset.code"
+            "order by t.tradeDate, t.asset.code, t.createdAt"
     )
     fun findBrokerSplits(
         brokerId: String,
@@ -125,7 +125,7 @@ interface TrnBrokerRepository {
             "and t.trnType in ('BUY', 'SELL', 'ADD', 'REDUCE') " +
             "and t.asset.marketCode not in ('PRIVATE', 'CASH') " +
             "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
-            "order by t.asset.code, t.tradeDate"
+            "order by t.asset.code, t.tradeDate, t.createdAt"
     )
     fun findWithNoBroker(
         owner: SystemUser,
@@ -152,7 +152,7 @@ interface TrnBrokerRepository {
             "and t.status = ?3 " +
             "and t.asset.marketCode not in ('PRIVATE', 'CASH') " +
             "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
-            "order by t.tradeDate, t.asset.code"
+            "order by t.tradeDate, t.asset.code, t.createdAt"
     )
     fun findAllWithNoBrokerForPositions(
         owner: SystemUser,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -37,7 +37,7 @@ interface TrnRepository :
             "where t.portfolio.id = ?1 " +
             "and t.tradeDate <= ?2 " +
             "and t.status = ?3 " +
-            "order by t.tradeDate, t.asset.code"
+            "order by t.tradeDate, t.asset.code, t.createdAt"
     )
     fun findByPortfolioId(
         portfolioId: String,
@@ -105,7 +105,7 @@ interface TrnRepository :
             "where t.portfolio.id = ?1 " +
             "and t.asset.id = ?2 " +
             "and t.trnType in (?3) " +
-            "order by t.tradeDate desc, t.asset.code"
+            "order by t.tradeDate desc, t.asset.code, t.createdAt desc"
     )
     fun findByPortfolioIdAndAssetIdAndTrnType(
         portfolioId: String,
@@ -123,7 +123,7 @@ interface TrnRepository :
             "where t.portfolio.id = ?1 " +
             "and t.asset.id = ?2 " +
             "and t.tradeDate <= ?3 " +
-            "order by t.tradeDate asc"
+            "order by t.tradeDate asc, t.createdAt asc"
     )
     fun findByPortfolioIdAndAssetIdUpTo(
         id: String,
@@ -140,7 +140,7 @@ interface TrnRepository :
             "left join fetch t.cashCurrency " +
             "where t.portfolio.id = ?1 " +
             "and t.asset.id = ?2 " +
-            "order by t.tradeDate asc"
+            "order by t.tradeDate asc, t.createdAt asc"
     )
     fun findByPortfolioIdAndAssetId(
         portfolioId: String,
@@ -159,7 +159,7 @@ interface TrnRepository :
             "and t.trnType = ?3 " +
             "and t.tradeDate >= ?4 " +
             "and t.tradeDate <= ?5 " +
-            "order by t.tradeDate asc"
+            "order by t.tradeDate asc, t.createdAt asc"
     )
     fun findExisting(
         portfolio: String,
@@ -181,7 +181,7 @@ interface TrnRepository :
             "left join fetch t.cashCurrency " +
             "where t.portfolio.id = ?1 " +
             "and t.status = ?2 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByPortfolioIdAndStatus(
         portfolioId: String,
@@ -204,7 +204,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.trnType in (?2) " +
             "and t.tradeDate <= ?3 " +
-            "order by t.tradeDate asc"
+            "order by t.tradeDate asc, t.createdAt asc"
     )
     fun findDueEventTransactions(
         status: TrnStatus,
@@ -228,7 +228,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate <= ?3 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioOwner(
         status: TrnStatus,
@@ -262,7 +262,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
             "and t.tradeDate <= ?3 " +
-            "order by t.tradeDate desc"
+            "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioIdIn(
         status: TrnStatus,
@@ -296,7 +296,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate = ?3 " +
-            "order by t.portfolio.code, t.asset.code"
+            "order by t.portfolio.code, t.asset.code, t.createdAt"
     )
     fun findByStatusAndPortfolioOwnerAndTradeDate(
         status: TrnStatus,
@@ -348,7 +348,7 @@ interface TrnRepository :
             "where t.portfolio.id = ?1 " +
             "and t.modelId = ?2 " +
             "and t.status = ?3 " +
-            "order by t.tradeDate asc"
+            "order by t.tradeDate asc, t.createdAt asc"
     )
     fun findByPortfolioIdAndModelId(
         portfolioId: String,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnTradeOrderingTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnTradeOrderingTest.kt
@@ -1,0 +1,171 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.contracts.FxPairResults
+import com.beancounter.common.contracts.FxResponse
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants
+import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.NYSE
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.assets.DefaultEnricher
+import com.beancounter.marketdata.assets.EnrichmentFactory
+import com.beancounter.marketdata.assets.figi.FigiProxy
+import com.beancounter.marketdata.fx.FxRateService
+import com.beancounter.marketdata.utils.BcMvcHelper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Same-day transactions must order deterministically. When an onboarding BALANCE
+ * and a later-entered ADD share a tradeDate, the trades view (newest-first) must
+ * tie-break on createdAt so the order is stable rather than depending on the
+ * database's row order. See [TrnRepository.findByPortfolioIdAndAssetIdAndTrnType].
+ */
+@SpringMvcDbTest
+class TrnTradeOrderingTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    lateinit var assetService: AssetService
+
+    @Autowired
+    lateinit var trnService: TrnService
+
+    @Autowired
+    lateinit var trnRepository: TrnRepository
+
+    @MockitoBean
+    private lateinit var figiProxy: FigiProxy
+
+    @MockitoBean
+    private lateinit var fxClientService: FxRateService
+
+    @MockitoBean
+    private lateinit var fxTransactions: FxTransactions
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @Autowired
+    private lateinit var enrichmentFactory: EnrichmentFactory
+
+    @Autowired
+    private lateinit var defaultEnricher: DefaultEnricher
+
+    private lateinit var bcMvcHelper: BcMvcHelper
+
+    @BeforeEach
+    fun setupObjects() {
+        bcMvcHelper =
+            BcMvcHelper(
+                mockMvc,
+                mockAuthConfig.getUserToken(Constants.systemUser)
+            )
+        bcMvcHelper.registerUser()
+        enrichmentFactory.register(defaultEnricher)
+        Mockito
+            .`when`(
+                fxClientService.getRates(any(), any())
+            ).thenReturn(FxResponse(FxPairResults()))
+    }
+
+    @Test
+    fun `same-day trades tie-break on createdAt newest-first`() {
+        val equity =
+            assetService
+                .handle(
+                    AssetRequest(AssetInput(NYSE.code, MSFT.code), MSFT.code)
+                ).data[MSFT.code]
+        assertThat(equity).isNotNull
+
+        val portfolio =
+            bcMvcHelper.portfolio(
+                PortfolioInput(code = "tradeOrderTest", currency = USD.code)
+            )
+
+        val tradeDate = LocalDate.parse("2026-06-24")
+
+        // BALANCE entered first (onboarding), then ADD (payslip) on the same day.
+        // Separate save calls so createdAt differs by wall-clock.
+        val balance =
+            trnService
+                .save(
+                    portfolio,
+                    TrnRequest(
+                        portfolio.id,
+                        listOf(
+                            TrnInput(
+                                callerRef = CallerRef(),
+                                assetId = equity!!.id,
+                                trnType = TrnType.BALANCE,
+                                tradeDate = tradeDate,
+                                quantity = BigDecimal("273000.00"),
+                                price = BigDecimal.ZERO,
+                                tradeAmount = BigDecimal("273000.00"),
+                                status = TrnStatus.SETTLED
+                            )
+                        )
+                    )
+                ).first()
+
+        val add =
+            trnService
+                .save(
+                    portfolio,
+                    TrnRequest(
+                        portfolio.id,
+                        listOf(
+                            TrnInput(
+                                callerRef = CallerRef(),
+                                assetId = equity.id,
+                                trnType = TrnType.ADD,
+                                tradeDate = tradeDate,
+                                quantity = BigDecimal("2312.50"),
+                                price = BigDecimal.ONE,
+                                tradeAmount = BigDecimal("2312.50"),
+                                status = TrnStatus.SETTLED
+                            )
+                        )
+                    )
+                ).first()
+
+        // Precondition: ADD was created after BALANCE.
+        assertThat(add.createdAt).isAfter(balance.createdAt)
+
+        val trades =
+            trnRepository
+                .findByPortfolioIdAndAssetIdAndTrnType(
+                    portfolio.id,
+                    equity.id,
+                    listOf(TrnType.BALANCE, TrnType.ADD)
+                ).toList()
+
+        assertThat(trades)
+            .extracting<TrnType> { it.trnType }
+            .containsExactly(TrnType.ADD, TrnType.BALANCE)
+    }
+}


### PR DESCRIPTION
Same-day transactions had no deterministic order: most Trn queries sorted on `tradeDate` (and sometimes `asset.code`) only, leaving same-date rows in DB row order. An onboarding BALANCE and a same-day ADD could render in either order. Trn ids are random UUIDs; the entity already carries `createdAt` for this purpose but only the cash-ladder query used it.

## Change
Added `t.createdAt` as the final ORDER BY tie-break to every tradeDate-ordered query in `TrnRepository`, `TrnBrokerRepository`, `TrnAnalysisRepository`. Direction follows each query's `tradeDate` direction:
- `tradeDate desc` (display/analysis) → `createdAt desc` (newest-entered first)
- `tradeDate asc` (position replay) → `createdAt asc` (BALANCE before same-day ADD = correct cost basis)

Cash-ladder query unchanged (already tie-broke on createdAt).

## Test
`TrnTradeOrderingTest` — same-day BALANCE + ADD, asserts deterministic newest-first order. Red without the fix, green with.

@coderabbitai ignore