### PR TITLE
fix(classification): manual sector override survives provider enrichment

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
@@ -118,6 +118,10 @@ class ClassificationService(
     /**
      * Classify an asset with a specific classification item.
      * Replaces any existing classification at the same level.
+     *
+     * A manual (user-defined) classification takes precedence: provider
+     * enrichment must not clobber a user override. Provider-over-provider and
+     * manual-over-provider replacements still apply.
      */
     fun classifyAsset(
         asset: Asset,
@@ -126,10 +130,14 @@ class ClassificationService(
         level: ClassificationLevel,
         source: String
     ): AssetClassification {
+        val existing = classificationRepository.findByAssetIdAndLevel(asset.id, level).orElse(null)
+        if (existing != null && existing.source == SOURCE_MANUAL && source != SOURCE_MANUAL) {
+            // User override wins over provider enrichment.
+            return existing
+        }
+
         // Remove existing classification at this level
-        classificationRepository
-            .findByAssetIdAndLevel(asset.id, level)
-            .ifPresent { classificationRepository.delete(it) }
+        existing?.let { classificationRepository.delete(it) }
 
         // Use a managed reference to ensure proper FK handling
         val managedAsset = entityManager.getReference(Asset::class.java, asset.id)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationServiceTest.kt
@@ -1,5 +1,7 @@
 package com.beancounter.marketdata.classification
 
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetClassification
 import com.beancounter.common.model.ClassificationItem
 import com.beancounter.common.model.ClassificationLevel
 import com.beancounter.common.model.ClassificationStandard
@@ -418,5 +420,161 @@ class ClassificationServiceTest {
             .thenReturn(emptyList())
 
         assertThat(service.hasExposures("asset-1")).isFalse()
+    }
+
+    @Test
+    fun `classifyAsset does not overwrite a manual classification with provider data`() {
+        val asset = mock<Asset>()
+        whenever(asset.id).thenReturn("asset-1")
+        val userStandard =
+            ClassificationStandard(id = STD_ID, key = STD_KEY_USER, name = STD_NAME_USER)
+        val alphaStandard =
+            ClassificationStandard(id = "std-alpha", key = "ALPHA", name = "Alpha")
+        val manualItem =
+            ClassificationItem(
+                id = "item-user",
+                standard = userStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "INFORMATION_TECHNOLOGY",
+                name = "Information Technology"
+            )
+        val alphaItem =
+            ClassificationItem(
+                id = "item-alpha",
+                standard = alphaStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "COMMUNICATION_SERVICES",
+                name = "Communication Services"
+            )
+        val existingManual =
+            AssetClassification(
+                id = "ac-1",
+                asset = asset,
+                standard = userStandard,
+                item = manualItem,
+                level = ClassificationLevel.SECTOR,
+                source = ClassificationService.SOURCE_MANUAL
+            )
+        whenever(
+            classificationRepository.findByAssetIdAndLevel("asset-1", ClassificationLevel.SECTOR)
+        ).thenReturn(Optional.of(existingManual))
+
+        val result =
+            service.classifyAsset(
+                asset = asset,
+                standard = alphaStandard,
+                item = alphaItem,
+                level = ClassificationLevel.SECTOR,
+                source = AssetClassification.SOURCE_ALPHA_OVERVIEW
+            )
+
+        // User precedence: provider enrichment must not clobber a manual override.
+        assertThat(result).isEqualTo(existingManual)
+        verify(classificationRepository, never()).delete(any())
+        verify(classificationRepository, never()).save(any())
+    }
+
+    @Test
+    fun `classifyAsset replaces an existing provider classification`() {
+        val asset = mock<Asset>()
+        whenever(asset.id).thenReturn("asset-1")
+        val alphaStandard =
+            ClassificationStandard(id = "std-alpha", key = "ALPHA", name = "Alpha")
+        val oldItem =
+            ClassificationItem(
+                id = "i-old",
+                standard = alphaStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "COMMUNICATION_SERVICES",
+                name = "Communication Services"
+            )
+        val newItem =
+            ClassificationItem(
+                id = "i-new",
+                standard = alphaStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "INFORMATION_TECHNOLOGY",
+                name = "Information Technology"
+            )
+        val existingProvider =
+            AssetClassification(
+                id = "ac-old",
+                asset = asset,
+                standard = alphaStandard,
+                item = oldItem,
+                level = ClassificationLevel.SECTOR,
+                source = AssetClassification.SOURCE_ALPHA_OVERVIEW
+            )
+        whenever(
+            classificationRepository.findByAssetIdAndLevel("asset-1", ClassificationLevel.SECTOR)
+        ).thenReturn(Optional.of(existingProvider))
+        whenever(entityManager.getReference(Asset::class.java, "asset-1")).thenReturn(asset)
+        whenever(classificationRepository.save(any<AssetClassification>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            service.classifyAsset(
+                asset = asset,
+                standard = alphaStandard,
+                item = newItem,
+                level = ClassificationLevel.SECTOR,
+                source = AssetClassification.SOURCE_ALPHA_OVERVIEW
+            )
+
+        verify(classificationRepository).delete(existingProvider)
+        assertThat(result.item).isEqualTo(newItem)
+        assertThat(result.source).isEqualTo(AssetClassification.SOURCE_ALPHA_OVERVIEW)
+    }
+
+    @Test
+    fun `classifyAsset allows a manual source to overwrite provider classification`() {
+        val asset = mock<Asset>()
+        whenever(asset.id).thenReturn("asset-1")
+        val alphaStandard =
+            ClassificationStandard(id = "std-alpha", key = "ALPHA", name = "Alpha")
+        val userStandard =
+            ClassificationStandard(id = STD_ID, key = STD_KEY_USER, name = STD_NAME_USER)
+        val providerItem =
+            ClassificationItem(
+                id = "i-alpha",
+                standard = alphaStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "COMMUNICATION_SERVICES",
+                name = "Communication Services"
+            )
+        val userItem =
+            ClassificationItem(
+                id = "i-user",
+                standard = userStandard,
+                level = ClassificationLevel.SECTOR,
+                code = "INFORMATION_TECHNOLOGY",
+                name = "Information Technology"
+            )
+        val existingProvider =
+            AssetClassification(
+                id = "ac-old",
+                asset = asset,
+                standard = alphaStandard,
+                item = providerItem,
+                level = ClassificationLevel.SECTOR,
+                source = AssetClassification.SOURCE_ALPHA_OVERVIEW
+            )
+        whenever(
+            classificationRepository.findByAssetIdAndLevel("asset-1", ClassificationLevel.SECTOR)
+        ).thenReturn(Optional.of(existingProvider))
+        whenever(entityManager.getReference(Asset::class.java, "asset-1")).thenReturn(asset)
+        whenever(classificationRepository.save(any<AssetClassification>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            service.classifyAsset(
+                asset = asset,
+                standard = userStandard,
+                item = userItem,
+                level = ClassificationLevel.SECTOR,
+                source = ClassificationService.SOURCE_MANUAL
+            )
+
+        verify(classificationRepository).delete(existingProvider)
+        assertThat(result.item).isEqualTo(userItem)
+        assertThat(result.source).isEqualTo(ClassificationService.SOURCE_MANUAL)
     }
 }


### PR DESCRIPTION
classifyAsset now skips replacing an existing MANUAL classification when
called with a provider source, so AlphaVantage refresh no longer clobbers a
user-set sector. Provider-over-provider and manual-over-provider replacements
still apply.