### PR TITLE
feat(trn): nest broker sub-totals in aggregate trade summary

### DIFF
--- a/jar-contracts/src/main/kotlin/com/beancounter/common/contracts/TrnTradeSummary.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/contracts/TrnTradeSummary.kt
@@ -14,10 +14,16 @@ enum class TrnGroupBy {
  * [groupId] is the broker id (empty string for "no broker") when the summary
  * groups by [TrnGroupBy.BROKER], or the portfolio id when it groups by
  * [TrnGroupBy.PORTFOLIO].
+ *
+ * [subTotals] breaks a portfolio group down by broker (empty for broker
+ * grouping and for portfolios that never carried a broker). Each sub-total is
+ * split-adjusted with the portfolio-wide split applied, so summing the
+ * sub-totals reconstructs [quantity].
  */
 data class TrnGroupTotal(
     val groupId: String,
-    val quantity: BigDecimal
+    val quantity: BigDecimal,
+    val subTotals: List<TrnGroupTotal> = emptyList()
 )
 
 /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnTradeSummaryBuilder.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnTradeSummaryBuilder.kt
@@ -48,25 +48,47 @@ object TrnTradeSummaryBuilder {
 
         val groups =
             trns.groupBy(keyOf).map { (groupId, groupTrns) ->
-                val portfolioIds = groupTrns.map { it.portfolio.id }.toSet()
-                val splitEvents = portfolioIds.flatMap { splitsByPortfolio[it].orEmpty() }
-                // Fold the group's own non-split trns plus the portfolio's splits.
-                val events = groupTrns.filter { it.trnType != TrnType.SPLIT } + splitEvents
-                var quantity = BigDecimal.ZERO
-                for (trn in events.sortedWith(
-                    compareBy({ it.tradeDate }, { sameDayOrder(it.trnType) })
-                )) {
-                    quantity =
-                        when (trn.trnType) {
-                            TrnType.BUY, TrnType.ADD -> quantity.add(trn.quantity)
-                            TrnType.SELL, TrnType.REDUCE -> quantity.subtract(trn.quantity)
-                            TrnType.SPLIT -> quantity.multiply(trn.quantity)
-                            TrnType.BALANCE -> trn.quantity
-                            else -> quantity
-                        }
-                }
-                TrnGroupTotal(groupId, quantity)
+                // When grouping by portfolio, break the group down by broker too,
+                // so the aggregated drill-down can show one asset's split across
+                // the brokers holding it. Broker grouping needs no finer level.
+                val subTotals =
+                    if (groupBy == TrnGroupBy.PORTFOLIO) {
+                        groupTrns
+                            .groupBy { it.broker?.id ?: "" }
+                            .map { (brokerId, brokerTrns) ->
+                                TrnGroupTotal(brokerId, foldQuantity(brokerTrns, splitsByPortfolio))
+                            }
+                    } else {
+                        emptyList()
+                    }
+                TrnGroupTotal(groupId, foldQuantity(groupTrns, splitsByPortfolio), subTotals)
             }
         return TrnTradeSummary(groupBy, groups)
+    }
+
+    // Fold a group's own non-split trns plus its portfolio's (portfolio-wide)
+    // splits into a single split-adjusted quantity. A SPLIT multiplies the
+    // running holding; a BALANCE resets it to an absolute snapshot.
+    private fun foldQuantity(
+        groupTrns: List<Trn>,
+        splitsByPortfolio: Map<String, List<Trn>>
+    ): BigDecimal {
+        val portfolioIds = groupTrns.map { it.portfolio.id }.toSet()
+        val splitEvents = portfolioIds.flatMap { splitsByPortfolio[it].orEmpty() }
+        val events = groupTrns.filter { it.trnType != TrnType.SPLIT } + splitEvents
+        var quantity = BigDecimal.ZERO
+        for (trn in events.sortedWith(
+            compareBy({ it.tradeDate }, { sameDayOrder(it.trnType) })
+        )) {
+            quantity =
+                when (trn.trnType) {
+                    TrnType.BUY, TrnType.ADD -> quantity.add(trn.quantity)
+                    TrnType.SELL, TrnType.REDUCE -> quantity.subtract(trn.quantity)
+                    TrnType.SPLIT -> quantity.multiply(trn.quantity)
+                    TrnType.BALANCE -> trn.quantity
+                    else -> quantity
+                }
+        }
+        return quantity
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnTradeSummaryBuilderTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnTradeSummaryBuilderTest.kt
@@ -45,6 +45,17 @@ class TrnTradeSummaryBuilderTest {
         groupId: String
     ): BigDecimal = summary.groups.first { it.groupId == groupId }.quantity
 
+    private fun subQtyFor(
+        summary: com.beancounter.common.contracts.TrnTradeSummary,
+        portfolioId: String,
+        brokerId: String
+    ): BigDecimal =
+        summary.groups
+            .first { it.groupId == portfolioId }
+            .subTotals
+            .first { it.groupId == brokerId }
+            .quantity
+
     @Test
     fun `broker group applies split as a multiply not an add`() {
         val dbs = Broker(name = "DBS", owner = owner)
@@ -109,6 +120,38 @@ class TrnTradeSummaryBuilderTest {
 
         assertThat(qtyFor(summary, "p1")).isEqualByComparingTo("20")
         assertThat(qtyFor(summary, "p2")).isEqualByComparingTo("3")
+    }
+
+    @Test
+    fun `portfolio grouping nests split-adjusted broker sub-totals`() {
+        val dbs = Broker(name = "DBS", owner = owner)
+        val scb = Broker(name = "SCB", owner = owner)
+        val trns =
+            listOf(
+                trn(TrnType.BUY, "175", "2024-12-10", portfolio = p1, broker = dbs),
+                trn(TrnType.BUY, "80", "2025-12-03", portfolio = p1, broker = scb),
+                trn(TrnType.SPLIT, "2", "2026-01-01", portfolio = p1) // portfolio-wide
+            )
+
+        val summary = TrnTradeSummaryBuilder.build(trns, TrnGroupBy.PORTFOLIO)
+
+        // Portfolio total = (175 + 80) * 2 = 510.
+        assertThat(qtyFor(summary, "p1")).isEqualByComparingTo("510")
+        // Each broker sub-total carries the portfolio-wide split: 175*2, 80*2.
+        assertThat(subQtyFor(summary, "p1", dbs.id)).isEqualByComparingTo("350")
+        assertThat(subQtyFor(summary, "p1", scb.id)).isEqualByComparingTo("160")
+    }
+
+    @Test
+    fun `broker grouping carries no sub-totals`() {
+        val dbs = Broker(name = "DBS", owner = owner)
+        val summary =
+            TrnTradeSummaryBuilder.build(
+                listOf(trn(TrnType.BUY, "10", "2026-01-01", broker = dbs)),
+                TrnGroupBy.BROKER
+            )
+
+        assertThat(summary.groups.first { it.groupId == dbs.id }.subTotals).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
The portfolio-grouped trade drill-down now breaks each portfolio down by
broker via TrnGroupTotal.subTotals, split-adjusted with the portfolio-wide
split. Lets the aggregated view surface one asset held across multiple
brokers instead of collapsing them under the portfolio.