### PR TITLE
feat(providers): retry transient provider I/O with backoff

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/figi/FigiGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.assets.figi
 
+import io.github.resilience4j.retry.annotation.Retry
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
@@ -17,6 +18,7 @@ class FigiGateway(
     /**
      * Enrichment lookup - exact ticker match using /v3/mapping.
      */
+    @Retry(name = "providerHttp")
     fun search(
         searchBody: Collection<FigiSearch>,
         apiKey: String
@@ -35,6 +37,7 @@ class FigiGateway(
      * Keyword search using /v3/search endpoint.
      * Supports partial name/ticker matching.
      */
+    @Retry(name = "providerHttp")
     fun filter(
         request: FigiFilterRequest,
         apiKey: String

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/fxrates/FrankfurterGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/fxrates/FrankfurterGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.fx.fxrates
 
+import io.github.resilience4j.retry.annotation.Retry
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
@@ -14,6 +15,7 @@ class FrankfurterGateway(
     @Qualifier("frankfurterRestClient")
     private val restClient: RestClient
 ) {
+    @Retry(name = "providerHttp")
     fun getRatesForSymbols(
         date: String,
         base: String,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/fxrates/FxGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/fxrates/FxGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.fx.fxrates
 
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -19,6 +20,7 @@ class FxGateway(
 ) {
     private val log = LoggerFactory.getLogger(FxGateway::class.java)
 
+    @Retry(name = "providerHttp")
     fun getRatesForSymbols(
         date: String,
         base: String,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.alpha
 
+import io.github.resilience4j.retry.annotation.Retry
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
@@ -13,6 +14,7 @@ class AlphaGateway(
     @Qualifier("alphaVantageRestClient")
     private val restClient: RestClient
 ) {
+    @Retry(name = "providerHttp")
     fun getCurrent(
         assetId: String,
         apiKey: String
@@ -24,6 +26,7 @@ class AlphaGateway(
             .body<String>()
             ?: ""
 
+    @Retry(name = "providerHttp")
     fun getHistoric(
         assetId: String?,
         apiKey: String?
@@ -35,6 +38,7 @@ class AlphaGateway(
             .body<String>()
             ?: ""
 
+    @Retry(name = "providerHttp")
     fun getAdjusted(
         assetId: String?,
         apiKey: String?
@@ -49,6 +53,7 @@ class AlphaGateway(
             .body<String>()
             ?: ""
 
+    @Retry(name = "providerHttp")
     fun search(
         symbol: String?,
         apiKey: String?
@@ -64,6 +69,7 @@ class AlphaGateway(
      * Get company overview including sector and industry.
      * Used for Equity classification.
      */
+    @Retry(name = "providerHttp")
     fun getOverview(
         symbol: String,
         apiKey: String
@@ -79,6 +85,7 @@ class AlphaGateway(
      * Get ETF profile including sector allocations.
      * Used for ETF exposure classification.
      */
+    @Retry(name = "providerHttp")
     fun getEtfProfile(
         symbol: String,
         apiKey: String
@@ -90,6 +97,7 @@ class AlphaGateway(
             .body<String>()
             ?: ""
 
+    @Retry(name = "providerHttp")
     fun getNewsSentiment(
         tickers: String,
         apiKey: String,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackGateway.kt
@@ -2,6 +2,7 @@ package com.beancounter.marketdata.providers.marketstack
 
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackTickerResponse
+import io.github.resilience4j.retry.annotation.Retry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ class MarketStackGateway(
 ) {
     private val log = LoggerFactory.getLogger(MarketStackGateway::class.java)
 
+    @Retry(name = "providerHttp")
     fun getPrices(
         assetId: String,
         date: String,
@@ -45,6 +47,7 @@ class MarketStackGateway(
             }
         }
 
+    @Retry(name = "providerHttp")
     fun getHistory(
         symbol: String,
         dateFrom: String,
@@ -72,6 +75,7 @@ class MarketStackGateway(
      * @param apiKey MarketStack API key
      * @param limit Maximum number of results
      */
+    @Retry(name = "providerHttp")
     fun searchTickers(
         exchangeMic: String,
         searchTerm: String,

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -275,6 +275,18 @@ resilience4j:
         waitDuration: 10s
         enableExponentialBackoff: true
         exponentialBackoffMultiplier: 2
+      # Outbound market-data provider HTTP (FX / prices / FIGI search).
+      # Retries only transient network faults (ResourceAccessException wraps
+      # "I/O error ... Try again", read timeouts, connection resets) so a single
+      # blip no longer fails the whole request or aborts a price batch. 4xx/5xx
+      # business errors are NOT retried — they surface immediately.
+      providerHttp:
+        maxRetryAttempts: 3
+        waitDuration: 500ms
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retryExceptions:
+          - org.springframework.web.client.ResourceAccessException
 
 beancounter:
   # Default FX rate provider: FRANKFURTER (free, unlimited) or EXCHANGE_RATES_API

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackApiTest.kt
@@ -18,6 +18,7 @@ import com.beancounter.marketdata.providers.marketstack.model.MarketStackData
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -334,6 +335,55 @@ internal class MarketStackApiTest {
     /**
      * Constants for MarketStack.
      **/
+    @Test
+    fun `retries a transient provider I-O fault and recovers instead of aborting the batch`() {
+        // DATA-4Y / POSITION-45..48: a single transient network blip
+        // (ResourceAccessException) from MarketStack used to abort the whole
+        // price batch and surface as a 500. @Retry(name="providerHttp") on the
+        // gateway now retries the call, so a fault-then-success sequence yields
+        // prices rather than failing.
+        val inputs =
+            mutableListOf(
+                PriceAsset(AAPL),
+                PriceAsset(MSFT)
+            )
+        val response =
+            getResponseMap(
+                ClassPathResource("$CONTRACTS/${AAPL.code}-${MSFT.code}.json").file
+            )
+        val url = "/v2/eod/$priceDate?symbols=AAPL%2CMSFT&access_key=demo"
+        val scenario = "marketstack-transient"
+        // First attempt: connection reset -> ResourceAccessException.
+        wireMock.stubFor(
+            WireMock
+                .get(WireMock.urlEqualTo(url))
+                .inScenario(scenario)
+                .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                .willSetStateTo("recovered")
+                .willReturn(WireMock.aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+        // Retry: succeeds with a valid body.
+        wireMock.stubFor(
+            WireMock
+                .get(WireMock.urlEqualTo(url))
+                .inScenario(scenario)
+                .whenScenarioStateIs("recovered")
+                .willReturn(
+                    WireMock
+                        .aResponse()
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(objectMapper.writeValueAsString(response))
+                        .withStatus(200)
+                )
+        )
+
+        val mdResult = marketStackService.getMarketData(PriceRequest(priceDate, inputs))
+
+        assertThat(mdResult)
+            .isNotNull
+            .hasSize(2)
+    }
+
     companion object {
         @JvmField
         @RegisterExtension


### PR DESCRIPTION
Wrap the FX / price / FIGI-search provider gateways in Resilience4j
@Retry(name="providerHttp") so a transient ResourceAccessException
(I/O 'Try again', read timeout, connection reset) is retried with
exponential backoff instead of failing the request or aborting a
MarketStack price batch. Scoped to ResourceAccessException only, so
4xx/5xx business errors still surface immediately.

Fixes DATA-4Y
Fixes DATA-5R