### PR TITLE
fix(svc-position): aggregate positions per-portfolio to stop split double-count

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.TrustedTrnQuery
 import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Currency
+import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.PortfolioBreakdown
 import com.beancounter.common.model.Position
@@ -49,6 +50,7 @@ class ValuationService
         private val dateUtils: DateUtils
     ) : Valuation {
         private val log = LoggerFactory.getLogger(ValuationService::class.java)
+        private val averageCost = AverageCost()
 
         override fun build(trnQuery: TrustedTrnQuery): PositionResponse {
             val trnResponse = trnService.query(trnQuery) // Adhoc query
@@ -153,26 +155,35 @@ class ValuationService
                         }.awaitAll()
                 }
 
-            // Combine all transactions and sort by trade date
-            // Sorting is required because the Accumulator validates date sequence
-            val combinedTransactions =
-                portfolioTransactions
-                    .flatMap { it.second.data.toTrns() }
-                    .sortedBy { it.tradeDate }
+            // Accumulate each portfolio's positions INDEPENDENTLY, then sum them.
+            //
+            // The previous approach merged every portfolio's transactions into a
+            // single stream and re-accumulated it. That double-applied any
+            // corporate action recorded per-portfolio: a 4:1 split written into
+            // each holding portfolio compounded across the combined balance
+            // (24 real shares reported as 186), and a SELL in one portfolio drew
+            // down a pooled average cost that included another portfolio's lot.
+            // Accumulating per portfolio keeps each split and cost basis local;
+            // summing the results yields the correct aggregate.
+            val perPortfolioPositions =
+                portfolioTransactions.mapNotNull { (portfolio, trnResponse) ->
+                    val trns = trnResponse.data.toTrns()
+                    if (trns.isEmpty()) {
+                        null
+                    } else {
+                        portfolio to positionService.build(portfolio, PositionRequest(portfolio.id, trns)).data
+                    }
+                }
 
