### PR TITLE
fix(svc-data): degrade MarketStack 422 no_valid_symbols to empty price

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackGateway.kt
@@ -2,8 +2,10 @@ package com.beancounter.marketdata.providers.marketstack
 
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackTickerResponse
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
@@ -15,17 +17,33 @@ class MarketStackGateway(
     @Qualifier("marketStackRestClient")
     private val restClient: RestClient
 ) {
+    private val log = LoggerFactory.getLogger(MarketStackGateway::class.java)
+
     fun getPrices(
         assetId: String,
         date: String,
         apiKey: String = "demo"
     ): MarketStackResponse =
-        restClient
-            .get()
-            .uri("/v2/eod/{date}?symbols={assets}&access_key={apiKey}", date, assetId, apiKey)
-            .retrieve()
-            .body<MarketStackResponse>()
-            ?: MarketStackResponse(emptyList(), null)
+        try {
+            restClient
+                .get()
+                .uri("/v2/eod/{date}?symbols={assets}&access_key={apiKey}", date, assetId, apiKey)
+                .retrieve()
+                .body<MarketStackResponse>()
+                ?: MarketStackResponse(emptyList(), null)
+        } catch (e: HttpClientErrorException) {
+            // DATA-5T: MarketStack answers 422 no_valid_symbols_provided when none of the
+            // requested tickers are valid - e.g. a cash/fund asset priced via
+            // GET /assets/{id}?includePrice=true. Degrade to an empty response so the proxy
+            // fills zero-price placeholders instead of letting the 422 surface as a 500.
+            // Any other client error (bad key, rate limit) still propagates.
+            if (e.statusCode.value() == 422 && e.responseBodyAsString.contains("no_valid_symbols_provided")) {
+                log.warn("MarketStack rejected all symbols [{}] on {} - no valid tickers", assetId, date)
+                MarketStackResponse(emptyList(), null)
+            } else {
+                throw e
+            }
+        }
 
     fun getHistory(
         symbol: String,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
@@ -203,6 +203,45 @@ internal class MarketStackApiTest {
     }
 
     @Test
+    fun `returns zero price when marketstack rejects all symbols with 422`() {
+        // DATA-5T: MarketStack returns the no_valid_symbols_provided body with HTTP 422
+        // (not 200) when an asset has no MarketStack-valid ticker - e.g. a cash/fund asset
+        // priced via GET /assets/{id}?includePrice=true. The gateway must degrade to a zero
+        // price rather than letting the 422 bubble to a 500.
+        val inputs = listOf(PriceAsset(MSFT))
+        wireMock.stubFor(
+            WireMock
+                .get(WireMock.urlPathEqualTo("/v2/eod/$priceDate"))
+                .withQueryParam("symbols", WireMock.equalTo(MSFT.code))
+                .withQueryParam("access_key", WireMock.equalTo("demo"))
+                .willReturn(
+                    WireMock
+                        .aResponse()
+                        .withHeader(
+                            HttpHeaders.CONTENT_TYPE,
+                            MediaType.APPLICATION_JSON_VALUE
+                        ).withBody(
+                            ClassPathResource("$CONTRACTS/no-data.json").file.readText()
+                        ).withStatus(422)
+                )
+        )
+        val prices =
+            marketStackService.getMarketData(
+                PriceRequest(
+                    priceDate,
+                    inputs
+                )
+            )
+        assertThat(prices).hasSize(inputs.size)
+        assertThat(
+            prices.first()
+        ).hasFieldOrPropertyWithValue(
+            closeField,
+            BigDecimal.ZERO
+        )
+    }
+
+    @Test
     fun `nzx market is correctly resolved and appended so Asset Price returns`() {
         val fph = getTestAsset(NZX, "FPH")
         val inputs = listOf(PriceAsset(fph))


### PR DESCRIPTION
MarketStack returns no_valid_symbols_provided with HTTP 422 when an asset
has no valid ticker (e.g. cash/fund priced via GET /assets/{id}?includePrice).
The gateway let the 422 surface as a 500. Catch that exact signature and
return an empty response so the proxy fills zero-price placeholders.

Fixes DATA-5T