### PR TITLE
fix(offboard): clear settlement accounts before assets in wealth/asset delete

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -81,6 +81,11 @@ class OffboardingService(
             )
         }
 
+        // Clear settlement accounts before assets: broker_settlement_account has a NO-ACTION
+        // FK to the cash asset (fk_settlement_account), so the asset delete below trips that
+        // constraint unless the settlement rows are gone first.
+        brokerSettlementAccountRepository.deleteByBrokerOwnerId(user.id)
+
         var deletedCount = 0
         assets.forEach { asset ->
             trnRepository.deleteByAssetId(asset.id)
@@ -147,7 +152,12 @@ class OffboardingService(
         portfolioRepository.deleteByOwnerId(user.id)
         totalDeleted += portfolios.size
 
-        // 2. Delete assets and their data
+        // 2. Clear settlement accounts BEFORE assets. broker_settlement_account has a NO-ACTION
+        //    FK to the cash asset (fk_settlement_account); the asset delete below rolls back the
+        //    whole wealth delete (kauri 409) unless the settlement rows are cleared first.
+        brokerSettlementAccountRepository.deleteByBrokerOwnerId(user.id)
+
+        // 3. Delete assets and their data
         val assets = assetRepository.findBySystemUserId(user.id)
         assets.forEach { asset ->
             trnRepository.deleteByAssetId(asset.id)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
@@ -454,6 +454,74 @@ class OffboardingServiceTest {
         assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
     }
 
+    // Regression guard (kauri 409): the wealth path deletes the user's assets, so it must
+    // clear broker_settlement_account first — same NO-ACTION fk_settlement_account constraint
+    // that the account path already handles. Without it the asset delete rolls back the whole
+    // wealth delete and the offboarding wizard reports a partial failure.
+    @Test
+    fun `should delete wealth when a settlement account references a user asset`() {
+        val user = SystemUser(id = "offboard-wealth-settlement-user", email = "offboard-wealth-settlement@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "test" to
+                                AssetInput.toRealEstate(
+                                    currency = USD,
+                                    code = "OFFBOARD-WEALTH-SETTLE-CASH",
+                                    name = "Wealth Settlement Cash Asset",
+                                    owner = user.id
+                                )
+                        )
+                    )
+                ).data["test"]!!
+        val broker = brokerRepository.save(Broker(name = "Wealth Settlement Broker", owner = user))
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = asset)
+        )
+
+        val result = offboardingService.deleteUserWealth()
+
+        assertThat(result.success).isTrue()
+        assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
+    }
+
+    // Regression guard (kauri 409): the assets path has the same FK exposure as the wealth and
+    // account paths — clear broker_settlement_account before deleting the referenced cash asset.
+    @Test
+    fun `should delete assets when a settlement account references a user asset`() {
+        val user = SystemUser(id = "offboard-assets-settlement-user", email = "offboard-assets-settlement@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        val asset =
+            assetService
+                .handle(
+                    AssetRequest(
+                        mapOf(
+                            "test" to
+                                AssetInput.toRealEstate(
+                                    currency = USD,
+                                    code = "OFFBOARD-ASSETS-SETTLE-CASH",
+                                    name = "Assets Settlement Cash Asset",
+                                    owner = user.id
+                                )
+                        )
+                    )
+                ).data["test"]!!
+        val broker = brokerRepository.save(Broker(name = "Assets Settlement Broker", owner = user))
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = asset)
+        )
+
+        val result = offboardingService.deleteUserAssets()
+
+        assertThat(result.success).isTrue()
+        assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
+    }
+
     // Soft-delete: offboarding deletes the user's DATA but keeps the SystemUser row
     // marked inactive (re-registration reactivates it). cash_portfolio_id must be
     // cleared so the surviving row does not dangle a deleted portfolio.


### PR DESCRIPTION
deleteUserWealth and deleteUserAssets deleted the cash asset without first
removing broker_settlement_account, tripping fk_settlement_account and rolling
back the whole delete (kauri 409 partial-failure). Mirror the account path.