### PR TITLE
fix(auth): deny-by-default api gate, guard BrokerController, harden isAdmin

### DIFF
--- a/jar-auth/src/main/kotlin/com/beancounter/auth/model/AuthConstants.kt
+++ b/jar-auth/src/main/kotlin/com/beancounter/auth/model/AuthConstants.kt
@@ -28,6 +28,6 @@ object AuthConstants {
      */
     fun isAdmin(jwt: Jwt): Boolean {
         val scope = jwt.getClaimAsString("scope") ?: ""
-        return scope.contains(ADMIN)
+        return scope.split(" ").contains(ADMIN)
     }
 }

--- a/jar-auth/src/main/kotlin/com/beancounter/auth/server/WebAuthFilterConfig.kt
+++ b/jar-auth/src/main/kotlin/com/beancounter/auth/server/WebAuthFilterConfig.kt
@@ -81,11 +81,14 @@ class WebAuthFilterConfig {
                 auth.requestMatchers("$apiPath/swagger-ui/**").permitAll()
                 auth
                     .requestMatchers("$apiPath/**")
-                    .hasAuthority(AuthConstants.SCOPE_BC) // Authenticated users
+                    .hasAnyAuthority(
+                        AuthConstants.SCOPE_USER,
+                        AuthConstants.SCOPE_SYSTEM,
+                        AuthConstants.SCOPE_ADMIN
+                    ) // Deny by default: only known, scoped callers
                 auth
                     .requestMatchers("$actuatorPath/**")
                     .hasAnyAuthority(AuthConstants.SCOPE_ADMIN, AuthConstants.SCOPE_SYSTEM) // Admin or System users
-//            auth.requestMatchers("$actuatorPath/**").hasRole(AuthConstants.ADMIN) // Admin users
                 auth.anyRequest().permitAll() //
             }.csrf { csrf ->
                 csrf.disable()

--- a/jar-auth/src/test/kotlin/com/beancounter/auth/AuthTest.kt
+++ b/jar-auth/src/test/kotlin/com/beancounter/auth/AuthTest.kt
@@ -94,6 +94,7 @@ class AuthTest {
     companion object {
         private const val HELLO = "/api/hello"
         const val WHAT = "/api/what"
+        private const val PLAIN = "/api/plain"
     }
 
     @Test
@@ -172,6 +173,28 @@ class AuthTest {
     }
 
     @Test
+    fun `should deny access to api path when only bare beancounter scope is granted`() {
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get(PLAIN)
+                    .with(jwt().authorities(SimpleGrantedAuthority(AuthConstants.SCOPE_BC)))
+            ).andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andReturn()
+    }
+
+    @Test
+    fun `should allow access to api path when beancounter user scope is granted`() {
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get(PLAIN)
+                    .with(jwt().authorities(SimpleGrantedAuthority(AuthConstants.SCOPE_USER)))
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+    }
+
+    @Test
     fun swaggerUi_IsAccessibleWithoutAuthentication() {
         val result =
             mockMvc
@@ -203,5 +226,11 @@ class AuthTest {
 
         @GetMapping("/api/swagger-ui/index.html")
         fun swaggerUi(): String = SWAGGER_UI_RESPONSE
+
+        // No @PreAuthorize: exercises the filter-chain-level rule alone,
+        // proving the "$apiPath/**" gate itself denies a bare `beancounter`
+        // scope while accepting `beancounter:user`.
+        @GetMapping("/api/plain")
+        fun plain(): String = "plain"
     }
 }

--- a/jar-auth/src/test/kotlin/com/beancounter/auth/model/AuthConstantsTest.kt
+++ b/jar-auth/src/test/kotlin/com/beancounter/auth/model/AuthConstantsTest.kt
@@ -53,4 +53,16 @@ class AuthConstantsTest {
         val jwt = createJwt(AuthConstants.ADMIN)
         assertThat(AuthConstants.isAdmin(jwt)).isTrue()
     }
+
+    @Test
+    fun `isAdmin returns false when scope contains admin as a substring of another token`() {
+        val jwt = createJwt("beancounter profile xbeancounter:adminx")
+        assertThat(AuthConstants.isAdmin(jwt)).isFalse()
+    }
+
+    @Test
+    fun `isAdmin returns false when scope contains admin as a suffix of another token`() {
+        val jwt = createJwt("beancounter profile notbeancounter:admin")
+        assertThat(AuthConstants.isAdmin(jwt)).isFalse()
+    }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/broker/BrokerController.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.broker
 
+import com.beancounter.auth.model.AuthConstants
 import com.beancounter.common.contracts.BrokerResponse
 import com.beancounter.common.contracts.BrokerWithAccountsResponse
 import com.beancounter.common.contracts.BrokersResponse
@@ -11,6 +12,7 @@ import com.beancounter.marketdata.trn.TrnBrokerService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -23,6 +25,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/brokers")
+@PreAuthorize(
+    "hasAnyAuthority('" + AuthConstants.SCOPE_USER + "', '" + AuthConstants.SCOPE_SYSTEM + "')"
+)
 class BrokerController(
     private val brokerService: BrokerService,
     private val systemUserService: SystemUserService,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/ControllerAuthorizationTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/ControllerAuthorizationTest.kt
@@ -1,0 +1,76 @@
+package com.beancounter.marketdata
+
+import com.beancounter.marketdata.registration.AuthController
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val HANDLER_ANNOTATIONS =
+    listOf(
+        RequestMapping::class.java,
+        GetMapping::class.java,
+        PostMapping::class.java,
+        PutMapping::class.java,
+        PatchMapping::class.java,
+        DeleteMapping::class.java
+    )
+
+/**
+ * Architecture test: every `@RestController` in svc-data must be scope-gated,
+ * either by a class-level `@PreAuthorize` or by a `@PreAuthorize` on every
+ * HTTP handler method. Guards against a repeat of the un-guarded
+ * BrokerController gap found in the 2026-07 auth audit.
+ *
+ * Allowlist is explicit and must not grow silently:
+ * - [AuthController]: permitAll login proxy for bc-shell
+ *   (`WebAuthFilterConfig`: "$apiPath/auth" is permitAll).
+ */
+class ControllerAuthorizationTest {
+    private val basePackage = "com.beancounter.marketdata"
+
+    private val allowlist = setOf(AuthController::class.java)
+
+    @Test
+    fun `every RestController is scope-gated by PreAuthorize`() {
+        val scanner = ClassPathScanningCandidateComponentProvider(false)
+        scanner.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+
+        val unguarded =
+            scanner
+                .findCandidateComponents(basePackage)
+                .map { Class.forName(it.beanClassName) }
+                .filterNot { allowlist.contains(it) }
+                .filterNot { isGuarded(it) }
+
+        assertThat(unguarded)
+            .withFailMessage(
+                "Un-guarded @RestController(s) found (no class-level @PreAuthorize, and not " +
+                    "every handler method has one): %s. Either add @PreAuthorize or, if the " +
+                    "endpoint is intentionally open, add it to the explicit allowlist.",
+                unguarded.map { it.name }
+            ).isEmpty()
+    }
+
+    private fun isGuarded(controllerClass: Class<*>): Boolean {
+        if (controllerClass.getAnnotation(PreAuthorize::class.java) != null) {
+            return true
+        }
+        val handlerMethods =
+            controllerClass.declaredMethods.filter { method ->
+                HANDLER_ANNOTATIONS.any { method.isAnnotationPresent(it) }
+            }
+        if (handlerMethods.isEmpty()) {
+            return false
+        }
+        return handlerMethods.all { it.isAnnotationPresent(PreAuthorize::class.java) }
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/broker/BrokerControllerAuthTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/broker/BrokerControllerAuthTest.kt
@@ -1,0 +1,77 @@
+package com.beancounter.marketdata.broker
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.utils.RegistrationUtils
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+private const val BROKERS_ROOT = "/brokers"
+
+/**
+ * Verifies BrokerController is guarded by the same scope-based authorization as its peers.
+ *
+ * The rejection case registers the caller first (so business logic such as
+ * `SystemUserService.getOrThrow` would succeed if reached) then grants only
+ * `beancounter:admin` — an authority that satisfies the global api-path
+ * filter gate (ADMIN is one of the accepted authorities there) but does not
+ * satisfy BrokerController's own class-level `@PreAuthorize` (USER or
+ * SYSTEM only). This isolates the controller's own guard from both the
+ * separate deny-by-default filter change and the unregistered-user business
+ * exception, so this test only goes green because of BrokerController's own
+ * `@PreAuthorize`.
+ */
+@SpringMvcDbTest
+internal class BrokerControllerAuthTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Test
+    fun `token without user or system authority is rejected even when registered`() {
+        val token =
+            RegistrationUtils.registerUser(
+                mockMvc,
+                mockAuthConfig.getUserToken(SystemUser())
+            )
+
+        mockMvc
+            .perform(
+                get(BROKERS_ROOT)
+                    .with(
+                        jwt()
+                            .jwt(token)
+                            .authorities(SimpleGrantedAuthority(AuthConstants.SCOPE_ADMIN))
+                    )
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `token with user scope is accepted`() {
+        val token =
+            RegistrationUtils.registerUser(
+                mockMvc,
+                mockAuthConfig.getUserToken(SystemUser())
+            )
+
+        mockMvc
+            .perform(
+                get(BROKERS_ROOT)
+                    .with(jwt().jwt(token))
+            ).andExpect(status().isOk)
+    }
+}

--- a/svc-event/src/test/kotlin/com/beancounter/event/ControllerAuthorizationTest.kt
+++ b/svc-event/src/test/kotlin/com/beancounter/event/ControllerAuthorizationTest.kt
@@ -1,0 +1,71 @@
+package com.beancounter.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val HANDLER_ANNOTATIONS =
+    listOf(
+        RequestMapping::class.java,
+        GetMapping::class.java,
+        PostMapping::class.java,
+        PutMapping::class.java,
+        PatchMapping::class.java,
+        DeleteMapping::class.java
+    )
+
+/**
+ * Architecture test: every `@RestController` in svc-event must be
+ * scope-gated, either by a class-level `@PreAuthorize` or by a
+ * `@PreAuthorize` on every HTTP handler method. Guards against a repeat of
+ * the un-guarded BrokerController gap found in the 2026-07 auth audit.
+ *
+ * No allowlist here: every svc-event controller is expected to be
+ * authenticated (there is no permitAll surface in this service).
+ */
+class ControllerAuthorizationTest {
+    private val basePackage = "com.beancounter.event"
+
+    @Test
+    fun `every RestController is scope-gated by PreAuthorize`() {
+        val scanner = ClassPathScanningCandidateComponentProvider(false)
+        scanner.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+
+        val unguarded =
+            scanner
+                .findCandidateComponents(basePackage)
+                .map { Class.forName(it.beanClassName) }
+                .filterNot { isGuarded(it) }
+
+        assertThat(unguarded)
+            .withFailMessage(
+                "Un-guarded @RestController(s) found (no class-level @PreAuthorize, and not " +
+                    "every handler method has one): %s. Either add @PreAuthorize or, if the " +
+                    "endpoint is intentionally open, add it to the explicit allowlist.",
+                unguarded.map { it.name }
+            ).isEmpty()
+    }
+
+    private fun isGuarded(controllerClass: Class<*>): Boolean {
+        if (controllerClass.getAnnotation(PreAuthorize::class.java) != null) {
+            return true
+        }
+        val handlerMethods =
+            controllerClass.declaredMethods.filter { method ->
+                HANDLER_ANNOTATIONS.any { method.isAnnotationPresent(it) }
+            }
+        if (handlerMethods.isEmpty()) {
+            return false
+        }
+        return handlerMethods.all { it.isAnnotationPresent(PreAuthorize::class.java) }
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/ControllerAuthorizationTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/ControllerAuthorizationTest.kt
@@ -1,0 +1,71 @@
+package com.beancounter.position
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val HANDLER_ANNOTATIONS =
+    listOf(
+        RequestMapping::class.java,
+        GetMapping::class.java,
+        PostMapping::class.java,
+        PutMapping::class.java,
+        PatchMapping::class.java,
+        DeleteMapping::class.java
+    )
+
+/**
+ * Architecture test: every `@RestController` in svc-position must be
+ * scope-gated, either by a class-level `@PreAuthorize` or by a
+ * `@PreAuthorize` on every HTTP handler method. Guards against a repeat of
+ * the un-guarded BrokerController gap found in the 2026-07 auth audit.
+ *
+ * No allowlist here: every svc-position controller is expected to be
+ * authenticated (there is no permitAll surface in this service).
+ */
+class ControllerAuthorizationTest {
+    private val basePackage = "com.beancounter.position"
+
+    @Test
+    fun `every RestController is scope-gated by PreAuthorize`() {
+        val scanner = ClassPathScanningCandidateComponentProvider(false)
+        scanner.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+
+        val unguarded =
+            scanner
+                .findCandidateComponents(basePackage)
+                .map { Class.forName(it.beanClassName) }
+                .filterNot { isGuarded(it) }
+
+        assertThat(unguarded)
+            .withFailMessage(
+                "Un-guarded @RestController(s) found (no class-level @PreAuthorize, and not " +
+                    "every handler method has one): %s. Either add @PreAuthorize or, if the " +
+                    "endpoint is intentionally open, add it to the explicit allowlist.",
+                unguarded.map { it.name }
+            ).isEmpty()
+    }
+
+    private fun isGuarded(controllerClass: Class<*>): Boolean {
+        if (controllerClass.getAnnotation(PreAuthorize::class.java) != null) {
+            return true
+        }
+        val handlerMethods =
+            controllerClass.declaredMethods.filter { method ->
+                HANDLER_ANNOTATIONS.any { method.isAnnotationPresent(it) }
+            }
+        if (handlerMethods.isEmpty()) {
+            return false
+        }
+        return handlerMethods.all { it.isAnnotationPresent(PreAuthorize::class.java) }
+    }
+}


### PR DESCRIPTION
- BrokerController: class-level @PreAuthorize (USER or SYSTEM), matching peers
- WebAuthFilterConfig: /api/** now requires user/system/admin scope instead
  of bare 'beancounter'; removed commented ROLE_-prefix trap
- AuthConstants.isAdmin: exact scope-token match, no substring false positives
- Architecture tests (svc-data/position/event): every @RestController must be
  @PreAuthorize-guarded; explicit allowlist for the permitAll AuthController