### PR TITLE
fix(providers): exact market-code matching, correct ProviderLogUtils KDoc

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/DataProviderConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/DataProviderConfig.kt
@@ -22,14 +22,15 @@ interface DataProviderConfig {
     fun getPriceCode(asset: Asset): String
 
     /**
-     * Null-safe market-code membership check shared by all price providers.
+     * Null-safe, delimiter-aware market-code membership check shared by all price providers.
      *
      * A null or blank [markets] allowlist means the provider supports no markets.
-     * Preserves the MarketStack `isBlank()` guard alongside Alpha's `?.contains` pattern:
-     * both collapse to `false` here without a `!!` or NPE risk.
+     * The allowlist is comma-separated; each token is trimmed before comparison so
+     * `"ASX, NZX"` and `"ASX,NZX"` are equivalent.  Matching is case-sensitive and
+     * exact — `"SX"` does **not** match an entry `"ASX"`.
      */
     fun supportsMarketCode(
         markets: String?,
         code: String
-    ): Boolean = !markets.isNullOrBlank() && markets.contains(code)
+    ): Boolean = !markets.isNullOrBlank() && markets.split(",").any { it.trim() == code }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderLogUtils.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/ProviderLogUtils.kt
@@ -11,8 +11,13 @@ import org.slf4j.Logger
  * mode are both visible.  The [demoLabel] default ("demo") matches AlphaVantage and EODHD;
  * pass "DEMO" for MarketStack to preserve its conventional uppercase label.
  *
- * Log output is byte-for-byte identical to the three inline `@PostConstruct logStatus()`
- * blocks it replaces:
+ * Detection is prefix-based — `apiKey.startsWith("demo", ignoreCase = true)` — which is a
+ * strict superset of the original exact comparisons (`equals("demo")` in EODHD/MarketStack,
+ * `substring(0,4) == "demo"` in AlphaVantage) and does not change their observable behaviour.
+ * The emitted value is always [demoLabel] or `"** Redacted **"` — never the key itself, so no
+ * key material can appear in logs regardless of the comparison result.
+ *
+ * Typical output (illustrative; exact env-var names are caller-supplied via [keyName]):
  *   "BEANCOUNTER_MARKET_PROVIDERS_ALPHA_KEY: demo"   / "** Redacted **"
  *   "BEANCOUNTER_MARKET_PROVIDERS_EODHD_KEY: demo"   / "** Redacted **"
  *   "BEANCOUNTER_MARKET_PROVIDERS_MSTACK_KEY: DEMO"  / "** Redacted **"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/DataProviderConfigTest.kt
@@ -54,4 +54,21 @@ internal class DataProviderConfigTest {
         assertThat(config.supportsMarketCode("US,ASX,LON", "SGX")).isFalse()
         assertThat(config.supportsMarketCode("US,ASX,LON", "NZX")).isFalse()
     }
+
+    @Test
+    fun `supportsMarketCode rejects substring match - code must be an exact token`() {
+        // "SX" is a suffix of "ASX" — substring-contains would incorrectly return true
+        assertThat(config.supportsMarketCode("ASX,NZX", "SX")).isFalse()
+        // "AS" is a prefix of "ASX"
+        assertThat(config.supportsMarketCode("ASX,NZX", "AS")).isFalse()
+        // "NZ" is a prefix of "NZX"
+        assertThat(config.supportsMarketCode("ASX,NZX", "NZ")).isFalse()
+    }
+
+    @Test
+    fun `supportsMarketCode trims whitespace around tokens`() {
+        // Comma-separated list with spaces around entries still resolves correctly
+        assertThat(config.supportsMarketCode("ASX, NZX", "NZX")).isTrue()
+        assertThat(config.supportsMarketCode(" ASX , NZX ", "ASX")).isTrue()
+    }
 }


### PR DESCRIPTION
- supportsMarketCode: replace contains() with split(',').any { trim() == code }
  to prevent substring false-positives (e.g. 'SX' matching 'ASX')
- DataProviderConfigTest: add delimiter-aware and whitespace-trim red-first cases
- ProviderLogUtils KDoc: correct 'byte-for-byte identical' claim; detection is
  prefix-based (startsWith), a strict superset of the old exact / substring checks