### PR TITLE
fix(trn): settle cash to broker's per-currency account before generic fallback

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerSettlementAccountRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerSettlementAccountRepository.kt
@@ -18,6 +18,22 @@ interface BrokerSettlementAccountRepository : JpaRepository<BrokerSettlementAcco
         @Param("brokerId") brokerId: String
     ): List<BrokerSettlementAccount>
 
+    /**
+     * Resolve a broker's settlement account for a specific currency.
+     * Keyed on the unique (broker_id, currency_code) constraint — used at trade
+     * time to settle a cash leg to the broker's designated account instead of a
+     * generic bare-currency balance.
+     */
+    @Query(
+        "SELECT b FROM BrokerSettlementAccount b " +
+            "JOIN FETCH b.broker JOIN FETCH b.account " +
+            "WHERE b.broker.id = :brokerId AND b.currencyCode = :currencyCode"
+    )
+    fun findByBrokerIdAndCurrencyCode(
+        @Param("brokerId") brokerId: String,
+        @Param("currencyCode") currencyCode: String
+    ): BrokerSettlementAccount?
+
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM BrokerSettlementAccount b WHERE b.broker.id = :brokerId")
     fun deleteByBrokerId(brokerId: String)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
@@ -83,7 +83,7 @@ class BcRowAdapter(
                 // the bought currency and silently drop the sell-side leg.
                 asset
             } else {
-                cashTrnServices.getCashAsset(trnType, cashAccount, cashCurrency, ownerId)
+                cashTrnServices.getCashAsset(trnType, cashAccount, cashCurrency, ownerId, getBrokerId(row))
             }
         return cashAsset?.id
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/CashTrnServices.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/CashTrnServices.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.model.TrnType.Companion.debitsCash
 import com.beancounter.common.utils.MathUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.cash.CASH
 import com.beancounter.marketdata.currency.CurrencyService
 import com.beancounter.marketdata.providers.custom.PrivateMarketDataProvider
