### PR TITLE
fix: round proposed sell quantities to board lot

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.trn
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.NoRepositoryBean
 import java.time.LocalDate
@@ -164,6 +165,27 @@ interface TrnBrokerRepository {
         tradeDate: LocalDate,
         status: TrnStatus
     ): Collection<Trn>
+
+    /**
+     * True when the owner already has a transaction of the given type/status
+     * for this asset at this broker (any portfolio). Used to block duplicate
+     * weighted sell proposals from the reconciliation view.
+     */
+    @Query(
+        "select count(t) > 0 from Trn t " +
+            "where t.broker.id = ?1 " +
+            "and t.asset.id = ?2 " +
+            "and t.trnType = ?3 " +
+            "and t.status = ?4 " +
+            "and t.portfolio.owner = ?5"
+    )
+    fun existsByBrokerAndAssetAndTypeAndStatus(
+        brokerId: String,
+        assetId: String,
+        trnType: TrnType,
+        status: TrnStatus,
+        owner: SystemUser
+    ): Boolean
 
     /**
      * Count transactions for a specific broker owned by the user.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -129,6 +129,7 @@ class TrnBrokerService(
         val assetCode: String,
         val assetName: String?,
         val market: String,
+        val boardLot: Int,
         var quantity: BigDecimal = BigDecimal.ZERO,
         val portfolioMap: MutableMap<String, PortfolioTrns> = mutableMapOf()
     )
@@ -158,7 +159,8 @@ class TrnBrokerService(
     /**
      * Create weighted PROPOSED SELL transactions from the broker reconciliation
      * view — one per portfolio holding [BrokerProposalRequest.assetId] at the
-     * broker, sized as `weight` * that portfolio's split-adjusted broker holding.
+     * broker, sized as `weight` * that portfolio's split-adjusted broker holding,
+     * rounded to the asset's board lot (see [roundToLot]).
      * No cash auto-settle fires: proposals are PROPOSED, not SETTLED.
      */
     fun proposeWeighted(
@@ -177,6 +179,17 @@ class TrnBrokerService(
         if (brokerId == NO_BROKER) {
             throw BusinessException("A broker is required to propose transactions")
         }
+        val user = systemUserService.getOrThrow()
+        if (trnRepository.existsByBrokerAndAssetAndTypeAndStatus(
+                brokerId,
+                request.assetId,
+                TrnType.SELL,
+                TrnStatus.PROPOSED,
+                user
+            )
+        ) {
+            throw BusinessException("A proposed sell already exists for this asset at this broker")
+        }
 
         val holdings = getBrokerHoldings(brokerId)
         val position =
@@ -194,7 +207,12 @@ class TrnBrokerService(
         val created = mutableListOf<Trn>()
         for (group in position.portfolioGroups) {
             if (group.quantity.compareTo(BigDecimal.ZERO) <= 0) continue
-            val quantity = group.quantity.multiply(request.weight).setScale(6, RoundingMode.HALF_UP)
+            val quantity =
+                roundToLot(
+                    group.quantity.multiply(request.weight),
+                    position.boardLot,
+                    group.quantity
+                )
             if (quantity.compareTo(BigDecimal.ZERO) == 0) continue
             val tradeAmount = quantity.multiply(request.price).setScale(2, RoundingMode.HALF_UP)
             val trnInput =
@@ -215,6 +233,27 @@ class TrnBrokerService(
             created.addAll(result.trns)
         }
         return TrnResponse(created)
+    }
+
+    /**
+     * Round [raw] to the asset's board lot. Lot 0 = fractional allowed (6dp,
+     * HALF_UP). Otherwise the nearest whole lot multiple, capped at [held]
+     * rounded DOWN to a full lot so a proposal never oversells — a fractional
+     * holding (e.g. DRIP residue) therefore floors to fewer units than
+     * weight * held, and a holding below one lot yields zero (skipped).
+     */
+    private fun roundToLot(
+        raw: BigDecimal,
+        boardLot: Int,
+        held: BigDecimal
+    ): BigDecimal {
+        if (boardLot < 1) return raw.setScale(6, RoundingMode.HALF_UP)
+        val lot = boardLot.toBigDecimal()
+        val rounded = raw.divide(lot, 0, RoundingMode.HALF_UP).multiply(lot)
+        if (rounded > held) {
+            return held.divide(lot, 0, RoundingMode.DOWN).multiply(lot)
+        }
+        return rounded
     }
 
     private fun resolveBrokerTransactions(
@@ -266,7 +305,8 @@ class TrnBrokerService(
                         assetId = asset.id,
                         assetCode = asset.code,
                         assetName = asset.name,
-                        market = asset.marketCode
+                        market = asset.marketCode,
+                        boardLot = asset.accountingType?.boardLot ?: 1
                     )
                 }
 
@@ -315,6 +355,7 @@ class TrnBrokerService(
                     assetName = agg.assetName,
                     market = agg.market,
                     quantity = agg.quantity,
+                    boardLot = agg.boardLot,
                     portfolioGroups = buildPortfolioGroups(agg.portfolioMap.values)
                 )
             }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
@@ -51,6 +51,9 @@ data class BrokerHoldingPosition(
     val assetName: String?,
     val market: String,
     val quantity: BigDecimal,
+    // Trade-size granularity from the asset's accounting type: quantities trade
+    // in whole multiples of this lot; 0 means fractional quantities are allowed.
+    val boardLot: Int = 1,
     val portfolioGroups: List<BrokerPortfolioGroup>
 )
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
@@ -16,6 +16,8 @@ import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AccountingTypeService
+import com.beancounter.marketdata.assets.AssetRepository
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.broker.BrokerRepository
 import com.beancounter.marketdata.portfolio.PortfolioService
@@ -51,6 +53,12 @@ class TrnBrokerServiceProposeTest {
     private lateinit var assetService: AssetService
 
     @Autowired
+    private lateinit var assetRepository: AssetRepository
+
+    @Autowired
+    private lateinit var accountingTypeService: AccountingTypeService
+
+    @Autowired
     private lateinit var trnRepository: TrnRepository
 
     @Autowired
@@ -74,6 +82,20 @@ class TrnBrokerServiceProposeTest {
         assetService
             .handle(AssetRequest(AssetInput(NASDAQ.code, code), code))
             .data[code]!!
+
+    private fun assetWithLot(
+        code: String,
+        boardLot: Int
+    ): com.beancounter.common.model.Asset {
+        val asset = asset(code)
+        asset.accountingType =
+            accountingTypeService.getOrCreate(
+                category = "LOT$boardLot",
+                currency = USD,
+                boardLot = boardLot
+            )
+        return assetRepository.save(asset)
+    }
 
     private fun buy(
         portfolio: Portfolio,
@@ -233,6 +255,205 @@ class TrnBrokerServiceProposeTest {
         assertThat(trns).hasSize(1)
         // 10 -> *2 (split) = 20 holding; weight 0.5 -> 10
         assertThat(trns.first().quantity).isEqualByComparingTo("10")
+    }
+
+    @Test
+    fun `should round weighted quantity to whole shares by default`() {
+        val user = login("propose-whole-shares@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-LOT1", owner = user))
+        val p1 = portfolio("PWL1-P1")
+        val p2 = portfolio("PWL1-P2")
+        val asset = asset("PWLA1")
+        buy(p1, broker, asset, "69")
+        buy(p2, broker, asset, "18")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("687.08")
+                )
+            )
+
+        val byPortfolio = response.data.trns.associateBy { it.portfolioId }
+        assertThat(byPortfolio).hasSize(2)
+        // 34.5 raw -> whole share HALF_UP -> 35; 9 stays 9
+        assertThat(byPortfolio[p1.id]!!.quantity).isEqualByComparingTo("35")
+        assertThat(byPortfolio[p2.id]!!.quantity).isEqualByComparingTo("9")
+        assertThat(
+            trnBrokerService
+                .getBrokerHoldings(broker.id)
+                .holdings
+                .first()
+                .boardLot
+        ).isEqualTo(1)
+    }
+
+    @Test
+    fun `should round to board lot multiples when accounting type defines a lot`() {
+        val user = login("propose-board-lot@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-LOT100", owner = user))
+        val p1 = portfolio("PWL2-P1")
+        val p2 = portfolio("PWL2-P2")
+        val asset = assetWithLot("PWLA2", 100)
+        buy(p1, broker, asset, "1000")
+        buy(p2, broker, asset, "130")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("2.00")
+                )
+            )
+
+        val byPortfolio = response.data.trns.associateBy { it.portfolioId }
+        assertThat(byPortfolio).hasSize(2)
+        assertThat(byPortfolio[p1.id]!!.quantity).isEqualByComparingTo("500")
+        // 65 raw -> nearest 100-lot -> 100 (still within the 130 held)
+        assertThat(byPortfolio[p2.id]!!.quantity).isEqualByComparingTo("100")
+        assertThat(
+            trnBrokerService
+                .getBrokerHoldings(broker.id)
+                .holdings
+                .first()
+                .boardLot
+        ).isEqualTo(100)
+    }
+
+    @Test
+    fun `should skip portfolio when rounded quantity is below one board lot`() {
+        val user = login("propose-below-lot@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-LOT-SKIP", owner = user))
+        val p1 = portfolio("PWL3-P1")
+        val asset = assetWithLot("PWLA3", 100)
+        buy(p1, broker, asset, "40")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("2.00")
+                )
+            )
+
+        // 20 raw -> rounds to zero lots -> nothing proposed
+        assertThat(response.data.trns).isEmpty()
+    }
+
+    @Test
+    fun `should not round above held quantity`() {
+        val user = login("propose-cap-held@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-LOT-CAP", owner = user))
+        val p1 = portfolio("PWL4-P1")
+        val asset = assetWithLot("PWLA4", 10)
+        buy(p1, broker, asset, "9")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("1"),
+                    price = BigDecimal("2.00")
+                )
+            )
+
+        // 9 raw -> nearest lot 10 would oversell -> capped to floor (0 lots) -> skipped
+        assertThat(response.data.trns).isEmpty()
+    }
+
+    @Test
+    fun `should keep fractional quantity when accounting type board lot is zero`() {
+        val user = login("propose-fractional@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-LOT0", owner = user))
+        val p1 = portfolio("PWL5-P1")
+        val asset = assetWithLot("PWLA5", 0)
+        buy(p1, broker, asset, "69")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("687.08")
+                )
+            )
+
+        assertThat(response.data.trns).hasSize(1)
+        assertThat(
+            response.data.trns
+                .first()
+                .quantity
+        ).isEqualByComparingTo("34.5")
+    }
+
+    @Test
+    fun `should reject when a proposed sell already exists for the asset at the broker`() {
+        val user = login("propose-duplicate@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-DUP", owner = user))
+        val p1 = portfolio("PWD-P1")
+        val asset = asset("PWDA1")
+        buy(p1, broker, asset, "100")
+
+        val first =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("2.00")
+                )
+            )
+        assertThat(first.data.trns).hasSize(1)
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.25"),
+                    price = BigDecimal("2.00")
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining("proposed sell already exists")
+    }
+
+    @Test
+    fun `should allow proposing when prior proposal was settled`() {
+        val user = login("propose-after-settle@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-SETTLED", owner = user))
+        val p1 = portfolio("PWAS-P1")
+        val asset = asset("PWSA1")
+        buy(p1, broker, asset, "100")
+        // A SETTLED sell at this broker must not block a new proposal
+        sell(p1, broker, asset, "20")
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal("2.00")
+                )
+            )
+
+        assertThat(response.data.trns).hasSize(1)
+        // holding after settled sell: 80; weight 0.5 -> 40
+        assertThat(
+            response.data.trns
+                .first()
+                .quantity
+        ).isEqualByComparingTo("40")
     }
 
     @Test


### PR DESCRIPTION
Quantity = nearest accountingType.boardLot multiple (default 1, whole
shares), capped at the held quantity; boardLot=0 permits fractional.
Recon holdings response now carries boardLot so the UI previews the
same rounding.

Also rejects duplicate proposals: an existing PROPOSED SELL for the
same asset and broker blocks a new one; settle or delete it first.