### PR TITLE
feat(offboard): delete user's brokers on wealth and assets paths

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/registration/OffboardingService.kt
@@ -19,10 +19,12 @@ import org.springframework.stereotype.Service
  * 1. Transactions (via portfolio and asset)
  * 2. MarketData (via asset)
  * 3. Portfolios
- * 4. Assets
- * 5. TaxRates
- * 6. UserPreferences
- * 7. SystemUser
+ * 4. Settlement accounts (before assets and brokers)
+ * 5. Assets
+ * 6. Brokers (after transactions and assets — trn.broker_id FK)
+ * 7. TaxRates
+ * 8. UserPreferences
+ * 9. SystemUser
  */
 @Service
 @Transactional
@@ -94,7 +96,11 @@ class OffboardingService(
             deletedCount++
         }
 
-        log.info("Deleted {} assets for user {}", deletedCount, user.id)
+        // Delete brokers — safe AFTER trns (trn.broker_id FK) and settlement
+        // accounts are gone. Idempotent bulk delete.
+        val brokerCount = brokerRepository.deleteByOwnerId(user.id)
+
+        log.info("Deleted {} assets, {} brokers for user {}", deletedCount, brokerCount, user.id)
         return OffboardingResult(
             success = true,
             deletedCount = deletedCount,
@@ -166,11 +172,16 @@ class OffboardingService(
             totalDeleted++
         }
 
+        // 4. Delete brokers — safe AFTER trns (trn.broker_id FK) and settlement
+        //    accounts are gone. Idempotent bulk delete.
+        val brokerCount = brokerRepository.deleteByOwnerId(user.id)
+
         log.info(
-            "Deleted wealth data for user {}: {} portfolios, {} assets",
+            "Deleted wealth data for user {}: {} portfolios, {} assets, {} brokers",
             user.id,
             portfolios.size,
-            assets.size
+            assets.size,
+            brokerCount
         )
 
         return OffboardingResult(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/registration/OffboardingServiceTest.kt
@@ -487,6 +487,7 @@ class OffboardingServiceTest {
 
         assertThat(result.success).isTrue()
         assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
     }
 
     // Regression guard (kauri 409): the assets path has the same FK exposure as the wealth and
@@ -520,6 +521,53 @@ class OffboardingServiceTest {
 
         assertThat(result.success).isTrue()
         assertThat(assetRepository.findBySystemUserId(user.id)).isEmpty()
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
+    }
+
+    // Brokers the user created must be removed on offboarding — safe once trns
+    // (trn.broker_id FK) and settlement accounts are gone. The wealth path
+    // deletes assets + their trns, so the broker delete that follows can't trip
+    // the FK. Mirrors the account path's broker cleanup.
+    @Test
+    fun `should delete brokers on wealth deletion`() {
+        val user = SystemUser(id = "offboard-wealth-broker-user", email = "offboard-wealth-broker@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        brokerRepository.save(Broker(name = "Wealth Broker", owner = user))
+
+        val result = offboardingService.deleteUserWealth()
+
+        assertThat(result.success).isTrue()
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
+    }
+
+    // Same broker cleanup on the assets-only path. deleteUserAssets early-returns
+    // when the user owns no assets, so this fixture creates one to exercise the
+    // full delete sequence ending in the broker removal.
+    @Test
+    fun `should delete brokers on assets deletion`() {
+        val user = SystemUser(id = "offboard-assets-broker-user", email = "offboard-assets-broker@test.com")
+        mockAuthConfig.login(user, systemUserService)
+
+        assetService.handle(
+            AssetRequest(
+                mapOf(
+                    "test" to
+                        AssetInput.toRealEstate(
+                            currency = USD,
+                            code = "OFFBOARD-ASSETS-BROKER-RE",
+                            name = "Assets Broker Real Estate",
+                            owner = user.id
+                        )
+                )
+            )
+        )
+        brokerRepository.save(Broker(name = "Assets Broker", owner = user))
+
+        val result = offboardingService.deleteUserAssets()
+
+        assertThat(result.success).isTrue()
+        assertThat(brokerRepository.findByOwner(user)).isEmpty()
     }
 
     // Soft-delete: offboarding deletes the user's DATA but keeps the SystemUser row


### PR DESCRIPTION
Account path already removed brokers; wealth/assets paths left them
orphaned. Delete after trns + assets so the trn.broker_id and
settlement-account FKs are clear. Idempotent bulk delete.