### PR TITLE
fix(svc-data): authenticate CSV-import consumer + tolerate transient FIGI failures

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiProxy.kt
@@ -6,6 +6,7 @@ import io.github.resilience4j.ratelimiter.annotation.RateLimiter
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
+import org.springframework.web.client.ResourceAccessException
 import java.util.Locale
 
 /**
@@ -48,7 +49,16 @@ class FigiProxy internal constructor(
                 bcAssetCode,
                 market
             )
-        val response = resolve(figiSearch)
+        val response =
+            try {
+                resolve(figiSearch)
+            } catch (e: ResourceAccessException) {
+                // DATA-4Z: a transient OpenFIGI I/O blip (api.openfigi.com: Try again) must not
+                // abort the caller. Degrade to no enrichment so the chain falls back to the
+                // default enricher rather than dead-lettering an async CSV-import message.
+                log.warn("FIGI lookup failed for {}/{} - {}; falling back", figiMarket, figiCode, e.message)
+                return null
+            }
         if (response?.error != null) {
             // Hard error (rate-limit / auth). Return null so the enricher chain falls
             // back to the default enricher rather than persisting a null-named asset.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnStreamConsumers.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnStreamConsumers.kt
@@ -1,10 +1,13 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.auth.client.LoginService
 import com.beancounter.common.input.TrustedTrnEvent
 import com.beancounter.common.input.TrustedTrnImportRequest
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.core.context.SecurityContextHolder
 import java.util.function.Consumer
 
 /**
@@ -13,21 +16,46 @@ import java.util.function.Consumer
  */
 @Configuration
 class TrnStreamConsumers(
-    private val trnImportService: TrnImportService
+    private val trnImportService: TrnImportService,
+    // ObjectProvider: LoginService is gated on auth.enabled=true, so it is absent from
+    // no-auth test contexts (contracts profile). Resolve it lazily and only establish the
+    // M2M context when present — auth-disabled contexts need no service token.
+    private val loginService: ObjectProvider<LoginService>
 ) {
     private val log = LoggerFactory.getLogger(TrnStreamConsumers::class.java)
 
     @Bean
     fun csvImportConsumer(): Consumer<TrustedTrnImportRequest> =
         Consumer { request ->
-            log.trace("Processing CSV import request: {}", request)
-            trnImportService.fromCsvImport(request)
+            withServiceContext {
+                log.trace("Processing CSV import request: {}", request)
+                trnImportService.fromCsvImport(request)
+            }
         }
 
     @Bean
     fun trnEventConsumer(): Consumer<TrustedTrnEvent> =
         Consumer { event ->
-            log.trace("Processing transaction event: {}", event)
-            trnImportService.fromTrnRequest(event)
+            withServiceContext {
+                log.trace("Processing transaction event: {}", event)
+                trnImportService.fromTrnRequest(event)
+            }
         }
+
+    /**
+     * DATA-4Z: AMQP consumer threads carry no SecurityContext, so any downstream
+     * getOrThrow()/isServiceToken() threw UnauthorizedException("Not authorised") and the
+     * message dead-lettered after exhausting the retry policy. Establish the cached M2M
+     * service token for the duration of processing, then clear it so nothing leaks onto the
+     * pooled thread.
+     */
+    private fun <T> withServiceContext(block: () -> T): T {
+        val login = loginService.ifAvailable ?: return block()
+        return try {
+            login.setAuthContext(login.loginM2m())
+            block()
+        } finally {
+            SecurityContextHolder.clearContext()
+        }
+    }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiProxyAliasTest.kt
@@ -14,8 +14,36 @@ import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
+import org.springframework.web.client.ResourceAccessException
 
 class FigiProxyAliasTest {
+    @Test
+    fun `find returns null when FIGI gateway throws a transient IO error`() {
+        // DATA-4Z: a transient OpenFIGI I/O blip (api.openfigi.com: Try again) used to
+        // propagate out of find(), abort the whole CSV-import message and exhaust the AMQP
+        // retry policy. find() must instead return null so the enricher chain falls back to
+        // the default enricher and the import continues rather than dead-lettering.
+        val config = Mockito.mock(FigiConfig::class.java)
+        whenever(config.apiKey).thenReturn("demoxx")
+        val gateway = Mockito.mock(FigiGateway::class.java)
+        val adapter = Mockito.mock(FigiAdapter::class.java)
+        val proxy = FigiProxy(config, gateway, adapter)
+        val lse = Market(code = "LSE", aliases = mapOf(FigiProxy.FIGI to "LN"))
+
+        whenever(gateway.search(any(), eq("demoxx")))
+            .thenThrow(
+                ResourceAccessException(
+                    "I/O error on POST request for \"https://api.openfigi.com/v3/mapping\": " +
+                        "api.openfigi.com: Try again"
+                )
+            )
+
+        val result = proxy.find(lse, "ANY")
+
+        assertThat(result).isNull()
+        Mockito.verifyNoInteractions(adapter)
+    }
+
     @Test
     fun `find skips FIGI and returns null when the market has no FIGI alias`() {
         // DATA-5K: enriching an asset on a market without a FIGI exchange alias

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnStreamConsumersTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnStreamConsumersTest.kt
@@ -1,0 +1,91 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.AuthConfig
+import com.beancounter.auth.TokenService
+import com.beancounter.auth.client.LoginService
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.auth.model.OpenIdResponse
+import com.beancounter.common.input.TrustedTrnImportRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+/**
+ * DATA-4Z: the RabbitMQ CSV-import consumer runs on a thread with no SecurityContext, so any
+ * downstream getOrThrow()/isServiceToken() threw UnauthorizedException("Not authorised") and the
+ * message dead-lettered after exhausting the AMQP retry policy. The consumer must establish an
+ * M2M service auth context before processing and clear it afterwards.
+ */
+class TrnStreamConsumersTest {
+    @AfterEach
+    fun clearContext() = SecurityContextHolder.clearContext()
+
+    private fun serviceToken(): JwtAuthenticationToken {
+        val jwt =
+            Jwt
+                .withTokenValue("m2m")
+                .header("alg", "none")
+                .claim("scope", AuthConstants.SYSTEM)
+                .build()
+        return JwtAuthenticationToken(jwt)
+    }
+
+    @Test
+    fun `csv consumer processes inside an M2M service context and clears it afterwards`() {
+        val authConfig = mock<AuthConfig>()
+        whenever(authConfig.clientSecret).thenReturn("secret")
+        val loginService = mock<LoginService>()
+        whenever(loginService.authConfig).thenReturn(authConfig)
+        whenever(loginService.loginM2m(any())).thenReturn(mock<OpenIdResponse>())
+        whenever(loginService.setAuthContext(any())).thenAnswer {
+            SecurityContextHolder.getContext().authentication = serviceToken()
+            it.arguments[0]
+        }
+
+        val tokenService = TokenService(mock<AuthConfig>())
+        var serviceTokenDuringProcessing: Boolean? = null
+        val importService = mock<TrnImportService>()
+        whenever(importService.fromCsvImport(any())).thenAnswer {
+            serviceTokenDuringProcessing = tokenService.isServiceToken
+            emptySet<Any>()
+        }
+
+        val consumers = TrnStreamConsumers(importService, providerFor(loginService))
+        consumers.csvImportConsumer().accept(mock<TrustedTrnImportRequest>())
+
+        // getOrThrow() -> isServiceAccount() -> isServiceToken would have resolved during processing.
+        assertThat(serviceTokenDuringProcessing).isTrue()
+        // Context must not leak onto the pooled AMQP thread.
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    @Test
+    fun `csv consumer still processes when no LoginService is configured`() {
+        // auth.enabled=false contexts (e.g. the contracts test profile) have no LoginService
+        // bean. The consumer must still process the message rather than failing to construct.
+        var processed = false
+        val importService = mock<TrnImportService>()
+        whenever(importService.fromCsvImport(any())).thenAnswer {
+            processed = true
+            emptySet<Any>()
+        }
+
+        val consumers = TrnStreamConsumers(importService, providerFor(null))
+        consumers.csvImportConsumer().accept(mock<TrustedTrnImportRequest>())
+
+        assertThat(processed).isTrue()
+    }
+
+    private fun providerFor(loginService: LoginService?): ObjectProvider<LoginService> {
+        val provider = mock<ObjectProvider<LoginService>>()
+        whenever(provider.ifAvailable).thenReturn(loginService)
+        return provider
+    }
+}


### PR DESCRIPTION
RabbitMQ consumer threads carry no SecurityContext, so getOrThrow()/
isServiceToken() during an import threw UnauthorizedException and the message
dead-lettered after exhausting the AMQP retry policy. loginM2m() is @Cacheable
so its internal setAuthContext is skipped on a cache hit - establish the M2M
service context explicitly per message and clear it afterwards.

Also degrade a transient OpenFIGI I/O blip (Try again) to no enrichment so a
network flake falls back to the default enricher instead of aborting the import.

Fixes DATA-4Z