### PR TITLE
feat(trn): rolling 30-day window for Monthly Investment metric

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
@@ -1,0 +1,25 @@
+package com.beancounter.marketdata.trn
+
+import java.time.LocalDate
+
+/**
+ * Default trailing window (in days) for the Monthly Investment metric.
+ * A rolling 30-day window replaces the former calendar-month boundary so the
+ * figure reflects the last month of activity regardless of today's date.
+ */
+const val DEFAULT_INVESTMENT_WINDOW_DAYS = 30
+
+/**
+ * Resolve the rolling investment window: a trailing [days]-day span ending today.
+ *
+ * @param days trailing window length; values < 1 fall back to [DEFAULT_INVESTMENT_WINDOW_DAYS].
+ * @param today window end (inclusive); defaults to the current date.
+ * @return (startDate, endDate) where startDate = today - days and endDate = today.
+ */
+fun investmentWindow(
+    days: Int,
+    today: LocalDate = LocalDate.now()
+): Pair<LocalDate, LocalDate> {
+    val span = if (days < 1) DEFAULT_INVESTMENT_WINDOW_DAYS else days
+    return today.minusDays(span.toLong()) to today
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
@@ -102,9 +102,10 @@ class TrnAnalysisController(
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     @Operation(
-        summary = "Get monthly investment summary",
+        summary = "Get rolling investment summary",
         description = """
-            Returns the net amount invested (BUY + ADD - SELL) in a specific month.
+            Returns the net amount invested (BUY - SELL) over a rolling trailing window
+            (default 30 days, ending today). ADD transactions are excluded as transfers.
             Optionally scoped to specific portfolios and converted to a target currency.
 
             Use this to:
@@ -117,16 +118,17 @@ class TrnAnalysisController(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "Monthly investment summary retrieved successfully",
+                description = "Investment summary retrieved successfully",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
                         examples = [
                             ExampleObject(
-                                name = "Monthly Investment",
+                                name = "Rolling Investment",
                                 value = """
                                 {
-                                  "yearMonth": "2024-01",
+                                  "startDate": "2024-01-01",
+                                  "endDate": "2024-01-31",
                                   "totalInvested": 5000.00,
                                   "currency": "USD"
                                 }
@@ -140,9 +142,9 @@ class TrnAnalysisController(
     )
     fun getMonthlyInvestment(
         @Parameter(
-            description = "Year and month in YYYY-MM format. Defaults to current month.",
-            example = "2024-01"
-        ) @RequestParam(required = false) yearMonth: String?,
+            description = "Trailing window length in days, ending today. Defaults to 30.",
+            example = "30"
+        ) @RequestParam(required = false, defaultValue = "$DEFAULT_INVESTMENT_WINDOW_DAYS") days: Int,
         @Parameter(
             description = "Target currency code for FX conversion. Required for accurate results.",
             example = "USD"
@@ -152,24 +154,20 @@ class TrnAnalysisController(
             example = "portfolio-1,portfolio-2"
         ) @RequestParam(required = false) portfolioIds: String?
     ): MonthlyInvestmentResponse {
-        val month =
-            if (yearMonth != null) {
-                YearMonth.parse(yearMonth)
-            } else {
-                YearMonth.now()
-            }
+        val (startDate, endDate) = investmentWindow(days)
 
         val portfolioIdList = portfolioIds?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
 
         val total =
             if (currency != null) {
-                trnAnalysisService.getMonthlyInvestmentConverted(month, portfolioIdList, currency)
+                trnAnalysisService.getMonthlyInvestmentConverted(startDate, endDate, portfolioIdList, currency)
             } else {
-                trnAnalysisService.getMonthlyInvestment(month)
+                trnAnalysisService.getMonthlyInvestment(startDate, endDate)
             }
 
         return MonthlyInvestmentResponse(
-            yearMonth = month.toString(),
+            startDate = startDate,
+            endDate = endDate,
             totalInvested = total,
             currency = currency
         )
@@ -180,37 +178,32 @@ class TrnAnalysisController(
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     @Operation(
-        summary = "Get monthly investment transactions for current user",
+        summary = "Get rolling investment transactions for current user",
         description = """
-            Returns all investment transactions (BUY and ADD) for the current user
-            in a specific month. Defaults to the current month if not specified.
+            Returns all investment transactions (BUY and SELL) for the current user
+            over a rolling trailing window (default 30 days, ending today).
 
             Use this to:
-            * View individual investment transactions for the month
-            * Provide detailed breakdown of monthly investing activity
+            * View individual investment transactions for the window
+            * Provide detailed breakdown of recent investing activity
         """
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "Monthly investment transactions retrieved successfully"
+                description = "Investment transactions retrieved successfully"
             )
         ]
     )
     fun getMonthlyInvestmentTransactions(
         @Parameter(
-            description = "Year and month in YYYY-MM format. Defaults to current month.",
-            example = "2024-01"
-        ) @RequestParam(required = false) yearMonth: String?
+            description = "Trailing window length in days, ending today. Defaults to 30.",
+            example = "30"
+        ) @RequestParam(required = false, defaultValue = "$DEFAULT_INVESTMENT_WINDOW_DAYS") days: Int
     ): TrnResponse {
-        val month =
-            if (yearMonth != null) {
-                YearMonth.parse(yearMonth)
-            } else {
-                YearMonth.now()
-            }
-        return TrnResponse(trnAnalysisService.getMonthlyInvestmentTransactions(month))
+        val (startDate, endDate) = investmentWindow(days)
+        return TrnResponse(trnAnalysisService.getMonthlyInvestmentTransactions(startDate, endDate))
     }
 
     @GetMapping(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
@@ -31,16 +31,18 @@ class TrnAnalysisService(
     private val log = LoggerFactory.getLogger(TrnAnalysisService::class.java)
 
     /**
-     * Get the total investment amount for the current user in a specific month.
-     * Sums all BUY and ADD transactions across all portfolios.
+     * Get the net investment amount for the current user over a date range.
+     * Sums BUY - SELL (ADD excluded as transfers) across all portfolios.
      *
-     * @param yearMonth The month to calculate (e.g., YearMonth.now() for current month)
-     * @return Total investment amount for the month
+     * @param startDate window start (inclusive)
+     * @param endDate window end (inclusive)
+     * @return Total net investment for the window
      */
-    fun getMonthlyInvestment(yearMonth: YearMonth): BigDecimal {
+    fun getMonthlyInvestment(
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): BigDecimal {
         val user = systemUserService.getOrThrow()
-        val startDate = yearMonth.atDay(1)
-        val endDate = yearMonth.atEndOfMonth()
         val total =
             trnRepository.sumInvestmentsByOwnerAndDateRange(
                 user,
@@ -48,21 +50,23 @@ class TrnAnalysisService(
                 endDate,
                 TrnStatus.SETTLED
             )
-        log.trace("Monthly investment for $yearMonth: $total")
+        log.trace("Investment for $startDate..$endDate: $total")
         return total
     }
 
     /**
-     * Get all investment transactions for the current user in a specific month.
-     * Returns individual BUY and ADD transactions across all portfolios.
+     * Get all investment transactions for the current user over a date range.
+     * Returns individual BUY and SELL transactions across all portfolios.
      *
-     * @param yearMonth The month to query
+     * @param startDate window start (inclusive)
+     * @param endDate window end (inclusive)
      * @return Collection of investment transactions
      */
-    fun getMonthlyInvestmentTransactions(yearMonth: YearMonth): Collection<Trn> {
+    fun getMonthlyInvestmentTransactions(
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): Collection<Trn> {
         val user = systemUserService.getOrThrow()
-        val startDate = yearMonth.atDay(1)
-        val endDate = yearMonth.atEndOfMonth()
         val results =
             trnRepository.findInvestmentsByOwnerAndDateRange(
                 user,
@@ -70,27 +74,26 @@ class TrnAnalysisService(
                 endDate,
                 TrnStatus.SETTLED
             )
-        log.trace("Monthly investment trns: ${results.size} in $yearMonth")
+        log.trace("Investment trns: ${results.size} in $startDate..$endDate")
         return results.toList()
     }
 
     /**
-     * Get net investment for specific portfolios in a month, converted to target currency.
-     * Calculates: BUY + ADD - SELL with FX conversion.
+     * Get net investment for specific portfolios over a date range, converted to target currency.
+     * Calculates: BUY - SELL with FX conversion.
      *
-     * @param yearMonth The month to calculate
+     * @param startDate window start (inclusive)
+     * @param endDate window end (inclusive)
      * @param portfolioIds List of portfolio IDs to include (empty = all user's portfolios)
      * @param targetCurrency Currency code to convert amounts to
      * @return Net investment amount in target currency
      */
     fun getMonthlyInvestmentConverted(
-        yearMonth: YearMonth,
+        startDate: LocalDate,
+        endDate: LocalDate,
         portfolioIds: List<String>,
         targetCurrency: String
     ): BigDecimal {
-        val startDate = yearMonth.atDay(1)
-        val endDate = yearMonth.atEndOfMonth()
-
         // Fetch transactions for the specified portfolios
         val transactions =
             if (portfolioIds.isEmpty()) {
@@ -130,7 +133,7 @@ class TrnAnalysisService(
                 }
         }
 
-        log.trace("Monthly investment for $yearMonth in $targetCurrency: $total (${transactions.size} trns)")
+        log.trace("Investment for $startDate..$endDate in $targetCurrency: $total (${transactions.size} trns)")
         return total
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
@@ -47,10 +47,12 @@ data class BrokerHoldingsResponse(
 )
 
 /**
- * Response for monthly investment summary.
+ * Response for the rolling investment window summary.
+ * [startDate]..[endDate] describe the trailing window the total covers.
  */
 data class MonthlyInvestmentResponse(
-    val yearMonth: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
     val totalInvested: BigDecimal,
     val currency: String? = null
 )

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/InvestmentWindowTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/InvestmentWindowTest.kt
@@ -1,0 +1,39 @@
+package com.beancounter.marketdata.trn
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+/**
+ * Verifies the rolling investment window that backs the Monthly Investment metric.
+ */
+class InvestmentWindowTest {
+    private val today = LocalDate.of(2026, 7, 1)
+
+    @Test
+    fun `default 30-day trailing window ends today`() {
+        val (start, end) = investmentWindow(DEFAULT_INVESTMENT_WINDOW_DAYS, today)
+        assertThat(end).isEqualTo(today)
+        assertThat(start).isEqualTo(LocalDate.of(2026, 6, 1))
+    }
+
+    @Test
+    fun `custom window length is honoured`() {
+        val (start, end) = investmentWindow(7, today)
+        assertThat(end).isEqualTo(today)
+        assertThat(start).isEqualTo(LocalDate.of(2026, 6, 24))
+    }
+
+    @Test
+    fun `crosses month and year boundaries`() {
+        val (start, end) = investmentWindow(30, LocalDate.of(2026, 1, 15))
+        assertThat(end).isEqualTo(LocalDate.of(2026, 1, 15))
+        assertThat(start).isEqualTo(LocalDate.of(2025, 12, 16))
+    }
+
+    @Test
+    fun `non-positive days falls back to default`() {
+        assertThat(investmentWindow(0, today).first).isEqualTo(LocalDate.of(2026, 6, 1))
+        assertThat(investmentWindow(-5, today).first).isEqualTo(LocalDate.of(2026, 6, 1))
+    }
+}


### PR DESCRIPTION
Replace the calendar-month boundary with a trailing rolling window (default 30 days, ending today) for the Monthly Investment metric. New investmentWindow() helper resolves the window; controller exposes a days query param; MonthlyInvestmentResponse now returns startDate/endDate instead of yearMonth.