### PR TITLE
fix(agent): rebalance domain defaults to latest plan, not just approved

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -384,15 +384,29 @@ object DomainSystemPrompts {
 
         - `listRebalanceModels`, `getRebalanceModel(id)` — target
           allocation templates.
-        - `listRebalancePlans`, `getApprovedRebalancePlan(id)`,
-          `getRebalancePlan(id)` — concrete rebalance plans.
+        - `listRebalancePlans(modelId)` — every plan version, newest first
+          (highest `version`). Each entry carries `status` (`DRAFT` or
+          `APPROVED`).
+        - `getApprovedRebalancePlan(modelId)` — the latest APPROVED plan
+          only — the live target used for actual rebalance calculations.
+        - `getRebalancePlan(modelId, planId)` — a specific plan version by
+          id, DRAFT or APPROVED.
         - Context: `listPortfolios`, `getPortfolio(code)`,
           `getPositions(code)`.
 
         ### Workflow
 
-        - By name: `listRebalanceModels` → match name →
-          `getApprovedRebalancePlan(id)`.
+        - **Review / look at a plan** (default — "review my plan", "what's
+          in it", no explicit "approved"/"live"/"current" wording):
+          `listRebalanceModels` → match name → `listRebalancePlans(modelId)`
+          → take the FIRST entry (highest version) → `getRebalancePlan(
+          modelId, planId)`. This picks up an in-progress DRAFT
+          automatically — do not ask the user whether they mean the draft;
+          the latest version IS what "my plan" means. If its `status` is
+          `DRAFT`, say so plainly ("this is an unapproved draft, v3") so
+          the user knows it isn't live yet.
+        - **Explicit approved/live/current target**: `listRebalanceModels`
+          → match name → `getApprovedRebalancePlan(modelId)`.
         - Drift analysis: compare `getRebalanceModel` targets against
           current `getPositions` weights. Highlight the largest gaps.
         """.trimIndent()

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/RebalanceTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/RebalanceTools.kt
@@ -54,9 +54,13 @@ class RebalanceTools(
                 "composite structure (if it references other models), base currency and " +
                 "ownership/transfer state."
         const val LIST_PLANS_DESC =
-            "List every versioned plan for a given model. A plan captures the target " +
-                "weights + asset prices at a point in time and can be in DRAFT or APPROVED " +
-                "state. Returns plan ids, versions, statuses and approval timestamps."
+            "List every versioned plan for a given model, newest first (highest version). " +
+                "A plan captures the target weights + asset prices at a point in time and " +
+                "can be in DRAFT or APPROVED state. Returns plan ids, versions, statuses and " +
+                "approval timestamps. The first entry is the plan the user means by 'my " +
+                "plan' or 'review it' even when still DRAFT — use its id with " +
+                "getRebalancePlan, not getApprovedRebalancePlan, unless the user explicitly " +
+                "wants the approved/live target."
         const val APPROVED_PLAN_DESC =
             "Return the latest APPROVED plan for a model — the authoritative target " +
                 "allocation used for actual rebalance calculations. Use this when the " +


### PR DESCRIPTION
"Review my plan" landed on getApprovedRebalancePlan only, so a pending
DRAFT was invisible unless the user explicitly said "draft". Workflow
now takes listRebalancePlans' first (highest-version) entry by default
and only calls getApprovedRebalancePlan for explicit approved/live/
current requests; tool description states the same contract.