-            if (combinedTransactions.isEmpty()) {
+            if (perPortfolioPositions.isEmpty()) {
                 return PositionResponse()
             }
 
             // Use the first portfolio as context for owner / ids. When the
-            // caller passes a [targetCurrencyCode] (the user-visible
-            // reporting currency), adopt that currency on the synthesised
-            // context portfolio so MarketValue prices each PORTFOLIO bucket
-            // directly against the user's target. Without this the bucket
-            // ends up in portfolios.first().currency and a separate
-            // convertPositionsToCurrency step has to FX-back to target — a
-            // round-trip whose inverse-rate imprecision shows up as drift
-            // on PRIVATE / POLICY (constant `close=1`) positions.
+            // caller passes a [targetCurrencyCode] (the user-visible reporting
+            // currency), adopt it on the synthesised context portfolio so
+            // MarketValue prices each PORTFOLIO bucket directly against the
+            // target rather than via a lossy FX round-trip.
             val baseContext = portfolios.first()
             val contextPortfolio =
                 if (!targetCurrencyCode.isNullOrBlank() &&
@@ -185,55 +196,117 @@ class ValuationService
                     baseContext
                 }
 
-            // Build positions from combined transactions using the normal accumulation flow
-            val positionRequest =
-                PositionRequest(
-                    contextPortfolio.id,
-                    combinedTransactions
-                )
-            val positionResponse = positionService.build(contextPortfolio, positionRequest)
+            val aggregated = mergePositions(contextPortfolio, perPortfolioPositions.map { it.second })
 
-            // Attach per-portfolio breakdown so the UI can list which portfolios
-            // hold each asset. Cost/quantity accumulation on the aggregated
-            // position itself is unchanged.
-            applyPortfolioBreakdown(positionResponse.data, portfolioTransactions)
+            // Attach per-portfolio breakdown so the UI can list which portfolios hold each asset.
+            applyPortfolioBreakdown(aggregated, perPortfolioPositions)
 
             if (!valuationDate.equals(DateUtils.TODAY, ignoreCase = true)) {
-                positionResponse.data.asAt = valuationDate
+                aggregated.asAt = valuationDate
             }
 
-            // Value the positions if requested
-            // Pass skipMarketValueUpdate=true since aggregated positions don't belong to a single portfolio
+            // Value the positions if requested.
+            // Pass skipMarketValueUpdate=true since aggregated positions don't belong to a single portfolio.
             return if (value) {
                 value(
-                    positions = positionResponse.data,
+                    positions = aggregated,
                     skipMarketValueUpdate = true
                 )
             } else {
-                positionResponse
+                PositionResponse(aggregated)
             }
         }
 
         /**
-         * For each contributing portfolio, build its own positions and record the
-         * asset quantity it holds, then attach that list to the matching aggregated
-         * position. Portfolios with zero net quantity in an asset are skipped.
+         * Sum independently-accumulated per-portfolio positions into a single
+         * aggregate keyed by asset. Quantities, cost and cash-flow history add
+         * directly; TRADE and BASE buckets share a currency across a user's
+         * portfolios so they sum exactly. The PORTFOLIO bucket adopts the
+         * context (reporting) currency — exact when the portfolios share it.
+         * Market value, gains and IRR are (re)derived later by [value].
+         */
+        private fun mergePositions(
+            contextPortfolio: Portfolio,
+            perPortfolio: List<Positions>
+        ): Positions {
+            val aggregated = Positions(contextPortfolio)
+            perPortfolio.forEach { positions ->
+                positions.positions.values.forEach { source ->
+                    val target = aggregated.getOrCreate(source.asset)
+                    mergeQuantities(target, source)
+                    source.moneyValues.forEach { (bucket, sourceMv) ->
+                        mergeMoneyValues(target.getMoneyValues(bucket, sourceMv.currency), sourceMv)
+                    }
+                    target.periodicCashFlows.addAll(source.periodicCashFlows.cashFlows)
+                    mergeDates(target, source)
+                }
+            }
+            // Restate unit cost from the summed basis so display stays consistent.
+            aggregated.positions.values.forEach { position ->
+                val total = position.quantityValues.getTotal()
+                position.moneyValues.values.forEach { mv ->
+                    mv.averageCost = averageCost.value(mv.costBasis, total)
+                }
+            }
+            return aggregated
+        }
+
+        private fun mergeQuantities(
+            target: Position,
+            source: Position
+        ) {
+            target.quantityValues.purchased = target.quantityValues.purchased.add(source.quantityValues.purchased)
+            target.quantityValues.sold = target.quantityValues.sold.add(source.quantityValues.sold)
+            target.quantityValues.adjustment = target.quantityValues.adjustment.add(source.quantityValues.adjustment)
+        }
+
+        private fun mergeMoneyValues(
+            target: MoneyValues,
+            source: MoneyValues
+        ) {
+            target.costValue = target.costValue.add(source.costValue)
+            target.costBasis = target.costBasis.add(source.costBasis)
+            target.purchases = target.purchases.add(source.purchases)
+            target.sales = target.sales.add(source.sales)
+            target.dividends = target.dividends.add(source.dividends)
+            target.fees = target.fees.add(source.fees)
+            target.expenses = target.expenses.add(source.expenses)
+            target.realisedGain = target.realisedGain.add(source.realisedGain)
+        }
+
+        private fun mergeDates(
+            target: Position,
+            source: Position
+        ) {
+            target.dateValues.firstTransaction =
+                earliest(target.dateValues.firstTransaction, source.dateValues.firstTransaction)
+            target.dateValues.opened = earliest(target.dateValues.opened, source.dateValues.opened)
+        }
+
+        private fun earliest(
+            a: LocalDate?,
+            b: LocalDate?
+        ): LocalDate? =
+            when {
+                a == null -> b
+                b == null -> a
+                else -> if (a.isBefore(b)) a else b
+            }
+
+        /**
+         * For each contributing portfolio, record the asset quantity it holds and
+         * attach that list to the matching aggregated position. Portfolios with
+         * zero net quantity in an asset are skipped.
          */
         private fun applyPortfolioBreakdown(
             aggregated: Positions,
-            portfolioTransactions: List<Pair<Portfolio, TrnResponse>>
+            perPortfolioPositions: List<Pair<Portfolio, Positions>>
         ) {
             if (!aggregated.hasPositions()) return
 
             val breakdownByAsset = mutableMapOf<String, MutableList<PortfolioBreakdown>>()
-            portfolioTransactions.forEach { (portfolio, trnResponse) ->
-                val trns = trnResponse.data.toTrns()
-                if (trns.isEmpty()) return@forEach
-                val perPortfolio =
-                    positionService
-                        .build(portfolio, PositionRequest(portfolio.id, trns))
-                        .data
-                perPortfolio.positions.values.forEach { position ->
+            perPortfolioPositions.forEach { (portfolio, positions) ->
+                positions.positions.values.forEach { position ->
                     val quantity = position.quantityValues.getTotal()
                     if (quantity.signum() == 0) return@forEach
                     breakdownByAsset

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -14,8 +14,14 @@ import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Position
 import com.beancounter.common.model.Positions
 import com.beancounter.common.model.Totals
+import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
+import com.beancounter.position.accumulation.Accumulator
+import com.beancounter.position.accumulation.BuyBehaviour
+import com.beancounter.position.accumulation.SellBehaviour
+import com.beancounter.position.accumulation.SplitBehaviour
+import com.beancounter.position.accumulation.TrnBehaviourFactory
 import com.beancounter.position.service.MarketValueUpdateProducer
 import com.beancounter.position.service.PositionService
 import com.beancounter.position.service.PositionValuationService
@@ -294,14 +300,6 @@ class ValuationServiceTest {
                     }
                 )
             }
-        val aggPositions =
-            Positions(portfolio).apply {
-                add(
-                    Position(asset, portfolio).apply {
-                        quantityValues.purchased = BigDecimal("15")
-                    }
-                )
-            }
 
         whenever(
             positionService.build(
@@ -315,20 +313,16 @@ class ValuationServiceTest {
                 argThat { trns.size == 1 }
             )
         ).thenReturn(PositionResponse(p2Positions))
-        whenever(
-            positionService.build(
-                argThat { id == portfolio.id },
-                argThat { trns.size == 2 }
-            )
-        ).thenReturn(PositionResponse(aggPositions))
 
         // When
         val result = valuationService.getAggregatedPositions(portfolios, DateUtils.TODAY, value = false)
 
-        // Then
+        // Then - the aggregate sums the two holdings (10 + 5)...
         val agg =
             result.data.positions.values
                 .first()
+        assertThat(agg.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal("15"))
+        // ...and lists each contributing portfolio.
         assertThat(agg.portfolioBreakdown).hasSize(2)
         assertThat(agg.portfolioBreakdown.map { it.portfolioId })
             .containsExactlyInAnyOrder(portfolio.id, portfolio2.id)
@@ -395,15 +389,6 @@ class ValuationServiceTest {
                     }
                 )
             }
-        val aggPositions =
-            Positions(portfolio).apply {
-                add(
-                    Position(asset, portfolio).apply {
-                        quantityValues.purchased = BigDecimal("10")
-                    }
-                )
-            }
-
         whenever(
             positionService.build(
                 argThat { id == portfolio.id },
@@ -416,20 +401,16 @@ class ValuationServiceTest {
                 argThat { trns.size == 2 }
             )
         ).thenReturn(PositionResponse(p2Positions))
-        whenever(
-            positionService.build(
-                argThat { id == portfolio.id },
-                argThat { trns.size == 3 }
-            )
-        ).thenReturn(PositionResponse(aggPositions))
 
         // When
         val result = valuationService.getAggregatedPositions(portfolios, DateUtils.TODAY, value = false)
 
-        // Then - only P1 appears in the breakdown
+        // Then - the aggregate nets to P1's 10 (P2 bought then sold 10)...
         val agg =
             result.data.positions.values
                 .first()
+        assertThat(agg.quantityValues.getTotal()).isEqualByComparingTo(BigDecimal("10"))
+        // ...and only P1 appears in the breakdown (P2 is net-zero).
         assertThat(agg.portfolioBreakdown).hasSize(1)
         assertThat(agg.portfolioBreakdown.single().portfolioId).isEqualTo(portfolio.id)
         assertThat(agg.portfolioBreakdown.single().quantity).isEqualByComparingTo(BigDecimal("10"))
@@ -479,12 +460,11 @@ class ValuationServiceTest {
     }
 
     @Test
-    fun `getAggregatedPositions adopts targetCurrency on synthesised context portfolio`() {
+    fun `getAggregatedPositions adopts targetCurrency on the aggregate reporting view`() {
         // Given - first portfolio is USD but the caller requested SGD totals.
-        // Without target-currency adoption, MarketValue would price each
-        // PORTFOLIO bucket in USD and the controller would have to FX-back
-        // to SGD — a round-trip whose imperfect rate-inverse shows up as
-        // ~0.4% drift on PRIVATE / POLICY (constant `close=1`) positions.
+        // The aggregate adopts SGD so its PORTFOLIO bucket is priced directly
+        // against the target rather than via a lossy FX round-trip (the drift
+        // that showed on PRIVATE / POLICY constant-`close=1` positions).
         val usdPortfolio = TestHelpers.createTestPortfolio("usd-pf", currencyCode = "USD")
         val sgdPortfolio = TestHelpers.createTestPortfolio("sgd-pf", currencyCode = "SGD")
         val portfolios = listOf(usdPortfolio, sgdPortfolio)
@@ -502,23 +482,136 @@ class ValuationServiceTest {
         whenever(trnService.query(any<Portfolio>(), any<String>()))
             .thenReturn(TrnResponse(listOf(trn)))
 
-        val contextCaptor = org.mockito.kotlin.argumentCaptor<Portfolio>()
-        whenever(positionService.build(contextCaptor.capture(), any()))
-            .thenReturn(PositionResponse(Positions(usdPortfolio)))
+        val held =
+            Positions(usdPortfolio).apply {
+                add(
+                    Position(asset, usdPortfolio).apply {
+                        quantityValues.purchased = BigDecimal("10")
+                    }
+                )
+            }
+        whenever(positionService.build(any(), any()))
+            .thenReturn(PositionResponse(held))
 
         // When - request aggregation in SGD
-        valuationService.getAggregatedPositions(
-            portfolios,
-            DateUtils.TODAY,
-            value = false,
-            targetCurrencyCode = "SGD"
-        )
+        val result =
+            valuationService.getAggregatedPositions(
+                portfolios,
+                DateUtils.TODAY,
+                value = false,
+                targetCurrencyCode = "SGD"
+            )
 
-        // Then - the context portfolio handed to positionService.build
-        // adopts SGD (not the first portfolio's USD), so downstream
-        // MarketValue prices each bucket directly in SGD.
-        assertThat(contextCaptor.firstValue.currency.code).isEqualTo("SGD")
-        assertThat(contextCaptor.firstValue.id).isEqualTo(usdPortfolio.id)
+        // Then - the aggregate reports in SGD and its PORTFOLIO bucket is
+        // denominated in the target currency.
+        assertThat(result.data.portfolio.currency.code).isEqualTo("SGD")
+        assertThat(result.data.portfolio.id).isEqualTo(usdPortfolio.id)
+        val agg =
+            result.data.positions.values
+                .first()
+        assertThat(agg.getMoneyValues(Position.In.PORTFOLIO).currency.code).isEqualTo("SGD")
+    }
+
+    @Test
+    fun `getAggregatedPositions applies per-portfolio splits once and sums cost across portfolios`() {
+        // Real accumulator: the split / cost-basis logic only misbehaves end-to-end.
+        // A mocked positionService.build cannot reproduce a corporate-action bug.
+        val realPositionService =
+            PositionService(
+                Accumulator(
+                    TrnBehaviourFactory(
+                        listOf(BuyBehaviour(), SellBehaviour(), SplitBehaviour())
+                    )
+                )
+            )
+        val service =
+            ValuationService(
+                positionValuationService,
+                trnService,
+                realPositionService,
+                marketValueUpdateProducer,
+                classificationClient,
+                dateUtils
+            )
+
+        val pfA = TestHelpers.createTestPortfolio("PF-A")
+        val pfB = TestHelpers.createTestPortfolio("PF-B")
+        val vo = TestHelpers.createTestAsset("VO", "US")
+
+        // PF-A: BUY 6 (cost 1801.74) then a 4:1 split -> 24 shares held.
+        val aBuy =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = vo,
+                portfolio = pfA,
+                quantity = BigDecimal("6"),
+                tradeAmount = BigDecimal("1801.74"),
+                tradeDate = LocalDate.of(2026, 1, 27)
+            )
+        val aSplit =
+            Trn(
+                trnType = TrnType.SPLIT,
+                asset = vo,
+                portfolio = pfA,
+                quantity = BigDecimal("4"),
+                tradeDate = LocalDate.of(2026, 4, 21)
+            )
+        // PF-B: BUY 12, the same 4:1 split -> 48, then SELL all 48 -> net zero.
+        val bBuy =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = vo,
+                portfolio = pfB,
+                quantity = BigDecimal("12"),
+                tradeAmount = BigDecimal("3285.00"),
+                tradeDate = LocalDate.of(2024, 12, 18)
+            )
+        val bSplit =
+            Trn(
+                trnType = TrnType.SPLIT,
+                asset = vo,
+                portfolio = pfB,
+                quantity = BigDecimal("4"),
+                tradeDate = LocalDate.of(2026, 4, 21)
+            )
+        val bSell =
+            Trn(
+                trnType = TrnType.SELL,
+                asset = vo,
+                portfolio = pfB,
+                quantity = BigDecimal("48"),
+                tradeAmount = BigDecimal("3812.00"),
+                tradeDate = LocalDate.of(2026, 6, 23)
+            )
+
+        whenever(trnService.query(argThat { id == pfA.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(aBuy, aSplit)))
+        whenever(trnService.query(argThat { id == pfB.id }, any<String>()))
+            .thenReturn(TrnResponse(listOf(bBuy, bSplit, bSell)))
+
+        // When - aggregate without valuation (no market data needed)
+        val result =
+            service.getAggregatedPositions(
+                listOf(pfA, pfB),
+                DateUtils.TODAY,
+                value = false
+            )
+
+        // Then - the asset's split is recorded once per portfolio; merging the
+        // raw transaction streams used to compound it (24 -> 186). Per-portfolio
+        // accumulation + summation must report the real net quantity.
+        val voPosition =
+            result.data.positions.values
+                .first()
+        assertThat(voPosition.quantityValues.getTotal())
+            .describedAs("4:1 split recorded per portfolio must not compound across the aggregate")
+            .isEqualByComparingTo(BigDecimal("24"))
+
+        // And cost must be the sum of each portfolio's own basis, not a pooled
+        // average drawn down by PF-B's sell. PF-B is fully sold -> contributes 0.
+        assertThat(voPosition.getMoneyValues(Position.In.TRADE, vo.market.currency).costValue)
+            .describedAs("aggregate cost = PF-A basis (1801.74); fully-sold PF-B contributes 0")
+            .isEqualByComparingTo(BigDecimal("1801.74"))
     }
 
     @Test


### PR DESCRIPTION
Merging every portfolio's transactions into one stream and re-accumulating
double-applied per-portfolio corporate actions: a 4:1 split written into each
holding portfolio compounded across the combined balance (24 shares reported
as 186), and a SELL in one portfolio drew down a pooled average cost that
included another portfolio's lot. Accumulate each portfolio independently and
sum the results per asset instead.