### PR TITLE
refactor: clear detekt NestedBlockDepth + TooGenericExceptionCaught (codacy cleanup)

### DIFF
--- a/svc-admin/src/main/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProvider.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/BearerTokenHttpHeadersProvider.kt
@@ -74,7 +74,11 @@ class BearerTokenHttpHeadersProvider(
             val accessToken = client.accessToken
             cachedUserToken.set(CachedToken(accessToken.tokenValue, accessToken.expiresAt))
             accessToken.tokenValue
-        } catch (ex: Exception) {
+        } catch (
+            // Token load is best-effort; on any failure fall back to anonymous (null).
+            @Suppress("TooGenericExceptionCaught")
+            ex: Exception
+        ) {
             log.warn("failed to load OAuth2 access token for {}: {}", auth.name, ex.message)
             null
         }

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -201,7 +201,11 @@ class AgentController(
                     timestamp = Instant.now().toString()
                 )
             )
-        } catch (e: Exception) {
+        } catch (
+            // Controller boundary: any LLM/tool failure becomes a 500 error body.
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
             log.error("Agent query failed: {}", e.message, e)
             ResponseEntity
                 .status(500)

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/health/ServiceHealthChecker.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/health/ServiceHealthChecker.kt
@@ -86,7 +86,11 @@ class ServiceHealthChecker(
             } else {
                 ServiceStatus(name = name, status = "DOWN", error = "HTTP ${response.statusCode.value()}")
             }
-        } catch (e: Exception) {
+        } catch (
+            // Any failure (connect/timeout/parse) means the probed service is DOWN.
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
             log.debug("Health probe failed for {} at {}: {}", name, url, e.message)
             ServiceStatus(name = name, status = "DOWN", error = e.message ?: e.javaClass.simpleName)
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityCountMetrics.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/metrics/EntityCountMetrics.kt
@@ -133,7 +133,11 @@ class EntityCountMetrics(
     ): Double =
         try {
             repository.count().toDouble()
-        } catch (ex: Exception) {
+        } catch (
+            // Gauge sampling must never throw into the meter registry; degrade to NaN.
+            @Suppress("TooGenericExceptionCaught")
+            ex: Exception
+        ) {
             log.warn("entity count gauge failed for {}: {}", entity, ex.message)
             Double.NaN
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
@@ -135,7 +135,11 @@ class AlphaNewsService(
         try {
             @Suppress("UNCHECKED_CAST")
             objectMapper.readValue(json, Map::class.java) as Map<String, Any>
-        } catch (e: Exception) {
+        } catch (
+            // Provider JSON is untrusted; malformed payload or shape mismatch → drop the feed.
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
             log.warn("Failed to parse news feed: {}", e.message)
             null
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarPriceService.kt
@@ -42,33 +42,26 @@ class MorningstarPriceService(
         log.info("Morningstar provider initialized for markets: {}", morningstarConfig.markets)
     }
 
-    override fun getMarketData(priceRequest: PriceRequest): Collection<MarketData> {
-        val results = mutableListOf<MarketData>()
+    override fun getMarketData(priceRequest: PriceRequest): Collection<MarketData> =
+        priceRequest.assets.mapNotNull { it.resolvedAsset }.mapNotNull { fetchPrice(it) }
 
-        for ((_, _, resolvedAsset) in priceRequest.assets) {
-            if (resolvedAsset == null) continue
-
-            val priceCode = morningstarConfig.getPriceCode(resolvedAsset)
-            val currencyId = resolvedAsset.market.currency.code
-
-            try {
-                val json = morningstarProxy.getPrice(priceCode, currencyId)
-                if (json != null) {
-                    val marketData = parseResponse(json, resolvedAsset)
-                    if (marketData != null) {
-                        results.add(marketData)
-                    }
-                }
-            } catch (
-                @Suppress("TooGenericExceptionCaught")
-                e: Exception
-            ) {
-                // Continue processing other assets even if one fails
-                log.error("Error fetching price for {}: {}", priceCode, e.message)
-            }
+    /**
+     * Fetch and parse a single asset's price. Returns null (with a logged
+     * warning) on fetch/parse failure so other assets keep processing.
+     */
+    private fun fetchPrice(resolvedAsset: Asset): MarketData? {
+        val priceCode = morningstarConfig.getPriceCode(resolvedAsset)
+        val currencyId = resolvedAsset.market.currency.code
+        return try {
+            val json = morningstarProxy.getPrice(priceCode, currencyId) ?: return null
+            parseResponse(json, resolvedAsset)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception
+        ) {
+            log.error("Error fetching price for {}: {}", priceCode, e.message)
+            null
         }
-
-        return results
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -263,42 +263,43 @@ class TrnService(
         trnIds: List<String>
     ): Collection<Trn> {
         val portfolio = portfolioService.find(portfolioId)
-        val settled = mutableListOf<Trn>()
-        for (trnId in trnIds) {
-            val trnOptional = trnRepository.findByPortfolioIdAndId(portfolio.id, trnId)
-            if (trnOptional.isPresent) {
-                val trn = trnOptional.get()
-                if (trn.status == TrnStatus.PROPOSED) {
-                    if (trn.tradeDate.isAfter(dateUtils.date)) {
-                        log.warn(
-                            "Cannot settle transaction {} - tradeDate {} is in the future",
-                            trnId,
-                            trn.tradeDate
-                        )
-                        continue
-                    }
-                    // Shared settle core: FX + status flip + cash emit. Returns
-                    // null when FX can't resolve yet (leaves it PROPOSED for retry).
-                    val saved = trnSettlementService.settle(portfolio, trn) ?: continue
-                    settled.add(saved)
-                    log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
-                } else {
-                    log.warn(
-                        "Cannot settle transaction {} - status is {} not PROPOSED",
-                        trnId,
-                        trn.status
-                    )
-                }
-            } else {
-                log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
-            }
-        }
+        val settled = trnIds.mapNotNull { settleOne(portfolio, it) }
         log.info("Settled {} transactions for portfolio {}", settled.size, portfolio.code)
         val earliestSettled = settled.minOfOrNull { it.tradeDate }
         if (earliestSettled != null) {
             cacheInvalidationProducer.sendTransactionEvent(portfolio.id, earliestSettled)
         }
         return postProcess(settled)
+    }
+
+    /**
+     * Settle a single PROPOSED transaction. Returns the settled Trn, or null
+     * (with a warning) when it is missing, not PROPOSED, future-dated, or FX
+     * can't resolve yet (leaving it PROPOSED for retry).
+     */
+    private fun settleOne(
+        portfolio: Portfolio,
+        trnId: String
+    ): Trn? {
+        val trn =
+            trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
+                ?: run {
+                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
+                    return null
+                }
+        if (trn.status != TrnStatus.PROPOSED) {
+            log.warn("Cannot settle transaction {} - status is {} not PROPOSED", trnId, trn.status)
+            return null
+        }
+        if (trn.tradeDate.isAfter(dateUtils.date)) {
+            log.warn("Cannot settle transaction {} - tradeDate {} is in the future", trnId, trn.tradeDate)
+            return null
+        }
+        // Shared settle core: FX + status flip + cash emit. Returns null when FX
+        // can't resolve yet (leaves it PROPOSED for retry).
+        val saved = trnSettlementService.settle(portfolio, trn) ?: return null
+        log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
+        return saved
     }
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
@@ -42,7 +42,12 @@ class TrnSettlementService(
             // Resolve FX now that settlement is confirmed. Ingest of forward-dated
             // event trns (DIVI payDate) defers FX; providers reject future dates.
             fxTransactions.setRates(portfolio, trn)
-        } catch (ex: RuntimeException) {
+        } catch (
+            // FX providers throw a range of runtime errors (rate lookup, parse,
+            // future-date rejection); any of them means "can't settle yet".
+            @Suppress("TooGenericExceptionCaught")
+            ex: RuntimeException
+        ) {
             log.warn(
                 "FX resolution failed for {} on {} — leaving PROPOSED for retry: {}",
                 trn.id,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/metrics/TrnMetricsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/metrics/TrnMetricsTest.kt
@@ -305,7 +305,11 @@ class TrnMetricsTest {
                 @Suppress("TooGenericExceptionThrown")
                 throw RuntimeException("test exception")
             }
-        } catch (e: RuntimeException) {
+        } catch (
+            // Asserting the propagated test exception is the point of this test.
+            @Suppress("TooGenericExceptionCaught")
+            e: RuntimeException
+        ) {
             assertThat(e.message).isEqualTo("test exception")
         }
 

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -280,29 +280,20 @@ class PerformanceService(
         var cumulativeDividends = BigDecimal.ZERO
 
         for (valDate in valuationDates) {
-            var cashFlowOnDate = BigDecimal.ZERO
-
             // Accumulate transactions up to and including this date
-            while (trnIndex < transactions.size && !transactions[trnIndex].tradeDate.isAfter(valDate)) {
-                val trn = transactions[trnIndex]
-                accumulator.accumulate(trn, positions)
-
-                if (isExternalCashFlow(trn.trnType)) {
-                    val amount = convertCashFlowToPortfolioCurrency(trn, portfolio)
-                    netContributions = netContributions.add(amount)
-                    if (trn.tradeDate == valDate) {
-                        cashFlowOnDate = cashFlowOnDate.add(amount)
-                    }
-                }
-
-                if (trn.trnType == TrnType.DIVI) {
-                    cumulativeDividends =
-                        cumulativeDividends.add(
-                            convertDividendToPortfolioCurrency(trn, portfolio)
-                        )
-                }
-                trnIndex++
-            }
+            val acc =
+                accumulateUpTo(
+                    valDate,
+                    transactions,
+                    positions,
+                    portfolio,
+                    trnIndex,
+                    netContributions,
+                    cumulativeDividends
+                )
+            trnIndex = acc.trnIndex
+            netContributions = acc.netContributions
+            cumulativeDividends = acc.cumulativeDividends
 
             val marketValue = valuePositionsFromCache(positions, valDate, portfolio, priceCache, fxCache)
 
@@ -310,7 +301,7 @@ class PerformanceService(
                 ValuationSnapshot(
                     date = valDate,
                     marketValue = marketValue,
-                    externalCashFlow = cashFlowOnDate
+                    externalCashFlow = acc.cashFlowOnDate
                 )
             )
             netContributionsList.add(netContributions)
@@ -318,6 +309,55 @@ class PerformanceService(
         }
 
         return Triple(snapshots, netContributionsList, cumulativeDividendsList)
+    }
+
+    /** Running totals after accumulating all transactions up to a valuation date. */
+    private data class DateAccumulation(
+        val trnIndex: Int,
+        val netContributions: BigDecimal,
+        val cumulativeDividends: BigDecimal,
+        val cashFlowOnDate: BigDecimal
+    )
+
+    /**
+     * Accumulates transactions into [positions] up to and including [valDate],
+     * advancing from [startIndex] and folding contributions/dividends onto the
+     * running totals. Mutates [positions]; returns the updated scalar totals.
+     */
+    private fun accumulateUpTo(
+        valDate: LocalDate,
+        transactions: List<Trn>,
+        positions: Positions,
+        portfolio: Portfolio,
+        startIndex: Int,
+        startNetContributions: BigDecimal,
+        startCumulativeDividends: BigDecimal
+    ): DateAccumulation {
+        var trnIndex = startIndex
+        var netContributions = startNetContributions
+        var cumulativeDividends = startCumulativeDividends
+        var cashFlowOnDate = BigDecimal.ZERO
+
+        while (trnIndex < transactions.size && !transactions[trnIndex].tradeDate.isAfter(valDate)) {
+            val trn = transactions[trnIndex]
+            accumulator.accumulate(trn, positions)
+
+            if (isExternalCashFlow(trn.trnType)) {
+                val amount = convertCashFlowToPortfolioCurrency(trn, portfolio)
+                netContributions = netContributions.add(amount)
+                if (trn.tradeDate == valDate) {
+                    cashFlowOnDate = cashFlowOnDate.add(amount)
+                }
+            }
+
+            if (trn.trnType == TrnType.DIVI) {
+                cumulativeDividends =
+                    cumulativeDividends.add(convertDividendToPortfolioCurrency(trn, portfolio))
+            }
+            trnIndex++
+        }
+
+        return DateAccumulation(trnIndex, netContributions, cumulativeDividends, cashFlowOnDate)
     }
 
     private fun convertDividendToPortfolioCurrency(


### PR DESCRIPTION
Codacy cleanup, two patterns, code-only.

- **NestedBlockDepth (3)**: flatten via extracted guard-clause helpers — settleOne, fetchPrice, accumulateUpTo.
- **TooGenericExceptionCaught (7)**: @Suppress + rationale on intentional degrade-gracefully boundaries (health probe, gauge, token load, JSON parse, controller, FX retry, test).

Verified: Codacy CLI clean on all touched files; format + lint + testSmart + svc-agent tests pass.

Note: TooManyFunctions (74) and LongParameterList (27) excluded — Codacy cloud ignores the repo detekt.yaml (default params, no test-excludes), so config tuning can't clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)