### PR TITLE
feat(agent): thread conversation history through AgentQuery

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/AgentController.kt
@@ -10,6 +10,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.ai.anthropic.AnthropicCacheOptions
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.metadata.Usage
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.beans.factory.annotation.Autowired
@@ -74,7 +77,28 @@ class AgentController(
         // enough to outlast a real outage — that surfaces as the error envelope.
         const val STREAM_RETRY_ATTEMPTS = 2L
         val STREAM_RETRY_MIN_BACKOFF: Duration = Duration.ofMillis(250)
+
+        // Caller-supplied history is trusted only up to this many trailing
+        // turns — bounds the tokens a single request can push into the
+        // prompt regardless of what the client sends.
+        const val MAX_HISTORY_TURNS = 6
     }
+
+    /**
+     * Map caller-supplied conversation history onto Spring AI [Message]s,
+     * truncated to the trailing [MAX_HISTORY_TURNS]. Plain text only — this
+     * replays the model's own prior *rendered* answers as ordinary assistant
+     * turns, never the raw `reasoning_content` a thinking-mode response
+     * carries, so it doesn't touch the known DeepSeek thinking-mode
+     * multi-turn tool-call round-trip issue.
+     */
+    internal fun historyMessages(request: AgentQuery): List<Message> =
+        request.history
+            ?.takeLast(MAX_HISTORY_TURNS)
+            ?.map { turn ->
+                if (turn.role == "assistant") AssistantMessage(turn.content) else UserMessage(turn.content)
+            }
+            ?: emptyList()
 
     /**
      * Anthropic-only feature: the per-call model override uses
@@ -178,6 +202,7 @@ class AgentController(
                 clientFor(request)
                     .prompt()
                     .system(systemPrompt)
+                    .messages(historyMessages(request))
                     .user(userMessage)
                     .tools(*tools)
             // Per-call options REPLACE (not merge) the ChatClient's default
@@ -410,6 +435,7 @@ class AgentController(
             clientFor(request)
                 .prompt()
                 .system(systemPromptSelector.selectFor(request.context))
+                .messages(historyMessages(request))
                 .user(buildUserMessage(request))
                 .tools(*tools)
         return buildOptions(modelId, request.deepThink)?.let { opts ->
@@ -559,7 +585,24 @@ data class AgentQuery(
      * or `claude-opus-*`). Off by default; flips model selection regardless of
      * page-context routing in [ChatModelSelector].
      */
-    val deepThink: Boolean = false
+    val deepThink: Boolean = false,
+    /**
+     * Prior conversation turns, oldest first, so the model can see its own
+     * previous question when the user replies to it instead of retyping the
+     * whole enriched question every round. Caller-supplied and scoped to
+     * this request only — no server-side persistence. Truncated server-side
+     * to the trailing few turns regardless of length.
+     */
+    val history: List<ChatTurn>? = null
+)
+
+/**
+ * One turn of caller-supplied conversation history. [role] is `"user"` or
+ * `"assistant"`; anything else is treated as `"user"`.
+ */
+data class ChatTurn(
+    val role: String,
+    val content: String
 )
 
 data class AgentResponse(

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/AgentControllerTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
 import org.springframework.mock.env.MockEnvironment
@@ -614,5 +615,92 @@ class AgentControllerTest {
                 permissiveAuthorizer
             )
         assertThat(ctrl.buildOptions("anything", deepThink = true)).isNull()
+    }
+
+    @Test
+    fun `historyMessages returns empty list when history is null`() {
+        assertThat(controller().historyMessages(AgentQuery("hi"))).isEmpty()
+    }
+
+    @Test
+    fun `historyMessages returns empty list when history is empty`() {
+        assertThat(controller().historyMessages(AgentQuery("hi", history = emptyList()))).isEmpty()
+    }
+
+    @Test
+    fun `historyMessages maps roles to Message types preserving order`() {
+        val history =
+            listOf(
+                ChatTurn("user", "what's my NZD exposure?"),
+                ChatTurn("assistant", "which portfolio — Kiwi or Global?"),
+                ChatTurn("user", "Kiwi")
+            )
+
+        val messages = controller().historyMessages(AgentQuery("hi", history = history))
+
+        assertThat(messages).containsExactly(
+            UserMessage("what's my NZD exposure?"),
+            AssistantMessage("which portfolio — Kiwi or Global?"),
+            UserMessage("Kiwi")
+        )
+    }
+
+    @Test
+    fun `historyMessages truncates to the trailing 6 turns`() {
+        val history = (1..10).map { ChatTurn("user", "turn $it") }
+
+        val messages = controller().historyMessages(AgentQuery("hi", history = history))
+
+        assertThat(messages).hasSize(6)
+        assertThat(messages).containsExactly(
+            UserMessage("turn 5"),
+            UserMessage("turn 6"),
+            UserMessage("turn 7"),
+            UserMessage("turn 8"),
+            UserMessage("turn 9"),
+            UserMessage("turn 10")
+        )
+    }
+
+    @Test
+    fun `query threads history onto the prompt before the current user message`() {
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val callResponse = mock<ChatClient.CallResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.call()).thenReturn(callResponse)
+        whenever(callResponse.chatResponse()).thenReturn(null)
+        whenever(callResponse.content()).thenReturn("Kiwi it is")
+        val history = listOf(ChatTurn("assistant", "which portfolio?"))
+
+        controller(chatClient = client).query(AgentQuery("Kiwi", history = history))
+
+        org.mockito.kotlin
+            .verify(request)
+            .messages(listOf(AssistantMessage("which portfolio?")))
+    }
+
+    @Test
+    fun `stream threads history onto the prompt before the current user message`() {
+        val request =
+            mock<ChatClient.ChatClientRequestSpec>(
+                defaultAnswer = org.mockito.Answers.RETURNS_SELF
+            )
+        val streamResponse = mock<ChatClient.StreamResponseSpec>()
+        val client = mock<ChatClient> { on { prompt() } doReturn request }
+        whenever(request.stream()).thenReturn(streamResponse)
+        whenever(streamResponse.chatResponse()).thenReturn(Flux.just(textResponse("ok")))
+        val history = listOf(ChatTurn("user", "earlier question"))
+
+        controller(chatClient = client)
+            .stream(AgentQuery("follow-up", history = history))
+            .collectList()
+            .block()
+
+        org.mockito.kotlin
+            .verify(request)
+            .messages(listOf(UserMessage("earlier question")))
     }
 }


### PR DESCRIPTION
Lets a user answer the agent's own clarifying question instead of
retyping the whole enriched query each round. History is caller-supplied
plain text per request (no persistence, no sessionId), truncated
server-side to the trailing 6 turns.