### PR TITLE
refactor(trn): split TrnService god-class to clear detekt TooManyFunctions

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PortfolioPriceBackfillService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PortfolioPriceBackfillService.kt
@@ -5,7 +5,7 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.CashUtils
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.portfolio.PortfolioService
-import com.beancounter.marketdata.trn.TrnService
+import com.beancounter.marketdata.trn.TrnFinder
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -18,7 +18,7 @@ import java.time.LocalDate
 @Service
 class PortfolioPriceBackfillService(
     private val portfolioService: PortfolioService,
-    private val trnService: TrnService,
+    private val trnFinder: TrnFinder,
     private val priceProcessor: MarketDataPriceProcessor,
     private val providerUtils: ProviderUtils,
     private val dateUtils: DateUtils,
@@ -30,7 +30,7 @@ class PortfolioPriceBackfillService(
         val portfolio = portfolioService.findByCode(code)
         val today = dateUtils.date
         val transactions =
-            trnService
+            trnFinder
                 .findForPortfolio(portfolio, today)
                 .sortedBy { it.tradeDate }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -53,6 +53,8 @@ import org.springframework.web.bind.annotation.RestController
 )
 class TrnController(
     var trnService: TrnService,
+    var trnFinder: TrnFinder,
+    var trnSettlementService: TrnSettlementService,
     var trnQueryService: TrnQueryService,
     var dateUtils: DateUtils,
     var positionMoveService: PositionMoveService
@@ -120,7 +122,7 @@ class TrnController(
         ) @RequestParam(required = false) asAt: String? = null
     ): TrnResponse =
         TrnResponse(
-            trnService.findForPortfolio(
+            trnFinder.findForPortfolio(
                 portfolioId,
                 dateUtils.getFormattedDate(asAt ?: dateUtils.today())
             )
@@ -156,7 +158,7 @@ class TrnController(
         ) trnId: String
     ): TrnResponse =
         TrnResponse(
-            trnService.getPortfolioTrn(
+            trnFinder.getPortfolioTrn(
                 trnId
             )
         )
@@ -369,7 +371,7 @@ class TrnController(
         require(request.status == TrnStatus.PROPOSED) {
             "Only PROPOSED is supported via this endpoint (Unsettle). Use POST /trns/settle for SETTLED."
         }
-        return trnService.unsettle(trnId)
+        return trnSettlementService.unsettle(trnId)
     }
 
     @GetMapping(
@@ -582,7 +584,7 @@ class TrnController(
         val trnStatus =
             com.beancounter.common.model.TrnStatus
                 .valueOf(status.uppercase())
-        return TrnResponse(trnService.findByStatus(portfolioId, trnStatus))
+        return TrnResponse(trnFinder.findByStatus(portfolioId, trnStatus))
     }
 
     @GetMapping(
@@ -614,7 +616,7 @@ class TrnController(
         @RequestParam(value = "asAt", required = false) asAt: String?
     ): TrnResponse =
         TrnResponse(
-            trnService.findProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today()))
+            trnFinder.findProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today()))
         )
 
     @GetMapping(
@@ -645,7 +647,7 @@ class TrnController(
         @Parameter(description = "Count proposed transactions due on or before this date (default today)")
         @RequestParam(value = "asAt", required = false) asAt: String?
     ): Map<String, Long> =
-        mapOf("count" to trnService.countProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today())))
+        mapOf("count" to trnFinder.countProposedForUser(scope, dateUtils.getFormattedDate(asAt ?: dateUtils.today())))
 
     @GetMapping(
         value = ["/settled"],
@@ -680,7 +682,7 @@ class TrnController(
             example = "2026-01-22",
             required = true
         ) @RequestParam("tradeDate") tradeDate: java.time.LocalDate
-    ): TrnResponse = TrnResponse(trnService.findSettledForUser(tradeDate))
+    ): TrnResponse = TrnResponse(trnFinder.findSettledForUser(tradeDate))
 
     @PostMapping(
         value = ["/portfolio/{portfolioId}/settle"],
@@ -717,7 +719,7 @@ class TrnController(
         @Parameter(
             description = "Request body containing transaction IDs to settle"
         ) @RequestBody request: SettleTransactionsRequest
-    ): TrnResponse = TrnResponse(trnService.settleTransactions(portfolioId, request.trnIds))
+    ): TrnResponse = TrnResponse(trnSettlementService.settleTransactions(portfolioId, request.trnIds))
 
     @PostMapping(
         value = ["/portfolio/{portfolioId}/unsettle"],
@@ -746,7 +748,7 @@ class TrnController(
         @Parameter(
             description = "Request body containing transaction IDs to unsettle"
         ) @RequestBody request: SettleTransactionsRequest
-    ): TrnResponse = TrnResponse(trnService.unsettleTransactions(portfolioId, request.trnIds))
+    ): TrnResponse = TrnResponse(trnSettlementService.unsettleTransactions(portfolioId, request.trnIds))
 
     @GetMapping(
         value = ["/{portfolioId}/cash-ladder/{cashAssetId}"],
@@ -785,7 +787,7 @@ class TrnController(
             description = "Cash asset identifier",
             example = "cash-usd-123"
         ) @PathVariable("cashAssetId") cashAssetId: String
-    ): TrnResponse = TrnResponse(trnService.getCashLadder(portfolioId, cashAssetId))
+    ): TrnResponse = TrnResponse(trnFinder.getCashLadder(portfolioId, cashAssetId))
 
     @GetMapping(
         value = ["/portfolio/{portfolioId}/model/{modelId}"],
@@ -825,7 +827,7 @@ class TrnController(
         ) @PathVariable("modelId") modelId: String
     ): TrnResponse =
         TrnResponse(
-            trnService.findByPortfolioAndModel(portfolioId, modelId)
+            trnFinder.findByPortfolioAndModel(portfolioId, modelId)
         )
 
     @PostMapping(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnExportController.kt
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController
     description = "Export transactions to external formats"
 )
 class TrnExportController(
-    var trnService: TrnService,
+    var trnFinder: TrnFinder,
     var dateUtils: DateUtils,
     var trnIoDefinition: TrnIoDefinition
 ) {
@@ -78,7 +78,7 @@ class TrnExportController(
             "attachment; filename=\"${sanitizeFilename(portfolioId)}.csv\""
         )
         val trnResponse =
-            trnService.findForPortfolio(
+            trnFinder.findForPortfolio(
                 portfolioId,
                 dateUtils.date
             )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
@@ -1,0 +1,194 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.ShareStatus
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
+import com.beancounter.marketdata.registration.SystemUserService
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Read-only finders for transactions scoped to a portfolio, status, model, cash
+ * asset, or the current user. Mutations and lifecycle live in [TrnService] and
+ * [TrnSettlementService]; asset/event queries live in [TrnQueryService].
+ */
+@Service
+@Transactional
+class TrnFinder(
+    private val trnRepository: TrnRepository,
+    private val portfolioService: PortfolioService,
+    private val systemUserService: SystemUserService,
+    private val portfolioShareRepository: PortfolioShareRepository,
+    private val dateUtils: DateUtils,
+    private val trnPostProcessor: TrnPostProcessor
+) {
+    private val log = LoggerFactory.getLogger(TrnFinder::class.java)
+
+    fun getPortfolioTrn(trnId: String): Collection<Trn> {
+        val trn = trnRepository.findById(trnId)
+        if (trn.isEmpty) {
+            throw NotFoundException("Trn not found: $trnId")
+        }
+        val result = trn.map { transaction: Trn -> trnPostProcessor.postProcess(setOf(transaction)) }
+        return result.get()
+    }
+
+    fun findForPortfolio(
+        portfolioId: String,
+        tradeDate: LocalDate
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        return findForPortfolio(portfolio, tradeDate)
+    }
+
+    fun findForPortfolio(
+        portfolio: Portfolio,
+        tradeDate: LocalDate
+    ): Collection<Trn> {
+        val results =
+            trnRepository.findByPortfolioId(
+                portfolio.id,
+                tradeDate,
+                TrnStatus.SETTLED
+            )
+        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, asAt: $tradeDate")
+        return trnPostProcessor.postProcess(results)
+    }
+
+    /**
+     * Find transactions for a portfolio with a specific status.
+     */
+    fun findByStatus(
+        portfolioId: String,
+        status: TrnStatus
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val results = trnRepository.findByPortfolioIdAndStatus(portfolio.id, status)
+        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, status: $status")
+        return trnPostProcessor.postProcess(results)
+    }
+
+    /**
+     * Find PROPOSED transactions for the current user, bounded to those due on or before [asAt]
+     * (defaults to today). Future-dated proposed transactions — e.g. dividends with a forward pay
+     * date — are excluded until [asAt] reaches their tradeDate, so the review list only shows
+     * actionable rows. Widen [asAt] to preview upcoming proposed transactions.
+     *
+     * - OWNED: portfolios where current user is the owner (default historical behaviour).
+     * - MANAGED: portfolios shared with the current user via an ACTIVE PortfolioShare.
+     * - ALL: union of both.
+     */
+    fun findProposedForUser(
+        scope: ProposedScope = ProposedScope.ALL,
+        asAt: LocalDate = dateUtils.date
+    ): Collection<Trn> {
+        val user = systemUserService.getOrThrow()
+        val results = mutableMapOf<String, Trn>()
+
+        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
+            trnRepository
+                .findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
+                .forEach { results[it.id] = it }
+        }
+
+        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
+            val managedPortfolioIds = managedPortfolioIdsFor(user)
+            if (managedPortfolioIds.isNotEmpty()) {
+                trnRepository
+                    .findByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
+                    .forEach { results[it.id] = it }
+            }
+        }
+
+        log.trace("proposed trns: ${results.size} (scope=$scope, asAt=$asAt)")
+        return trnPostProcessor.postProcess(results.values.toList())
+    }
+
+    /**
+     * Count PROPOSED transactions for the current user under the given scope, bounded to those due
+     * on or before [asAt] (defaults to today) so the badge tracks the same set as the review list.
+     */
+    fun countProposedForUser(
+        scope: ProposedScope = ProposedScope.ALL,
+        asAt: LocalDate = dateUtils.date
+    ): Long {
+        val user = systemUserService.getOrThrow()
+        var count = 0L
+
+        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
+            count += trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
+        }
+
+        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
+            val managedPortfolioIds = managedPortfolioIdsFor(user)
+            if (managedPortfolioIds.isNotEmpty()) {
+                count += trnRepository.countByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
+            }
+        }
+
+        log.trace("proposed count: $count (scope=$scope, asAt=$asAt)")
+        return count
+    }
+
+    private fun managedPortfolioIdsFor(user: SystemUser): Set<String> =
+        portfolioShareRepository
+            .findBySharedWithAndStatus(user, ShareStatus.ACTIVE)
+            .mapNotNull { it.portfolio?.id }
+            .toSet()
+
+    /**
+     * Find all SETTLED transactions for the current user on a specific trade date.
+     */
+    fun findSettledForUser(tradeDate: LocalDate): Collection<Trn> {
+        val user = systemUserService.getOrThrow()
+        val results = trnRepository.findByStatusAndPortfolioOwnerAndTradeDate(TrnStatus.SETTLED, user, tradeDate)
+        log.trace("settled trns on $tradeDate: ${results.size}")
+        return trnPostProcessor.postProcess(results.toList())
+    }
+
+    /**
+     * Get the Cash Ladder for a specific cash asset in a portfolio.
+     */
+    fun getCashLadder(
+        portfolioId: String,
+        cashAssetId: String
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val today = LocalDate.now()
+        val results =
+            trnRepository.findByPortfolioIdAndCashAssetId(
+                portfolio.id,
+                cashAssetId,
+                today,
+                TrnStatus.SETTLED
+            )
+        log.trace("cash ladder: ${results.size} trns for portfolio: ${portfolio.code}, cashAsset: $cashAssetId")
+        return trnPostProcessor.postProcess(results.toList())
+    }
+
+    /**
+     * Find all transactions for a portfolio that belong to a specific rebalance model.
+     */
+    fun findByPortfolioAndModel(
+        portfolioId: String,
+        modelId: String
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val results =
+            trnRepository.findByPortfolioIdAndModelId(
+                portfolio.id,
+                modelId,
+                TrnStatus.SETTLED
+            )
+        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, model: $modelId")
+        return trnPostProcessor.postProcess(results.toList())
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnImportService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnImportService.kt
@@ -19,6 +19,7 @@ class TrnImportService(
     private val adapterFactory: AdapterFactory,
     private val portfolioService: PortfolioService,
     private val trnService: TrnService,
+    private val trnRepository: TrnRepository,
     private val trnMetrics: TrnMetrics
 ) {
     /**
@@ -71,7 +72,7 @@ class TrnImportService(
                 trnMetrics.recordTrnIgnored("portfolio_verification_failed")
                 return@timeTransactionImport emptySet()
             }
-            val existing = trnService.existing(trustedTrnEvent)
+            val existing = existing(trustedTrnEvent)
             if (existing.isNotEmpty()) {
                 // Calculate days difference for metrics
                 val daysDiff =
@@ -103,6 +104,23 @@ class TrnImportService(
             trnMetrics.recordTrnWritten(trustedTrnEvent.trnInput.trnType.name, written.size)
             written
         }
+    }
+
+    /**
+     * Existing transactions near the event's trade date, used to detect and skip
+     * duplicate corporate-action imports (the same DIVI/SPLIT arriving twice with
+     * a slightly different pay date).
+     */
+    fun existing(trustedTrnEvent: TrustedTrnEvent): Collection<Trn> {
+        val start = trustedTrnEvent.trnInput.tradeDate.minusDays(5)
+        val endDate = trustedTrnEvent.trnInput.tradeDate.plusDays(20)
+        return trnRepository.findExisting(
+            trustedTrnEvent.portfolio.id,
+            trustedTrnEvent.trnInput.assetId!!,
+            trustedTrnEvent.trnInput.trnType,
+            start,
+            endDate
+        )
     }
 
     private fun writeTrn(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnPostProcessor.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnPostProcessor.kt
@@ -1,0 +1,61 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.model.Trn
+import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.registration.SystemUserService
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Cross-cutting read-time processing applied to every Trn collection returned by
+ * the trn services: version upgrade (persisting the migrated row), optional
+ * owner-scoped security filtering, and BALANCE contribution stamping.
+ *
+ * Asset hydration itself happens via AssetEntityListener @PostLoad — Trn.asset
+ * and Trn.cashAsset arrive populated from JPA; this only runs the migrate +
+ * stamp steps.
+ */
+@Service
+@Transactional
+class TrnPostProcessor(
+    private val trnMigrator: TrnMigrator,
+    private val trnRepository: TrnRepository,
+    private val balanceContributionStamper: BalanceContributionStamper,
+    private val systemUserService: SystemUserService,
+    private val portfolioService: PortfolioService
+) {
+    private val log = LoggerFactory.getLogger(TrnPostProcessor::class.java)
+
+    fun postProcess(trns: List<Trn>): List<Trn> {
+        log.trace("PostProcess ${trns.size} transactions")
+        // Version-upgrade step; asset references are already hydrated by JPA.
+        for (trn in trns) {
+            val upgraded = trnMigrator.upgrade(trn)
+            if (upgraded.version != trn.version) {
+                trnRepository.save(upgraded)
+            }
+        }
+        // Read-time only: stamp contribution on BALANCE snapshots so
+        // svc-position can separate interest from fresh principal.
+        balanceContributionStamper.stamp(trns)
+        log.trace("Completed postProcess trns: ${trns.size}")
+        return trns
+    }
+
+    fun postProcess(
+        trns: Iterable<Trn>,
+        secure: Boolean = true
+    ): Collection<Trn> {
+        if (secure) {
+            val systemUser = systemUserService.getOrThrow()
+            val filteredTrns =
+                trns.filter {
+                    portfolioService.isViewable(systemUser, it.portfolio)
+                }
+            return postProcess(filteredTrns)
+        } else {
+            return postProcess(trns.toList())
+        }
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnQueryService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnQueryService.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
  */
 @Service
 class TrnQueryService(
-    val trnService: TrnService,
+    val trnPostProcessor: TrnPostProcessor,
     val trnRepository: TrnRepository,
     val portfolioService: PortfolioService
 ) {
@@ -44,7 +44,7 @@ class TrnQueryService(
             portfolio.code,
             assetId
         )
-        return trnService.postProcess(
+        return trnPostProcessor.postProcess(
             results,
             false
         )
@@ -151,7 +151,7 @@ class TrnQueryService(
             portfolio.code,
             assetId
         )
-        return trnService.postProcess(
+        return trnPostProcessor.postProcess(
             results,
             true
         )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -4,21 +4,14 @@ import com.beancounter.common.contracts.TrnDeleteResponse
 import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.contracts.TrnResponse
 import com.beancounter.common.contracts.TrnSaveResult
-import com.beancounter.common.contracts.TrnStatusUpdateResponse
 import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.input.TrnInput
-import com.beancounter.common.input.TrustedTrnEvent
 import com.beancounter.common.model.Portfolio
-import com.beancounter.common.model.ShareStatus
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
-import com.beancounter.common.utils.DateUtils
-import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.cash.CashAutoSettleService
 import com.beancounter.marketdata.portfolio.PortfolioService
-import com.beancounter.marketdata.portfolio.PortfolioShareRepository
-import com.beancounter.marketdata.registration.SystemUserService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -26,10 +19,12 @@ import java.time.LocalDate
 import java.util.function.Consumer
 
 /**
- * Core service for transaction CRUD operations and portfolio queries.
+ * Core service for transaction writes (create / patch / delete / purge).
  *
- * For broker-related operations, see [TrnBrokerService].
- * For investment/income analysis, see [TrnAnalysisService].
+ * Reads live in [TrnFinder] (portfolio-scoped) and [TrnQueryService] (asset /
+ * event). Settle / unsettle lifecycle lives in [TrnSettlementService]. Shared
+ * read-time processing lives in [TrnPostProcessor]. Broker operations live in
+ * [TrnBrokerService]; investment/income analysis in [TrnAnalysisService].
  */
 @Service
 @Transactional
@@ -37,26 +32,11 @@ class TrnService(
     private val trnRepository: TrnRepository,
     private val trnInputMapper: TrnInputMapper,
     private val portfolioService: PortfolioService,
-    private val trnMigrator: TrnMigrator,
-    private val assetFinder: AssetFinder,
-    private val systemUserService: SystemUserService,
     private val cacheInvalidationProducer: CacheInvalidationProducer,
-    private val portfolioShareRepository: PortfolioShareRepository,
     private val cashAutoSettleService: CashAutoSettleService,
-    private val trnSettlementService: TrnSettlementService,
-    private val dateUtils: DateUtils,
-    private val balanceContributionStamper: BalanceContributionStamper
+    private val trnFinder: TrnFinder
 ) {
     private val log = LoggerFactory.getLogger(TrnService::class.java)
-
-    fun getPortfolioTrn(trnId: String): Collection<Trn> {
-        val trn = trnRepository.findById(trnId)
-        if (trn.isEmpty) {
-            throw NotFoundException("Trn not found: $trnId")
-        }
-        val result = trn.map { transaction: Trn -> postProcess(setOf(transaction)) }
-        return result.get()
-    }
 
     fun save(
         portfolioId: String,
@@ -101,7 +81,8 @@ class TrnService(
         for (trn in results.toList()) {
             // Cash auto-settle fires on SETTLEMENT, not creation. A PROPOSED trade
             // carries no compensating cash transfer until it settles (see
-            // settleTransactions); a trade saved already-SETTLED still emits here.
+            // TrnSettlementService.settleTransactions); a trade saved already-SETTLED
+            // still emits here.
             if (trn.status != TrnStatus.SETTLED) continue
             val res = cashAutoSettleService.emitCompensatingTransfer(trn)
             warnings.addAll(res.warnings)
@@ -122,204 +103,6 @@ class TrnService(
         return TrnSaveResult(results.toList(), warnings.toList())
     }
 
-    fun findForPortfolio(
-        portfolioId: String,
-        tradeDate: LocalDate
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        return findForPortfolio(portfolio, tradeDate)
-    }
-
-    fun findForPortfolio(
-        portfolio: Portfolio,
-        tradeDate: LocalDate
-    ): Collection<Trn> {
-        val results =
-            trnRepository.findByPortfolioId(
-                portfolio.id,
-                tradeDate,
-                TrnStatus.SETTLED
-            )
-        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, asAt: $tradeDate")
-        return postProcess(results)
-    }
-
-    /**
-     * Find transactions for a portfolio with a specific status.
-     */
-    fun findByStatus(
-        portfolioId: String,
-        status: TrnStatus
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        val results = trnRepository.findByPortfolioIdAndStatus(portfolio.id, status)
-        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, status: $status")
-        return postProcess(results)
-    }
-
-    /**
-     * Find PROPOSED transactions for the current user, bounded to those due on or before [asAt]
-     * (defaults to today). Future-dated proposed transactions — e.g. dividends with a forward pay
-     * date — are excluded until [asAt] reaches their tradeDate, so the review list only shows
-     * actionable rows. Widen [asAt] to preview upcoming proposed transactions.
-     *
-     * - OWNED: portfolios where current user is the owner (default historical behaviour).
-     * - MANAGED: portfolios shared with the current user via an ACTIVE PortfolioShare.
-     * - ALL: union of both.
-     */
-    fun findProposedForUser(
-        scope: ProposedScope = ProposedScope.ALL,
-        asAt: LocalDate = dateUtils.date
-    ): Collection<Trn> {
-        val user = systemUserService.getOrThrow()
-        val results = mutableMapOf<String, Trn>()
-
-        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
-            trnRepository
-                .findByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
-                .forEach { results[it.id] = it }
-        }
-
-        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
-            val managedPortfolioIds = managedPortfolioIdsFor(user)
-            if (managedPortfolioIds.isNotEmpty()) {
-                trnRepository
-                    .findByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
-                    .forEach { results[it.id] = it }
-            }
-        }
-
-        log.trace("proposed trns: ${results.size} (scope=$scope, asAt=$asAt)")
-        return postProcess(results.values.toList())
-    }
-
-    /**
-     * Count PROPOSED transactions for the current user under the given scope, bounded to those due
-     * on or before [asAt] (defaults to today) so the badge tracks the same set as the review list.
-     */
-    fun countProposedForUser(
-        scope: ProposedScope = ProposedScope.ALL,
-        asAt: LocalDate = dateUtils.date
-    ): Long {
-        val user = systemUserService.getOrThrow()
-        var count = 0L
-
-        if (scope == ProposedScope.OWNED || scope == ProposedScope.ALL) {
-            count += trnRepository.countByStatusAndPortfolioOwner(TrnStatus.PROPOSED, user, asAt)
-        }
-
-        if (scope == ProposedScope.MANAGED || scope == ProposedScope.ALL) {
-            val managedPortfolioIds = managedPortfolioIdsFor(user)
-            if (managedPortfolioIds.isNotEmpty()) {
-                count += trnRepository.countByStatusAndPortfolioIdIn(TrnStatus.PROPOSED, managedPortfolioIds, asAt)
-            }
-        }
-
-        log.trace("proposed count: $count (scope=$scope, asAt=$asAt)")
-        return count
-    }
-
-    private fun managedPortfolioIdsFor(user: com.beancounter.common.model.SystemUser): Set<String> =
-        portfolioShareRepository
-            .findBySharedWithAndStatus(user, ShareStatus.ACTIVE)
-            .mapNotNull { it.portfolio?.id }
-            .toSet()
-
-    /**
-     * Find all SETTLED transactions for the current user on a specific trade date.
-     */
-    fun findSettledForUser(tradeDate: LocalDate): Collection<Trn> {
-        val user = systemUserService.getOrThrow()
-        val results = trnRepository.findByStatusAndPortfolioOwnerAndTradeDate(TrnStatus.SETTLED, user, tradeDate)
-        log.trace("settled trns on $tradeDate: ${results.size}")
-        return postProcess(results.toList())
-    }
-
-    /**
-     * Get the Cash Ladder for a specific cash asset in a portfolio.
-     */
-    fun getCashLadder(
-        portfolioId: String,
-        cashAssetId: String
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        val today = LocalDate.now()
-        val results =
-            trnRepository.findByPortfolioIdAndCashAssetId(
-                portfolio.id,
-                cashAssetId,
-                today,
-                TrnStatus.SETTLED
-            )
-        log.trace("cash ladder: ${results.size} trns for portfolio: ${portfolio.code}, cashAsset: $cashAssetId")
-        return postProcess(results.toList())
-    }
-
-    /**
-     * Settle transactions by updating their status from PROPOSED to SETTLED.
-     */
-    fun settleTransactions(
-        portfolioId: String,
-        trnIds: List<String>
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        val settled = trnIds.mapNotNull { settleOne(portfolio, it) }
-        log.info("Settled {} transactions for portfolio {}", settled.size, portfolio.code)
-        val earliestSettled = settled.minOfOrNull { it.tradeDate }
-        if (earliestSettled != null) {
-            cacheInvalidationProducer.sendTransactionEvent(portfolio.id, earliestSettled)
-        }
-        return postProcess(settled)
-    }
-
-    /**
-     * Settle a single PROPOSED transaction. Returns the settled Trn, or null
-     * (with a warning) when it is missing, not PROPOSED, future-dated, or FX
-     * can't resolve yet (leaving it PROPOSED for retry).
-     */
-    private fun settleOne(
-        portfolio: Portfolio,
-        trnId: String
-    ): Trn? {
-        val trn =
-            trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
-                ?: run {
-                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
-                    return null
-                }
-        if (trn.status != TrnStatus.PROPOSED) {
-            log.warn("Cannot settle transaction {} - status is {} not PROPOSED", trnId, trn.status)
-            return null
-        }
-        if (trn.tradeDate.isAfter(dateUtils.date)) {
-            log.warn("Cannot settle transaction {} - tradeDate {} is in the future", trnId, trn.tradeDate)
-            return null
-        }
-        // Shared settle core: FX + status flip + cash emit. Returns null when FX
-        // can't resolve yet (leaves it PROPOSED for retry).
-        val saved = trnSettlementService.settle(portfolio, trn) ?: return null
-        log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
-        return saved
-    }
-
-    /**
-     * Find all transactions for a portfolio that belong to a specific rebalance model.
-     */
-    fun findByPortfolioAndModel(
-        portfolioId: String,
-        modelId: String
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        val results =
-            trnRepository.findByPortfolioIdAndModelId(
-                portfolio.id,
-                modelId,
-                TrnStatus.SETTLED
-            )
-        log.trace("trns: ${results.size}, portfolio: ${portfolio.code}, model: $modelId")
-        return postProcess(results.toList())
-    }
-
     fun purge(portfolioId: String): Long {
         val portfolio = portfolioService.find(portfolioId)
         return purge(portfolio)
@@ -333,18 +116,6 @@ class TrnService(
         val count = trnRepository.deleteByPortfolioId(portfolio.id)
         cacheInvalidationProducer.sendTransactionEvent(portfolio.id, LocalDate.MIN)
         return count
-    }
-
-    fun existing(trustedTrnEvent: TrustedTrnEvent): Collection<Trn> {
-        val start = trustedTrnEvent.trnInput.tradeDate.minusDays(5)
-        val endDate = trustedTrnEvent.trnInput.tradeDate.plusDays(20)
-        return trnRepository.findExisting(
-            trustedTrnEvent.portfolio.id,
-            trustedTrnEvent.trnInput.assetId!!,
-            trustedTrnEvent.trnInput.trnType,
-            start,
-            endDate
-        )
     }
 
     fun delete(trnId: String): Collection<String> {
@@ -382,65 +153,6 @@ class TrnService(
         return TrnDeleteResponse(listOf(parent.id), siblings)
     }
 
-    /**
-     * Toggle a trn from SETTLED to PROPOSED, cascade-deleting its auto-emitted
-     * cash legs (see [TrnSettlementService.unsettle]). `siblings` reports the
-     * removed leg ids for the UI to refresh.
-     *
-     * Idempotency: calling unsettle on a trn that isn't SETTLED throws — there's
-     * no useful "transition to PROPOSED from PROPOSED" semantic.
-     */
-    fun unsettle(trnId: String): TrnStatusUpdateResponse {
-        val parent =
-            trnRepository.findById(trnId).orElseThrow {
-                NotFoundException("Transaction not found: $trnId")
-            }
-        if (!portfolioService.canView(parent.portfolio)) {
-            throw NotFoundException("Transaction not found: $trnId")
-        }
-        require(parent.status == TrnStatus.SETTLED) {
-            "Cannot unsettle trn $trnId: status is ${parent.status}, expected SETTLED"
-        }
-        val siblings = trnSettlementService.unsettle(parent)
-        cacheInvalidationProducer.sendTransactionEvent(parent.portfolio.id, parent.tradeDate)
-        return TrnStatusUpdateResponse(updated = parent, siblings = siblings)
-    }
-
-    /**
-     * Bulk unsettle for a portfolio — the multi-select counterpart to
-     * [settleTransactions]. Each SETTLED trn flows through the same
-     * [TrnSettlementService.unsettle] core (cash-leg cascade) as the single path,
-     * so behaviour is identical regardless of UI. Non-SETTLED / missing ids are
-     * skipped with a log, never aborting the batch.
-     */
-    fun unsettleTransactions(
-        portfolioId: String,
-        trnIds: List<String>
-    ): Collection<Trn> {
-        val portfolio = portfolioService.find(portfolioId)
-        val unsettled = mutableListOf<Trn>()
-        for (trnId in trnIds) {
-            val trn = trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
-            when {
-                trn == null -> {
-                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
-                }
-                trn.status != TrnStatus.SETTLED -> {
-                    log.warn("Cannot unsettle {} - status is {} not SETTLED", trnId, trn.status)
-                }
-                else -> {
-                    trnSettlementService.unsettle(trn)
-                    unsettled.add(trn)
-                }
-            }
-        }
-        log.info("Unsettled {} transactions for portfolio {}", unsettled.size, portfolio.code)
-        unsettled.minOfOrNull { it.tradeDate }?.let {
-            cacheInvalidationProducer.sendTransactionEvent(portfolio.id, it)
-        }
-        return postProcess(unsettled)
-    }
-
     fun patch(
         portfolioId: String,
         trnId: String,
@@ -455,7 +167,7 @@ class TrnService(
         trnId: String,
         trnInput: TrnInput
     ): TrnResponse {
-        val existing = getPortfolioTrn(trnId)
+        val existing = trnFinder.getPortfolioTrn(trnId)
         val trn =
             trnInputMapper.map(
                 portfolio,
@@ -474,38 +186,5 @@ class TrnService(
             }
         cacheInvalidationProducer.sendTransactionEvent(portfolio.id, trn.tradeDate)
         return TrnResponse(arrayListOf(trn), warnings)
-    }
-
-    private fun postProcess(trns: List<Trn>): List<Trn> {
-        log.trace("PostProcess ${trns.size} transactions")
-        // Asset hydration happens via AssetEntityListener @PostLoad — Trn.asset and
-        // Trn.cashAsset arrive populated from JPA. Only the version-upgrade step here.
-        for (trn in trns) {
-            val upgraded = trnMigrator.upgrade(trn)
-            if (upgraded.version != trn.version) {
-                trnRepository.save(upgraded)
-            }
-        }
-        // Read-time only: stamp contribution on BALANCE snapshots so
-        // svc-position can separate interest from fresh principal.
-        balanceContributionStamper.stamp(trns)
-        log.trace("Completed postProcess trns: ${trns.size}")
-        return trns
-    }
-
-    internal fun postProcess(
-        trns: Iterable<Trn>,
-        secure: Boolean = true
-    ): Collection<Trn> {
-        if (secure) {
-            val systemUser = systemUserService.getOrThrow()
-            val filteredTrns =
-                trns.filter {
-                    portfolioService.isViewable(systemUser, it.portfolio)
-                }
-            return postProcess(filteredTrns)
-        } else {
-            return postProcess(trns.toList())
-        }
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
@@ -1,32 +1,150 @@
 package com.beancounter.marketdata.trn
 
 import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.contracts.TrnStatusUpdateResponse
+import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.cash.CashAutoSettleService
+import com.beancounter.marketdata.portfolio.PortfolioService
+import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 /**
  * Single source of truth for the settle / unsettle state transition and its cash
  * side effects, so every caller behaves identically regardless of the UI or entry
- * path — manual bulk settle ([TrnService.settleTransactions]), the scheduled event
- * settle ([AutoSettleService]), single and bulk unsettle ([TrnService.unsettle],
- * [TrnService.unsettleTransactions]).
+ * path — manual bulk settle ([settleTransactions]), the scheduled event settle
+ * ([AutoSettleService]), single and bulk unsettle ([unsettle],
+ * [unsettleTransactions]).
  *
- * Callers own their own preconditions (future-date guard, owner opt-in, auth,
- * status checks); this service owns the transition itself: FX resolution, the
- * status flip + persist, and the compensating cash transfer (emit on settle,
- * cascade-delete on unsettle).
+ * The per-trn core ([settle] / [unsettle]) owns the transition itself: FX
+ * resolution, the status flip + persist, and the compensating cash transfer
+ * (emit on settle, cascade-delete on unsettle). The batch entry points own the
+ * surrounding preconditions (future-date guard, auth/view checks, status checks)
+ * and cache invalidation.
  */
 @Service
+@Transactional
 class TrnSettlementService(
     private val trnRepository: TrnRepository,
     private val fxTransactions: FxTransactions,
-    private val cashAutoSettleService: CashAutoSettleService
+    private val cashAutoSettleService: CashAutoSettleService,
+    private val portfolioService: PortfolioService,
+    private val cacheInvalidationProducer: CacheInvalidationProducer,
+    private val dateUtils: DateUtils,
+    private val trnPostProcessor: TrnPostProcessor
 ) {
     private val log = LoggerFactory.getLogger(TrnSettlementService::class.java)
+
+    /**
+     * Settle transactions by updating their status from PROPOSED to SETTLED.
+     */
+    fun settleTransactions(
+        portfolioId: String,
+        trnIds: List<String>
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val settled = trnIds.mapNotNull { settleOne(portfolio, it) }
+        log.info("Settled {} transactions for portfolio {}", settled.size, portfolio.code)
+        val earliestSettled = settled.minOfOrNull { it.tradeDate }
+        if (earliestSettled != null) {
+            cacheInvalidationProducer.sendTransactionEvent(portfolio.id, earliestSettled)
+        }
+        return trnPostProcessor.postProcess(settled)
+    }
+
+    /**
+     * Settle a single PROPOSED transaction. Returns the settled Trn, or null
+     * (with a warning) when it is missing, not PROPOSED, future-dated, or FX
+     * can't resolve yet (leaving it PROPOSED for retry).
+     */
+    private fun settleOne(
+        portfolio: Portfolio,
+        trnId: String
+    ): Trn? {
+        val trn =
+            trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
+                ?: run {
+                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
+                    return null
+                }
+        if (trn.status != TrnStatus.PROPOSED) {
+            log.warn("Cannot settle transaction {} - status is {} not PROPOSED", trnId, trn.status)
+            return null
+        }
+        if (trn.tradeDate.isAfter(dateUtils.date)) {
+            log.warn("Cannot settle transaction {} - tradeDate {} is in the future", trnId, trn.tradeDate)
+            return null
+        }
+        // Shared settle core: FX + status flip + cash emit. Returns null when FX
+        // can't resolve yet (leaves it PROPOSED for retry).
+        val saved = settle(portfolio, trn) ?: return null
+        log.debug("Settled transaction {} for portfolio {}", trnId, portfolio.code)
+        return saved
+    }
+
+    /**
+     * Toggle a trn from SETTLED to PROPOSED, cascade-deleting its auto-emitted
+     * cash legs (see [unsettle]). `siblings` reports the removed leg ids for the
+     * UI to refresh.
+     *
+     * Idempotency: calling unsettle on a trn that isn't SETTLED throws — there's
+     * no useful "transition to PROPOSED from PROPOSED" semantic.
+     */
+    fun unsettle(trnId: String): TrnStatusUpdateResponse {
+        val parent =
+            trnRepository.findById(trnId).orElseThrow {
+                NotFoundException("Transaction not found: $trnId")
+            }
+        if (!portfolioService.canView(parent.portfolio)) {
+            throw NotFoundException("Transaction not found: $trnId")
+        }
+        require(parent.status == TrnStatus.SETTLED) {
+            "Cannot unsettle trn $trnId: status is ${parent.status}, expected SETTLED"
+        }
+        val siblings = unsettle(parent)
+        cacheInvalidationProducer.sendTransactionEvent(parent.portfolio.id, parent.tradeDate)
+        return TrnStatusUpdateResponse(updated = parent, siblings = siblings)
+    }
+
+    /**
+     * Bulk unsettle for a portfolio — the multi-select counterpart to
+     * [settleTransactions]. Each SETTLED trn flows through the same per-trn
+     * [unsettle] core (cash-leg cascade) as the single path, so behaviour is
+     * identical regardless of UI. Non-SETTLED / missing ids are skipped with a
+     * log, never aborting the batch.
+     */
+    fun unsettleTransactions(
+        portfolioId: String,
+        trnIds: List<String>
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        val unsettled = mutableListOf<Trn>()
+        for (trnId in trnIds) {
+            val trn = trnRepository.findByPortfolioIdAndId(portfolio.id, trnId).orElse(null)
+            when {
+                trn == null -> {
+                    log.warn("Transaction {} not found in portfolio {}", trnId, portfolio.code)
+                }
+                trn.status != TrnStatus.SETTLED -> {
+                    log.warn("Cannot unsettle {} - status is {} not SETTLED", trnId, trn.status)
+                }
+                else -> {
+                    unsettle(trn)
+                    unsettled.add(trn)
+                }
+            }
+        }
+        log.info("Unsettled {} transactions for portfolio {}", unsettled.size, portfolio.code)
+        unsettled.minOfOrNull { it.tradeDate }?.let {
+            cacheInvalidationProducer.sendTransactionEvent(portfolio.id, it)
+        }
+        return trnPostProcessor.postProcess(unsettled)
+    }
 
     /**
      * Settle one trn: resolve FX, flip PROPOSED→SETTLED, persist, and emit the

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PortfolioPriceBackfillServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PortfolioPriceBackfillServiceTest.kt
@@ -11,7 +11,7 @@ import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.Constants.Companion.NYSE
 import com.beancounter.marketdata.portfolio.PortfolioService
-import com.beancounter.marketdata.trn.TrnService
+import com.beancounter.marketdata.trn.TrnFinder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,7 +28,7 @@ import java.time.LocalDate
 class PortfolioPriceBackfillServiceTest {
     private lateinit var service: PortfolioPriceBackfillService
     private lateinit var portfolioService: PortfolioService
-    private lateinit var trnService: TrnService
+    private lateinit var trnFinder: TrnFinder
     private lateinit var priceProcessor: MarketDataPriceProcessor
     private lateinit var providerUtils: ProviderUtils
     private lateinit var dateUtils: DateUtils
@@ -49,7 +49,7 @@ class PortfolioPriceBackfillServiceTest {
     @BeforeEach
     fun setUp() {
         portfolioService = mock(PortfolioService::class.java)
-        trnService = mock(TrnService::class.java)
+        trnFinder = mock(TrnFinder::class.java)
         priceProcessor = mock(MarketDataPriceProcessor::class.java)
         providerUtils = mock(ProviderUtils::class.java)
         dateUtils = mock(DateUtils::class.java)
@@ -57,7 +57,7 @@ class PortfolioPriceBackfillServiceTest {
         service =
             PortfolioPriceBackfillService(
                 portfolioService,
-                trnService,
+                trnFinder,
                 priceProcessor,
                 providerUtils,
                 dateUtils,
@@ -70,7 +70,7 @@ class PortfolioPriceBackfillServiceTest {
 
     @Test
     fun `should return no_transactions when portfolio has no transactions`() {
-        `when`(trnService.findForPortfolio(portfolio, today)).thenReturn(emptyList())
+        `when`(trnFinder.findForPortfolio(portfolio, today)).thenReturn(emptyList())
 
         val result = service.backfill("TEST")
 
@@ -87,7 +87,7 @@ class PortfolioPriceBackfillServiceTest {
                 asset = cashAsset,
                 tradeDate = LocalDate.of(2025, 1, 15)
             )
-        `when`(trnService.findForPortfolio(portfolio, today)).thenReturn(listOf(cashTrn))
+        `when`(trnFinder.findForPortfolio(portfolio, today)).thenReturn(listOf(cashTrn))
 
         val result = service.backfill("TEST")
 
@@ -109,7 +109,7 @@ class PortfolioPriceBackfillServiceTest {
                 asset = assetMsft,
                 tradeDate = LocalDate.of(2025, 3, 10)
             )
-        `when`(trnService.findForPortfolio(portfolio, today)).thenReturn(listOf(trn1, trn2))
+        `when`(trnFinder.findForPortfolio(portfolio, today)).thenReturn(listOf(trn1, trn2))
         `when`(providerUtils.getInputs(any())).thenReturn(emptyList())
         `when`(priceProcessor.getPriceResponse(any())).thenReturn(PriceResponse(emptyList()))
 
@@ -169,7 +169,7 @@ class PortfolioPriceBackfillServiceTest {
                 asset = assetAapl,
                 tradeDate = LocalDate.of(2025, 3, 10)
             )
-        `when`(trnService.findForPortfolio(portfolio, today)).thenReturn(listOf(trn1, trn2))
+        `when`(trnFinder.findForPortfolio(portfolio, today)).thenReturn(listOf(trn1, trn2))
         `when`(providerUtils.getInputs(any())).thenReturn(emptyList())
         `when`(priceProcessor.getPriceResponse(any())).thenReturn(PriceResponse(emptyList()))
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnControllerTest.kt
@@ -79,6 +79,9 @@ class TrnControllerTest {
     private lateinit var trnService: TrnService
 
     @Autowired
+    private lateinit var trnImportService: TrnImportService
+
+    @Autowired
     private lateinit var enrichmentFactory: EnrichmentFactory
 
     @Autowired
@@ -182,7 +185,7 @@ class TrnControllerTest {
         // Then the existing dividend should be found
         val divi = existingTrns.iterator().next()
         val trustedTrnEvent = TrustedTrnEvent(portfolioA, trnInput = divi)
-        assertThat(trnService.existing(trustedTrnEvent)).isNotNull().isNotEmpty()
+        assertThat(trnImportService.existing(trustedTrnEvent)).isNotNull().isNotEmpty()
 
         // And the dividend should be retrievable via API
         val findByAsset =

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.client.ingest.FxTransactions
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
@@ -8,16 +9,13 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.USD
-import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
-import com.beancounter.marketdata.cash.CashAutoSettleService
 import com.beancounter.marketdata.portfolio.PortfolioService
-import com.beancounter.marketdata.portfolio.PortfolioShareRepository
-import com.beancounter.marketdata.registration.SystemUserService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -27,18 +25,17 @@ import java.time.LocalDate
 import java.util.Optional
 
 /**
- * Focused unit tests for TrnService.settleTransactions covering settlement preconditions
- * (forward-dated trns must not flip to SETTLED) and FX deferral on settle.
+ * Focused unit tests for TrnSettlementService.settleTransactions covering settlement
+ * preconditions (forward-dated trns must not flip to SETTLED) and FX resolution on settle.
  */
 class TrnSettleTest {
     private lateinit var trnRepository: TrnRepository
     private lateinit var portfolioService: PortfolioService
-    private lateinit var trnMigrator: TrnMigrator
     private lateinit var cacheInvalidationProducer: CacheInvalidationProducer
-    private lateinit var systemUserService: SystemUserService
-    private lateinit var trnService: TrnService
     private lateinit var dateUtils: DateUtils
+    private lateinit var fxTransactions: FxTransactions
     private lateinit var cashAutoSettleService: com.beancounter.marketdata.cash.CashAutoSettleService
+    private lateinit var trnPostProcessor: TrnPostProcessor
     private lateinit var trnSettlementService: TrnSettlementService
 
     private val today: LocalDate = LocalDate.of(2026, 6, 6)
@@ -58,40 +55,29 @@ class TrnSettleTest {
     fun setUp() {
         trnRepository = mock()
         portfolioService = mock()
-        trnMigrator = mock()
         cacheInvalidationProducer = mock()
-        systemUserService = mock()
         dateUtils = mock()
+        fxTransactions = mock()
         whenever(dateUtils.date).thenReturn(today)
         whenever(portfolioService.find("pf-1")).thenReturn(portfolio)
-        whenever(trnMigrator.upgrade(any())).thenAnswer { it.arguments[0] as Trn }
-        whenever(systemUserService.getOrThrow()).thenReturn(owner)
         cashAutoSettleService = mock()
         whenever(cashAutoSettleService.emitCompensatingTransfer(any()))
             .thenReturn(
                 com.beancounter.marketdata.cash
                     .AutoSettleResult()
             )
-        trnSettlementService = mock()
-        whenever(trnSettlementService.settle(any(), any())).thenAnswer {
-            val t = it.getArgument<Trn>(1)
-            t.status = TrnStatus.SETTLED
-            t
-        }
-        trnService =
-            TrnService(
+        trnPostProcessor = mock()
+        whenever(trnPostProcessor.postProcess(any<List<Trn>>()))
+            .thenAnswer { it.getArgument<List<Trn>>(0) }
+        trnSettlementService =
+            TrnSettlementService(
                 trnRepository = trnRepository,
-                trnInputMapper = mock(),
-                portfolioService = portfolioService,
-                trnMigrator = trnMigrator,
-                assetFinder = mock<AssetFinder>(),
-                systemUserService = systemUserService,
-                cacheInvalidationProducer = cacheInvalidationProducer,
-                portfolioShareRepository = mock<PortfolioShareRepository>(),
+                fxTransactions = fxTransactions,
                 cashAutoSettleService = cashAutoSettleService,
-                trnSettlementService = trnSettlementService,
+                portfolioService = portfolioService,
+                cacheInvalidationProducer = cacheInvalidationProducer,
                 dateUtils = dateUtils,
-                balanceContributionStamper = mock()
+                trnPostProcessor = trnPostProcessor
             )
     }
 
@@ -101,12 +87,12 @@ class TrnSettleTest {
         whenever(trnRepository.findByPortfolioIdAndId(portfolio.id, "trn-future"))
             .thenReturn(Optional.of(forwardTrn))
 
-        val result = trnService.settleTransactions("pf-1", listOf("trn-future"))
+        val result = trnSettlementService.settleTransactions("pf-1", listOf("trn-future"))
 
         assertThat(result).isEmpty()
         assertThat(forwardTrn.status).isEqualTo(TrnStatus.PROPOSED)
         verify(trnRepository, never()).save(forwardTrn)
-        verify(trnSettlementService, never()).settle(any(), any())
+        verify(fxTransactions, never()).setRates(any<Portfolio>(), any<Trn>())
     }
 
     @Test
@@ -115,11 +101,12 @@ class TrnSettleTest {
         whenever(trnRepository.findByPortfolioIdAndId(portfolio.id, "trn-today"))
             .thenReturn(Optional.of(dueTrn))
 
-        val result = trnService.settleTransactions("pf-1", listOf("trn-today"))
+        val result = trnSettlementService.settleTransactions("pf-1", listOf("trn-today"))
 
         assertThat(result).hasSize(1)
         assertThat(dueTrn.status).isEqualTo(TrnStatus.SETTLED)
-        verify(trnSettlementService).settle(portfolio, dueTrn)
+        verify(fxTransactions).setRates(eq(portfolio), eq(dueTrn))
+        verify(trnRepository).save(dueTrn)
     }
 
     private fun proposed(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
@@ -41,7 +41,16 @@ class TrnSettlementServiceTest {
         fxTransactions = org.mockito.kotlin.mock()
         cashAutoSettleService = org.mockito.kotlin.mock()
         whenever(cashAutoSettleService.emitCompensatingTransfer(any())).thenReturn(AutoSettleResult())
-        service = TrnSettlementService(trnRepository, fxTransactions, cashAutoSettleService)
+        service =
+            TrnSettlementService(
+                trnRepository,
+                fxTransactions,
+                cashAutoSettleService,
+                org.mockito.kotlin.mock(),
+                org.mockito.kotlin.mock(),
+                org.mockito.kotlin.mock(),
+                org.mockito.kotlin.mock()
+            )
     }
 
     private fun proposed(id: String) =

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
@@ -28,6 +28,7 @@ import com.beancounter.marketdata.cash.CashAutoSettleService
 import com.beancounter.marketdata.fx.FxRateService
 import com.beancounter.marketdata.trn.TrnRepository
 import com.beancounter.marketdata.trn.TrnService
+import com.beancounter.marketdata.trn.TrnSettlementService
 import com.beancounter.marketdata.utils.BcMvcHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -70,6 +71,9 @@ class CashAutoSettleServiceTest {
 
     @Autowired
     private lateinit var trnService: TrnService
+
+    @Autowired
+    private lateinit var trnSettlementService: TrnSettlementService
 
     @Autowired
     private lateinit var trnRepository: TrnRepository
@@ -476,7 +480,7 @@ class CashAutoSettleServiceTest {
         val buy = buildBuy(invest, BigDecimal("-2000"))
         assertThat(findAutoSiblings(buy)).hasSize(2)
 
-        val response = trnService.unsettle(buy.id)
+        val response = trnSettlementService.unsettle(buy.id)
 
         assertThat(response.updated.id).isEqualTo(buy.id)
         assertThat(response.updated.status).isEqualTo(TrnStatus.PROPOSED)
@@ -500,7 +504,7 @@ class CashAutoSettleServiceTest {
         val buy = buildBuy(invest, BigDecimal("-1200"), status = TrnStatus.PROPOSED)
         assertThat(findAutoSiblings(buy)).isEmpty()
 
-        trnService.settleTransactions(invest.id, listOf(buy.id))
+        trnSettlementService.settleTransactions(invest.id, listOf(buy.id))
 
         assertThat(findAutoSiblings(buy)).hasSize(2)
     }
@@ -513,7 +517,7 @@ class CashAutoSettleServiceTest {
         assertThat(findAutoSiblings(b1)).hasSize(2)
         assertThat(findAutoSiblings(b2)).hasSize(2)
 
-        val result = trnService.unsettleTransactions(invest.id, listOf(b1.id, b2.id))
+        val result = trnSettlementService.unsettleTransactions(invest.id, listOf(b1.id, b2.id))
 
         assertThat(result).hasSize(2)
         assertThat(result.map { it.status }).containsOnly(TrnStatus.PROPOSED)
@@ -525,9 +529,9 @@ class CashAutoSettleServiceTest {
     fun `unsettle on already PROPOSED trn throws IllegalArgumentException`() {
         mockAuthConfig.login(testUser, systemUserService)
         val buy = buildBuy(invest, BigDecimal("-1000"))
-        trnService.unsettle(buy.id)
+        trnSettlementService.unsettle(buy.id)
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            trnService.unsettle(buy.id)
+            trnSettlementService.unsettle(buy.id)
         }
     }
 


### PR DESCRIPTION
Splits the `TrnService` god-class (26 functions, top detekt TooManyFunctions offender) into cohesive services.

**New / changed:**
- `TrnFinder` — 10 portfolio-scoped read finders
- `TrnPostProcessor` — shared hydrate/migrate/secure (was TrnService.postProcess)
- `TrnSettlementService` — gains settle/unsettle batch lifecycle (joins its per-trn core); settleTransactions flattened via settleOne guard clauses
- `TrnService` — writes only (save/patch/delete/purge), 26 → 10 functions
- `existing` moved to its sole caller `TrnImportService`
- Callers rewired: TrnController, TrnExportController, TrnImportService, TrnQueryService, PortfolioPriceBackfillService
- `@Transactional` preserved on all extracted services (batch atomicity + migration-save-on-read)

Behaviour-preserving; existing suite is the regression guard. Verified: Codacy CLI clean, format + lint + svc-data tests pass.

Note: independent of #994 (NestedBlockDepth/TooGenericException). settleTransactions also flattened here, mirroring #994 — rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)