### PR TITLE
fix(trn): repoint contractTest findForPortfolio to TrnFinder

### DIFF
--- a/svc-data/src/contractTest/kotlin/com/contracts/data/RealestateBase.kt
+++ b/svc-data/src/contractTest/kotlin/com/contracts/data/RealestateBase.kt
@@ -28,6 +28,7 @@ import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.registration.SystemUserRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.BcRowAdapter
+import com.beancounter.marketdata.trn.TrnFinder
 import com.beancounter.marketdata.trn.TrnRepository
 import com.beancounter.marketdata.trn.TrnService
 import io.restassured.RestAssured
@@ -76,6 +77,9 @@ class RealestateBase {
 
     @MockitoBean
     private lateinit var trnService: TrnService
+
+    @MockitoBean
+    private lateinit var trnFinder: TrnFinder
 
     @MockitoBean
     private lateinit var assetService: AssetService
@@ -247,10 +251,10 @@ class RealestateBase {
                 trns
             }
 
-        // Mock TrnService.findForPortfolio method for GET requests
+        // Mock TrnFinder.findForPortfolio method for GET requests
         Mockito
             .`when`(
-                trnService.findForPortfolio(
+                trnFinder.findForPortfolio(
                     any<String>(),
                     any<java.time.LocalDate>()
                 )

--- a/svc-data/src/contractTest/kotlin/com/contracts/data/TrnBase.kt
+++ b/svc-data/src/contractTest/kotlin/com/contracts/data/TrnBase.kt
@@ -18,6 +18,7 @@ import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.portfolio.PortfolioRepository
 import com.beancounter.marketdata.registration.SystemUserRepository
 import com.beancounter.marketdata.registration.SystemUserService
+import com.beancounter.marketdata.trn.TrnFinder
 import com.beancounter.marketdata.trn.TrnQueryService
 import com.beancounter.marketdata.trn.TrnService
 import io.restassured.RestAssured
@@ -62,6 +63,9 @@ class TrnBase {
 
     @MockitoBean
     private lateinit var trnService: TrnService
+
+    @MockitoBean
+    private lateinit var trnFinder: TrnFinder
 
     @MockitoBean
     private lateinit var assetService: AssetService
@@ -182,7 +186,7 @@ class TrnBase {
             )
         Mockito
             .`when`(
-                trnService.findForPortfolio(
+                trnFinder.findForPortfolio(
                     portfolio.id,
                     dateUtils.getFormattedDate(date)
                 )


### PR DESCRIPTION
Hotfix: main build red after #995. `contractTest` is a separate source set not run by `:svc-data:test`, so the TrnService split didn't compile-check it. `RealestateBase`/`TrnBase` stubbed `trnService.findForPortfolio` — now on `TrnFinder`. Mock TrnFinder + repoint; save/saveWithResult stay on TrnService.

Verified: :svc-data:contractTest + lint pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)