### PR TITLE
fix(assets): header search no longer hides cross-market ticker duplicates

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetSearchService.kt
@@ -239,9 +239,10 @@ class AssetSearchService(
      * dedupe, since discarding a row here would make a market-scoped search seem to have no
      * local match even when one exists (e.g. same code listed on both US and LON).
      *
-     * When [market] is null (header bar), the same code can legitimately appear once per
-     * market, so results are deduped by code with a US-priority tiebreak — the header search
-     * surfaces one row per code rather than every market's variant.
+     * When [market] is null (header bar), the same code can legitimately appear on more than
+     * one market (e.g. SMOT on both US and LON) — every variant is returned, US-first, so the
+     * caller's market-grouped display can surface all of them rather than silently dropping
+     * whichever market lost an internal tiebreak.
      */
     private fun searchLocalDbAssets(
         keyword: String,
@@ -252,15 +253,7 @@ class AssetSearchService(
             if (market != null) {
                 assets.filter { it.marketCode.equals(market, ignoreCase = true) }
             } else {
-                val marketPriority = listOf("US", "NYSE", "NASDAQ", "ASX", "NZX")
-                assets
-                    .groupBy { it.code.uppercase() }
-                    .map { (_, variants) ->
-                        variants.minByOrNull { asset ->
-                            val idx = marketPriority.indexOf(asset.marketCode)
-                            if (idx >= 0) idx else marketPriority.size
-                        } ?: variants.first()
-                    }
+                assets.sortedBy { if (it.marketCode.uppercase() in US_MARKETS) 0 else 1 }
             }
         return scoped.take(50).map { toLocalSearchResult(it) }
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetSearchPublicFallbackTest.kt
@@ -471,6 +471,47 @@ class AssetSearchPublicFallbackTest {
             .containsExactly("LON")
     }
 
+    @Test
+    fun `null-market search returns every market variant of a colliding code`() {
+        // Regression: searchLocalDbAssets deduped null-market DB hits down to one row per
+        // code (US-priority tiebreak), so a newly created LON asset sharing a US ticker
+        // (e.g. SMOT) never reached the header search results at all.
+        val smotUs =
+            com.beancounter.common.model.Asset(
+                id = "smot-us",
+                code = "SMOT",
+                name = "VanEck SMOT US",
+                market =
+                    com.beancounter.common.model
+                        .Market("US", currencyId = "USD"),
+                marketCode = "US",
+                category = "Equity"
+            )
+        val smotLon =
+            com.beancounter.common.model.Asset(
+                id = "smot-lon",
+                code = "SMOT",
+                name = "VanEck SMOT LON",
+                market =
+                    com.beancounter.common.model
+                        .Market("LON", currencyId = "USD"),
+                marketCode = "LON",
+                category = "Equity"
+            )
+        val (service, _) =
+            buildService(
+                marketProvider = mock { on { searchAssets(any(), anyOrNull()) } doReturn emptyList() },
+                dbAssets = listOf(smotUs, smotLon),
+                alphaProxy = mock<AlphaProxy>()
+            )
+
+        val results = service.search("SMOT", null)
+
+        assertThat(results.data)
+            .extracting<String> { it.market }
+            .containsExactlyInAnyOrder("US", "LON")
+    }
+
     companion object {
         private const val MUTUAL_FUND = "Mutual Fund"
         private const val HYSA_NAME = "Pacer International HY Corp Bond ETF"


### PR DESCRIPTION
Null-market DB search collapsed same-code hits to one row (US-priority
tiebreak), so a market outside that list (e.g. LON) never surfaced in
header search even though it existed. Return every market variant,
US-first, matching the market-scoped path's no-dedupe behavior.