### PR TITLE
feat: weighted SELL proposals from broker holdings

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerController.kt
@@ -13,6 +13,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -112,4 +114,46 @@ class TrnBrokerController(
                 dateUtils.getFormattedDate(asAt ?: dateUtils.today())
             )
         )
+
+    @PostMapping(
+        value = ["/broker/{brokerId}/propose"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "Propose weighted SELL transactions from broker holdings",
+        description = """
+            Creates PROPOSED SELL transactions for every portfolio holding the given asset
+            at the broker, sized as `weight` * that portfolio's split-adjusted broker holding.
+
+            Use this to:
+            * Kick off a broker-wide partial (or full) liquidation from the reconciliation view
+            * Stage proposals for review/settle without directly mutating live positions
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Proposed transactions created successfully"
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Invalid proposal request"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Broker or asset not found"
+            )
+        ]
+    )
+    fun proposeWeighted(
+        @Parameter(
+            description = "Broker identifier",
+            example = "broker-123"
+        ) @PathVariable("brokerId") brokerId: String,
+        @Parameter(
+            description = "Weighted SELL proposal request"
+        ) @RequestBody request: BrokerProposalRequest
+    ): TrnResponse = trnBrokerService.proposeWeighted(brokerId, request)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -1,6 +1,10 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.contracts.TrnResponse
+import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
@@ -8,11 +12,13 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.broker.BrokerService
+import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.registration.SystemUserService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * Service for broker-related transaction operations including holdings aggregation and transfers.
@@ -24,7 +30,9 @@ class TrnBrokerService(
     private val brokerService: BrokerService,
     private val systemUserService: SystemUserService,
     private val assetFinder: AssetFinder,
-    private val trnMigrator: TrnMigrator
+    private val trnMigrator: TrnMigrator,
+    private val trnService: TrnService,
+    private val portfolioService: PortfolioService
 ) {
     private val log = LoggerFactory.getLogger(TrnBrokerService::class.java)
 
@@ -145,6 +153,68 @@ class TrnBrokerService(
             brokerName = brokerName,
             holdings = holdings
         )
+    }
+
+    /**
+     * Create weighted PROPOSED SELL transactions from the broker reconciliation
+     * view — one per portfolio holding [BrokerProposalRequest.assetId] at the
+     * broker, sized as `weight` * that portfolio's split-adjusted broker holding.
+     * No cash auto-settle fires: proposals are PROPOSED, not SETTLED.
+     */
+    fun proposeWeighted(
+        brokerId: String,
+        request: BrokerProposalRequest
+    ): TrnResponse {
+        if (request.trnType != TrnType.SELL) {
+            throw BusinessException("Only SELL proposals are supported")
+        }
+        if (request.weight <= BigDecimal.ZERO || request.weight > BigDecimal.ONE) {
+            throw BusinessException("Weight must be greater than 0 and less than or equal to 1")
+        }
+        if (request.price <= BigDecimal.ZERO) {
+            throw BusinessException("Price must be greater than 0")
+        }
+        if (brokerId == NO_BROKER) {
+            throw BusinessException("A broker is required to propose transactions")
+        }
+
+        val holdings = getBrokerHoldings(brokerId)
+        val position =
+            holdings.holdings.firstOrNull { it.assetId == request.assetId }
+                ?: throw NotFoundException("Asset not held at broker: ${request.assetId}")
+
+        // Resolve trade currency up front (same fallback CSV import uses via
+        // BcRowAdapter.getTradeCurrency) so FxTransactions.setRates compares
+        // like-for-like currencies instead of tripping over the TrnInput
+        // default empty tradeCurrency, which reads as an unknown "" currency.
+        val asset = assetFinder.find(request.assetId)
+        val tradeCurrencyCode = asset.accountingType?.currency?.code ?: asset.market.currency.code
+
+        val tradeDate = request.tradeDate ?: DateUtils().date
+        val created = mutableListOf<Trn>()
+        for (group in position.portfolioGroups) {
+            if (group.quantity.compareTo(BigDecimal.ZERO) <= 0) continue
+            val quantity = group.quantity.multiply(request.weight).setScale(6, RoundingMode.HALF_UP)
+            if (quantity.compareTo(BigDecimal.ZERO) == 0) continue
+            val tradeAmount = quantity.multiply(request.price).setScale(2, RoundingMode.HALF_UP)
+            val trnInput =
+                TrnInput(
+                    assetId = request.assetId,
+                    trnType = TrnType.SELL,
+                    quantity = quantity,
+                    tradeCurrency = tradeCurrencyCode,
+                    price = request.price,
+                    tradeAmount = tradeAmount,
+                    cashAmount = tradeAmount,
+                    status = TrnStatus.PROPOSED,
+                    brokerId = brokerId,
+                    tradeDate = tradeDate
+                )
+            val portfolio = portfolioService.find(group.portfolioId)
+            val result = trnService.saveWithResult(portfolio, TrnRequest(portfolio.id, listOf(trnInput)))
+            created.addAll(result.trns)
+        }
+        return TrnResponse(created)
     }
 
     private fun resolveBrokerTransactions(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.trn
 
+import com.beancounter.common.model.TrnType
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -8,6 +9,19 @@ import java.time.LocalDate
  */
 data class SettleTransactionsRequest(
     val trnIds: List<String>
+)
+
+/**
+ * Request to create weighted PROPOSED SELL transactions from the broker
+ * reconciliation view — one per portfolio holding [assetId] at the broker,
+ * sized as [weight] * that portfolio's split-adjusted broker holding.
+ */
+data class BrokerProposalRequest(
+    val assetId: String,
+    val trnType: TrnType = TrnType.SELL,
+    val weight: BigDecimal,
+    val price: BigDecimal,
+    val tradeDate: LocalDate? = null
 )
 
 /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
@@ -1,0 +1,315 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.auth.model.Registration
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.model.Broker
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.portfolio.PortfolioService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Weighted PROPOSED SELL proposals generated from the broker reconciliation view —
+ * one trn per portfolio holding the asset at the broker, sized as weight * that
+ * portfolio's split-adjusted broker holding.
+ */
+@SpringMvcDbTest
+class TrnBrokerServiceProposeTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var trnBrokerService: TrnBrokerService
+
+    @Autowired
+    private lateinit var brokerRepository: BrokerRepository
+
+    @Autowired
+    private lateinit var portfolioService: PortfolioService
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @Autowired
+    private lateinit var systemUserService: Registration
+
+    private fun login(email: String): SystemUser {
+        val user = SystemUser(id = email, email = email)
+        mockAuthConfig.login(user, systemUserService)
+        return user
+    }
+
+    private fun portfolio(code: String): Portfolio =
+        portfolioService
+            .save(listOf(PortfolioInput(code = code, name = code, currency = USD.code)))
+            .first()
+
+    private fun asset(code: String) =
+        assetService
+            .handle(AssetRequest(AssetInput(NASDAQ.code, code), code))
+            .data[code]!!
+
+    private fun buy(
+        portfolio: Portfolio,
+        broker: Broker,
+        asset: com.beancounter.common.model.Asset,
+        quantity: String,
+        tradeDate: LocalDate = LocalDate.of(2026, 1, 1)
+    ) {
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.BUY,
+                asset = asset,
+                quantity = BigDecimal(quantity),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = tradeDate
+            )
+        )
+    }
+
+    private fun sell(
+        portfolio: Portfolio,
+        broker: Broker,
+        asset: com.beancounter.common.model.Asset,
+        quantity: String,
+        tradeDate: LocalDate = LocalDate.of(2026, 2, 1)
+    ) {
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SELL,
+                asset = asset,
+                quantity = BigDecimal(quantity),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = tradeDate
+            )
+        )
+    }
+
+    @Test
+    fun `should create one proposed SELL per portfolio holding the asset at the broker weighted by holding`() {
+        val user = login("propose-weighted@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER1", owner = user))
+        val p1 = portfolio("PW-P1")
+        val p2 = portfolio("PW-P2")
+        val asset = asset("PWA1")
+        buy(p1, broker, asset, "100")
+        buy(p2, broker, asset, "60")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("10.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(2)
+        assertThat(trns).allSatisfy { trn ->
+            assertThat(trn.trnType).isEqualTo(TrnType.SELL)
+            assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+            assertThat(trn.brokerId).isEqualTo(broker.id)
+            assertThat(trn.price).isEqualByComparingTo("10.00")
+        }
+        val byPortfolio = trns.associateBy { it.portfolioId }
+        assertThat(byPortfolio[p1.id]!!.quantity).isEqualByComparingTo("50")
+        assertThat(byPortfolio[p1.id]!!.tradeAmount).isEqualByComparingTo("500.00")
+        assertThat(byPortfolio[p2.id]!!.quantity).isEqualByComparingTo("30")
+        assertThat(byPortfolio[p2.id]!!.tradeAmount).isEqualByComparingTo("300.00")
+    }
+
+    @Test
+    fun `should sell full holding when weight is 1`() {
+        val user = login("propose-full@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER2", owner = user))
+        val p1 = portfolio("PWF-P1")
+        val asset = asset("PWA2")
+        buy(p1, broker, asset, "75")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("1"),
+                    price = BigDecimal("5.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(1)
+        assertThat(trns.first().quantity).isEqualByComparingTo("75")
+    }
+
+    @Test
+    fun `should skip portfolios with zero or negative holding at the broker`() {
+        val user = login("propose-skip-zero@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER3", owner = user))
+        val p1 = portfolio("PWZ-P1")
+        val p2 = portfolio("PWZ-P2")
+        val asset = asset("PWA3")
+        // p1 bought and sold everything -> net zero at this broker
+        buy(p1, broker, asset, "50")
+        sell(p1, broker, asset, "50")
+        // p2 still holds
+        buy(p2, broker, asset, "100")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("2.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(1)
+        assertThat(trns.first().portfolioId).isEqualTo(p2.id)
+        assertThat(trns.first().quantity).isEqualByComparingTo("50")
+    }
+
+    @Test
+    fun `should apply split adjustment to weighted quantity`() {
+        val user = login("propose-split@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER4", owner = user))
+        val p1 = portfolio("PWS-P1")
+        val asset = asset("PWA4")
+        buy(p1, broker, asset, "10", tradeDate = LocalDate.of(2026, 1, 1))
+        // 2:1 SPLIT — corporate action, carries NO broker
+        trnRepository.save(
+            Trn(
+                trnType = TrnType.SPLIT,
+                asset = asset,
+                quantity = BigDecimal("2"),
+                portfolio = p1,
+                broker = null,
+                tradeDate = LocalDate.of(2026, 2, 1)
+            )
+        )
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("1.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(1)
+        // 10 -> *2 (split) = 20 holding; weight 0.5 -> 10
+        assertThat(trns.first().quantity).isEqualByComparingTo("10")
+    }
+
+    @Test
+    fun `should reject weight above 1`() {
+        val user = login("propose-weight-high@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER5", owner = user))
+        val p1 = portfolio("PWH-P1")
+        val asset = asset("PWA5")
+        buy(p1, broker, asset, "10")
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("1.5"),
+                    price = BigDecimal("1.00")
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+    }
+
+    @Test
+    fun `should reject non-SELL type`() {
+        val user = login("propose-non-sell@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER6", owner = user))
+        val p1 = portfolio("PWN-P1")
+        val asset = asset("PWA6")
+        buy(p1, broker, asset, "10")
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    trnType = TrnType.BUY,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("1.00")
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+    }
+
+    @Test
+    fun `should reject unknown asset for broker`() {
+        val user = login("propose-unknown-asset@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER7", owner = user))
+        val p1 = portfolio("PWU-P1")
+        val heldAsset = asset("PWA7")
+        buy(p1, broker, heldAsset, "10")
+        val unheldAsset = asset("PWA7B")
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = unheldAsset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("1.00")
+                )
+            )
+        }.isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `should reject NO_BROKER sentinel`() {
+        login("propose-no-broker@test.com")
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                TrnBrokerService.NO_BROKER,
+                BrokerProposalRequest(
+                    assetId = "any-asset-id",
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("1.00")
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+    }
+}


### PR DESCRIPTION
POST /trns/broker/{brokerId}/propose creates one PROPOSED SELL per
portfolio holding the asset at the broker, quantity = weight x that
portfolio's split-adjusted holding. Persists via TrnService so the
existing mapper resolves currency/rates; no cash legs until settle.