### PR TITLE
build: testAll covers all modules incl. contract tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ reason; `validateDependencies` enforces the rule.
 # Build everything (clean checkout OK)
 ./gradlew build
 
-# Run all tests (buildSmart/testSmart/testWithStubs remain as aliases)
+# Run all tests incl. contract tests (buildSmart/testSmart remain as aliases)
 ./gradlew testAll
 
 # Code quality

--- a/README.md
+++ b/README.md
@@ -39,13 +39,7 @@ svc-position and svc-event), so a plain build works from a clean checkout:
 #### Individual Module Builds
 
 ```bash
-# Build core libraries
-./gradlew buildCore
-
-# Build all services
-./gradlew buildServices
-
-# Build specific module
+# Build specific module (Gradle builds any stub producers it needs first)
 ./gradlew :jar-client:build
 ./gradlew :svc-data:build
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -289,35 +289,8 @@ version = "0.0.1-SNAPSHOT"
 // ordering or ~/.m2 stub publishing is required — plain `./gradlew build` works
 // from a clean checkout.
 tasks.register("buildAll") {
-    dependsOn(":jar-common:build")
-    dependsOn(":jar-auth:build")
-    dependsOn(":jar-client:build")
-    dependsOn(":jar-shell:build")
-    dependsOn(":svc-data:build")
-    dependsOn(":svc-position:build")
-    dependsOn(":svc-event:build")
-    dependsOn(":svc-admin:build")
-    description = "Build all subprojects in dependency order"
-}
-
-// Build core libraries first (no service dependencies)
-tasks.register("buildCoreLibraries") {
-    dependsOn(":jar-contracts:build")
-    dependsOn(":jar-common:build")
-    dependsOn(":jar-auth:build")
-    dependsOn(":jar-client:build")
-    dependsOn(":jar-shell:build")
-    description = "Build core libraries (no service dependencies)"
-}
-
-// Build services after core libraries
-tasks.register("buildServices") {
-    dependsOn("buildCoreLibraries")
-    dependsOn(":svc-data:build")
-    dependsOn(":svc-position:build")
-    dependsOn(":svc-event:build")
-    dependsOn(":svc-admin:build")
-    description = "Build services after core libraries"
+    dependsOn(subprojects.map { "${it.path}:build" })
+    description = "Build all subprojects"
 }
 
 // Publish contract stubs for services that need them
@@ -349,15 +322,12 @@ tasks.register("publishJarsLocal") {
 }
 
 tasks.register("testAll") {
-    dependsOn(":jar-common:test")
-    dependsOn(":jar-auth:test")
-    dependsOn(":jar-client:test")
-    dependsOn(":jar-shell:test")
-    dependsOn(":svc-data:test")
-    dependsOn(":svc-position:test")
-    dependsOn(":svc-event:test")
-    dependsOn(":svc-admin:test")
-    description = "Test all subprojects (stub ordering handled by Gradle)"
+    dependsOn(subprojects.map { "${it.path}:test" })
+    // contractTest is a separate source set/task on the stub producers and is
+    // not wired into `test` — include it so testAll covers contract checks.
+    dependsOn(":svc-data:contractTest")
+    dependsOn(":svc-position:contractTest")
+    description = "Test all subprojects incl. contract tests (stub ordering handled by Gradle)"
 }
 
 tasks.register("cleanAll") {
@@ -371,14 +341,6 @@ tasks.register("verifyDependencies") {
     description = "Verify all project dependencies"
 }
 
-// Build core libraries first (no service dependencies)
-tasks.register("buildCore") {
-    dependsOn(":jar-common:build")
-    dependsOn(":jar-auth:build")
-    dependsOn(":jar-client:build")
-    description = "Build core libraries (jar-common, jar-auth, jar-client)"
-}
-
 // Legacy aliases: stubs are now wired as Gradle project artifacts, so the
 // old "verify stubs exist in ~/.m2 first" dance is gone. Kept so existing
 // muscle memory / scripts / docs keep working.
@@ -388,11 +350,6 @@ tasks.register("buildSmart") {
 }
 
 tasks.register("testSmart") {
-    dependsOn("testAll")
-    description = "Alias for testAll (stub ordering handled by Gradle)"
-}
-
-tasks.register("testWithStubs") {
     dependsOn("testAll")
     description = "Alias for testAll (stub ordering handled by Gradle)"
 }


### PR DESCRIPTION
testAll/buildAll now derive from subprojects (picks up jar-contracts and
svc-agent, previously missed) and testAll runs the svc-data/svc-position
contractTest source sets. Drop obsolete phase helpers (buildCore,
buildCoreLibraries, buildServices) and the testWithStubs alias.