@@ -22,7 +23,8 @@ import java.math.BigDecimal
 class CashTrnServices(
     private val assetFinder: AssetFinder,
     private val assetService: AssetService,
-    val currencyService: CurrencyService
+    val currencyService: CurrencyService,
+    private val brokerSettlementAccountRepository: BrokerSettlementAccountRepository
 ) {
     fun getCashImpact(
         trnInput: TrnInput,
@@ -56,13 +58,16 @@ class CashTrnServices(
      *                        Can be an asset code or UUID for backward compatibility.
      * @param cashCurrency Currency code for generic cash balance fallback (e.g., "SGD")
      * @param ownerId Owner ID for looking up private assets by code
+     * @param brokerId Optional broker whose per-currency settlement account is used
+     *                 when no explicit cash account is supplied
      * @return The resolved Asset, or null if no cash asset is required
      */
     fun getCashAsset(
         trnType: TrnType,
         cashAccountCode: String?,
         cashCurrency: String?,
-        ownerId: String? = null
+        ownerId: String? = null,
+        brokerId: String? = null
     ): Asset? {
         if (!TrnType.isCashImpacted(trnType)) {
             return null // No cash asset required
@@ -92,6 +97,19 @@ class CashTrnServices(
                 if (privateAsset != null) {
                     return privateAsset
                 }
+            }
+        }
+
+        // No explicit account resolved — settle to the broker's designated
+        // account for this currency, if one is configured.
+        if (!brokerId.isNullOrEmpty() && !cashCurrency.isNullOrEmpty()) {
+            val settlement =
+                brokerSettlementAccountRepository.findByBrokerIdAndCurrencyCode(
+                    brokerId,
+                    cashCurrency
+                )
+            if (settlement != null) {
+                return settlement.account
             }
         }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
@@ -52,13 +52,15 @@ class TrnInputMapper(
             trnInput
         )
 
+        val broker = getBroker(trnInput, existing)
         // Preserve existing cashAsset if no new one is provided (similar to broker handling)
         val cashAsset =
             cashTrnServices.getCashAsset(
                 trnInput.trnType,
                 trnInput.cashAssetId,
                 trnInput.cashCurrency,
-                portfolio.owner.id
+                portfolio.owner.id,
+                broker?.id
             ) ?: existing?.cashAsset
         var cashCurrency: Currency? = null
         if (cashAsset != null) {
@@ -102,7 +104,6 @@ class TrnInputMapper(
             )
         val asset = getAsset(trnInput, existing)
         val tradeCurrency = resolveTradeCurrency(asset, trnInput.tradeCurrency)
-        val broker = getBroker(trnInput, existing)
         return Trn(
             id = existing?.id ?: keyGenUtils.id,
             trnType = trnInput.trnType,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
@@ -19,6 +19,7 @@ import com.beancounter.marketdata.Constants.Companion.nzdCashBalance
 import com.beancounter.marketdata.Constants.Companion.usdCashBalance
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.currency.CurrencyService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -53,6 +54,9 @@ class BcRowAdapterTest {
     @Mock
     private lateinit var ais: AssetIngestService
 
+    @Mock
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
+
     private lateinit var bcRowAdapter: BcRowAdapter
     private lateinit var cashTrnServices: CashTrnServices
 
@@ -63,7 +67,8 @@ class BcRowAdapterTest {
 
     @BeforeEach
     fun setUp() {
-        cashTrnServices = CashTrnServices(assetFinder, assetService, currencyService)
+        cashTrnServices =
+            CashTrnServices(assetFinder, assetService, currencyService, brokerSettlementAccountRepository)
         bcRowAdapter = BcRowAdapter(ais, cashTrnServices)
 
         setupMocks()

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/FxBetweenPrivateAccountsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/FxBetweenPrivateAccountsTest.kt
@@ -14,6 +14,7 @@ import com.beancounter.marketdata.Constants.Companion.SGD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.currency.CurrencyService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -41,6 +42,9 @@ class FxBetweenPrivateAccountsTest {
 
     @Mock
     private lateinit var ais: AssetIngestService
+
+    @Mock
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
 
     private lateinit var bcRowAdapter: BcRowAdapter
     private lateinit var cashTrnServices: CashTrnServices
@@ -83,7 +87,8 @@ class FxBetweenPrivateAccountsTest {
 
     @BeforeEach
     fun setUp() {
-        cashTrnServices = CashTrnServices(assetFinder, assetService, currencyService)
+        cashTrnServices =
+            CashTrnServices(assetFinder, assetService, currencyService, brokerSettlementAccountRepository)
         bcRowAdapter = BcRowAdapter(ais, cashTrnServices)
     }
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnFxDefaultTests.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnFxDefaultTests.kt
@@ -62,6 +62,10 @@ class TrnFxDefaultTests {
     @MockitoBean
     private lateinit var brokerRepository: com.beancounter.marketdata.broker.BrokerRepository
 
+    @MockitoBean
+    private lateinit var brokerSettlementAccountRepository:
+        com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
+
     @Autowired
     private lateinit var trnInputMapper: TrnInputMapper
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
@@ -73,6 +73,10 @@ internal class TrnInputMapperTest {
     @MockitoBean
     private lateinit var brokerRepository: com.beancounter.marketdata.broker.BrokerRepository
 
+    @MockitoBean
+    private lateinit var brokerSettlementAccountRepository:
+        com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
+
     @Autowired
     private lateinit var trnInputMapper: TrnInputMapper
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashTrnServicesTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashTrnServicesTest.kt
@@ -2,15 +2,23 @@ package com.beancounter.marketdata.trn.cash
 
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Broker
 import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.Market
 import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.Constants.Companion.CASH_MARKET
 import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.Constants.Companion.nzdCashBalance
+import com.beancounter.marketdata.Constants.Companion.systemUser
+import com.beancounter.marketdata.Constants.Companion.usdCashBalance
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerSettlementAccount
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.currency.CurrencyService
 import com.beancounter.marketdata.trn.CashTrnServices
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +36,76 @@ internal class CashTrnServicesTest {
     private val assetFinder = Mockito.mock(AssetFinder::class.java)
     private val assetService = Mockito.mock(AssetService::class.java)
     private val currencyService = Mockito.mock(CurrencyService::class.java)
-    private val cashTrnServices = CashTrnServices(assetFinder, assetService, currencyService)
+    private val brokerSettlementAccountRepository = Mockito.mock(BrokerSettlementAccountRepository::class.java)
+    private val cashTrnServices =
+        CashTrnServices(assetFinder, assetService, currencyService, brokerSettlementAccountRepository)
+
+    private val broker = Broker(id = "ib-broker", name = "Interactive Brokers", owner = systemUser)
+    private val ibrkUsd =
+        Asset(
+            code = "IBRK-USD",
+            id = "ibrk-usd-id",
+            name = "IBRK USD",
+            market = Market("PRIVATE", USD.code),
+            priceSymbol = USD.code,
+            category = "CASH",
+            assetCategory = AssetCategory("CASH", "Cash")
+        )
+    private val ibrkSettlement =
+        BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = ibrkUsd)
+
+    @Test
+    fun `should settle to broker settlement account when broker present and no explicit cash account`() {
+        Mockito
+            .`when`(brokerSettlementAccountRepository.findByBrokerIdAndCurrencyCode(broker.id, USD.code))
+            .thenReturn(ibrkSettlement)
+        assertThat(
+            cashTrnServices.getCashAsset(
+                trnType = TrnType.BUY,
+                cashAccountCode = null,
+                cashCurrency = USD.code,
+                ownerId = systemUser.id,
+                brokerId = broker.id
+            )
+        ).isEqualTo(ibrkUsd)
+        // Broker tier resolved — generic currency fallback must not fire
+        Mockito.verifyNoInteractions(assetService)
+    }
+
+    @Test
+    fun `should fall back to generic balance when broker has no settlement account for currency`() {
+        Mockito
+            .`when`(brokerSettlementAccountRepository.findByBrokerIdAndCurrencyCode(broker.id, USD.code))
+            .thenReturn(null)
+        Mockito
+            .`when`(assetService.findOrCreate(AssetInput("CASH", USD.code)))
+            .thenReturn(usdCashBalance)
+        assertThat(
+            cashTrnServices.getCashAsset(
+                trnType = TrnType.BUY,
+                cashAccountCode = null,
+                cashCurrency = USD.code,
+                ownerId = systemUser.id,
+                brokerId = broker.id
+            )
+        ).isEqualTo(usdCashBalance)
+    }
+
+    @Test
+    fun `should settle FX_BUY to broker settlement account for the sell-leg currency`() {
+        Mockito
+            .`when`(brokerSettlementAccountRepository.findByBrokerIdAndCurrencyCode(broker.id, USD.code))
+            .thenReturn(ibrkSettlement)
+        assertThat(
+            cashTrnServices.getCashAsset(
+                trnType = TrnType.FX_BUY,
+                cashAccountCode = null,
+                cashCurrency = USD.code,
+                ownerId = systemUser.id,
+                brokerId = broker.id
+            )
+        ).isEqualTo(ibrkUsd)
+    }
 
     @Test
     fun is_CashBalanceFromTradeCurrency() {


### PR DESCRIPTION
getCashAsset now consults broker_settlement_account(broker, currency) when a trade carries a brokerId but no explicit cash account, before the bare-currency balance fallback. Covers manual/API, CSV, and FX_BUY paths. Null-broker transactions (corp-event DIVI, auto-settle pairs) intentionally keep the generic fallback.