### PR TITLE
fix(providers): shared null-safe supportsMarketCode + logApiKeyStatus dedup

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/DataProviderConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/DataProviderConfig.kt
@@ -20,4 +20,16 @@ interface DataProviderConfig {
     ): LocalDate
 
     fun getPriceCode(asset: Asset): String
+
+    /**
+     * Null-safe market-code membership check shared by all price providers.
+     *
+     * A null or blank [markets] allowlist means the provider supports no markets.
+     * Preserves the MarketStack `isBlank()` guard alongside Alpha's `?.contains` pattern:
+     * both collapse to `false` here without a `!!` or NPE risk.
+     */
+    fun supportsMarketCode(
+        markets: String?,
+        code: String
+    ): Boolean = !markets.isNullOrBlank() && markets.contains(code)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderLogUtils.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderLogUtils.kt
@@ -1,0 +1,28 @@
+package com.beancounter.marketdata.providers
+
+import org.slf4j.Logger
+
+/**
+ * Logs the configured API key status at service startup, masking any non-demo key as
+ * "** Redacted **".
+ *
+ * A key whose value starts with "demo" (case-insensitive) is treated as a placeholder
+ * and [demoLabel] is emitted in the log so the environment-variable name and configured
+ * mode are both visible.  The [demoLabel] default ("demo") matches AlphaVantage and EODHD;
+ * pass "DEMO" for MarketStack to preserve its conventional uppercase label.
+ *
+ * Log output is byte-for-byte identical to the three inline `@PostConstruct logStatus()`
+ * blocks it replaces:
+ *   "BEANCOUNTER_MARKET_PROVIDERS_ALPHA_KEY: demo"   / "** Redacted **"
+ *   "BEANCOUNTER_MARKET_PROVIDERS_EODHD_KEY: demo"   / "** Redacted **"
+ *   "BEANCOUNTER_MARKET_PROVIDERS_MSTACK_KEY: DEMO"  / "** Redacted **"
+ */
+fun logApiKeyStatus(
+    logger: Logger,
+    keyName: String,
+    apiKey: String,
+    demoLabel: String = "demo"
+) {
+    val display = if (apiKey.startsWith("demo", ignoreCase = true)) demoLabel else "** Redacted **"
+    logger.info("{}: {}", keyName, display)
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceService.kt
@@ -11,6 +11,7 @@ import com.beancounter.common.telemetry.runBlockingTraced
 import com.beancounter.marketdata.providers.MarketDataPriceProvider
 import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
+import com.beancounter.marketdata.providers.logApiKeyStatus
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.CancellationException
@@ -50,23 +51,7 @@ class AlphaPriceService(
     }
 
     @PostConstruct
-    fun logStatus() =
-        log.info(
-            "BEANCOUNTER_MARKET_PROVIDERS_ALPHA_KEY: {}",
-            if (apiKey
-                    .substring(
-                        0,
-                        4
-                    ).equals(
-                        "demo",
-                        ignoreCase = true
-                    )
-            ) {
-                "demo"
-            } else {
-                "** Redacted **"
-            }
-        )
+    fun logStatus() = logApiKeyStatus(log, "BEANCOUNTER_MARKET_PROVIDERS_ALPHA_KEY", apiKey)
 
     override fun getMarketData(priceRequest: PriceRequest): Collection<MarketData> {
         val providerArguments = getInstance(priceRequest, alphaConfig)
@@ -141,7 +126,7 @@ class AlphaPriceService(
 
     override fun getId(): String = ID
 
-    override fun isMarketSupported(market: Market) = alphaConfig.markets?.contains(market.code) ?: false
+    override fun isMarketSupported(market: Market) = alphaConfig.supportsMarketCode(alphaConfig.markets, market.code)
 
     override fun getDate(
         market: Market,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdPriceService.kt
@@ -12,6 +12,7 @@ import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
 import com.beancounter.marketdata.providers.eodhd.model.EodhdBulkPrice
 import com.beancounter.marketdata.providers.eodhd.model.EodhdSearchResult
+import com.beancounter.marketdata.providers.logApiKeyStatus
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -35,16 +36,7 @@ class EodhdPriceService(
     private val log = LoggerFactory.getLogger(EodhdPriceService::class.java)
 
     @PostConstruct
-    fun logStatus() {
-        log.info(
-            "BEANCOUNTER_MARKET_PROVIDERS_EODHD_KEY: {}",
-            if (eodhdConfig.apiKey.equals("demo", ignoreCase = true)) {
-                "demo"
-            } else {
-                "** Redacted **"
-            }
-        )
-    }
+    fun logStatus() = logApiKeyStatus(log, "BEANCOUNTER_MARKET_PROVIDERS_EODHD_KEY", eodhdConfig.apiKey)
 
     override fun getMarketData(priceRequest: PriceRequest): Collection<MarketData> {
         val providerArguments = getInstance(priceRequest, eodhdConfig, dateUtils)
@@ -199,11 +191,7 @@ class EodhdPriceService(
     override fun getId(): String = ID
 
     override fun isMarketSupported(market: Market): Boolean =
-        if (eodhdConfig.markets.isNullOrBlank()) {
-            false
-        } else {
-            eodhdConfig.markets!!.contains(market.code)
-        }
+        eodhdConfig.supportsMarketCode(eodhdConfig.markets, market.code)
 
     override fun getDate(
         market: Market,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackService.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.MarketDataPriceProvider
 import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.ProviderArguments.Companion.getInstance
+import com.beancounter.marketdata.providers.logApiKeyStatus
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
@@ -32,20 +33,7 @@ class MarketStackService(
     private val log = LoggerFactory.getLogger(MarketStackService::class.java)
 
     @PostConstruct
-    fun logStatus() {
-        log.info(
-            "BEANCOUNTER_MARKET_PROVIDERS_MSTACK_KEY: {}",
-            if (marketStackConfig.apiKey.equals(
-                    "DEMO",
-                    ignoreCase = true
-                )
-            ) {
-                "DEMO"
-            } else {
-                "** Redacted **"
-            }
-        )
-    }
+    fun logStatus() = logApiKeyStatus(log, "BEANCOUNTER_MARKET_PROVIDERS_MSTACK_KEY", marketStackConfig.apiKey, "DEMO")
 
     override fun getMarketData(priceRequest: PriceRequest): Collection<MarketData> {
         val apiRequests: MutableMap<Int, MarketStackResponse> = mutableMapOf()
@@ -92,11 +80,7 @@ class MarketStackService(
     override fun getId(): String = ID
 
     override fun isMarketSupported(market: Market): Boolean =
-        if (marketStackConfig.markets!!.isBlank()) {
-            false
-        } else {
-            marketStackConfig.markets!!.contains(market.code)
-        }
+        marketStackConfig.supportsMarketCode(marketStackConfig.markets, market.code)
 
     override fun getDate(
         market: Market,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderConfigTest.kt
@@ -1,0 +1,57 @@
+package com.beancounter.marketdata.providers
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+/**
+ * Unit tests for [DataProviderConfig.supportsMarketCode] — the shared null-safe helper
+ * that drives [isMarketSupported] across all three price providers.
+ *
+ * Tests the four cases called out in CLEANUP_SPEC.md TASK C:
+ *   null markets  — always not supported
+ *   blank markets — always not supported (preserves MarketStack's isBlank() guard)
+ *   hit           — code present in allowlist → supported
+ *   miss          — code absent from allowlist → not supported
+ */
+internal class DataProviderConfigTest {
+    /** Minimal no-op implementation to exercise the interface default method. */
+    private val config: DataProviderConfig =
+        object : DataProviderConfig {
+            override fun getBatchSize() = 1
+
+            override fun getMarketDate(
+                market: Market,
+                date: String,
+                currentMode: Boolean
+            ): LocalDate = LocalDate.now()
+
+            override fun getPriceCode(asset: Asset): String = asset.code
+        }
+
+    @Test
+    fun `supportsMarketCode returns false when markets is null`() {
+        assertThat(config.supportsMarketCode(null, "US")).isFalse()
+    }
+
+    @Test
+    fun `supportsMarketCode returns false when markets is blank`() {
+        assertThat(config.supportsMarketCode("", "US")).isFalse()
+        assertThat(config.supportsMarketCode("   ", "US")).isFalse()
+    }
+
+    @Test
+    fun `supportsMarketCode returns true when code is present in allowlist`() {
+        assertThat(config.supportsMarketCode("US,ASX,LON", "US")).isTrue()
+        assertThat(config.supportsMarketCode("US,ASX,LON", "ASX")).isTrue()
+        assertThat(config.supportsMarketCode("US,ASX,LON", "LON")).isTrue()
+    }
+
+    @Test
+    fun `supportsMarketCode returns false when code is absent from allowlist`() {
+        assertThat(config.supportsMarketCode("US,ASX,LON", "SGX")).isFalse()
+        assertThat(config.supportsMarketCode("US,ASX,LON", "NZX")).isFalse()
+    }
+}


### PR DESCRIPTION
Replace three divergent isMarketSupported bodies (MarketStackService used
markets!! risking NPE; EodhdPriceService used markets!! after a null guard;
AlphaPriceService was the correct reference) with a single default method on
DataProviderConfig. The shared supportsMarketCode(markets, code) uses
isNullOrBlank() so null and blank markets both return false, preserving
MarketStack's blank-guard and Alpha's safe-navigation pattern.

Extract logApiKeyStatus(logger, keyName, apiKey, demoLabel) top-level helper
to deduplicate three near-identical @PostConstruct logStatus() blocks. Log
output is byte-for-byte identical per service: Alpha and EODHD emit "demo",
MarketStack emits "DEMO", all redact real keys as "** Redacted **".

New AssertJ unit tests cover null / blank / hit / miss for supportsMarketCode.