### PR TITLE
feat: broker holdings by asset for lookup screen

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerController.kt
@@ -156,4 +156,36 @@ class TrnBrokerController(
             description = "Weighted SELL proposal request"
         ) @RequestBody request: BrokerProposalRequest
     ): TrnResponse = trnBrokerService.proposeWeighted(brokerId, request)
+
+    @GetMapping(
+        value = ["/asset/{assetId}/brokers"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "Get brokers holding a given asset for the calling user",
+        description = """
+            Reverse lookup of getBrokerHoldings: finds which broker(s) hold the given
+            asset, with per-broker split-adjusted quantities and portfolio groups.
+
+            Use this to:
+            * Populate the WeightedSellDialog's broker picker for an asset
+            * Show where an asset is actually held before staging a weighted sell
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description =
+                    "Asset broker holdings retrieved successfully (empty data " +
+                        "list when the asset is unknown or not currently held)"
+            )
+        ]
+    )
+    fun getAssetBrokerHoldings(
+        @Parameter(
+            description = "Asset identifier",
+            example = "asset-123"
+        ) @PathVariable("assetId") assetId: String
+    ): AssetBrokerHoldingsResponse = trnBrokerService.getAssetBrokerHoldings(assetId)
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerRepository.kt
@@ -219,4 +219,87 @@ interface TrnBrokerRepository {
         brokerId: String,
         owner: SystemUser
     ): Collection<Trn>
+
+    /**
+     * Find settled trade transactions for a specific asset across every broker, for
+     * portfolios owned by the user. Reverse of [findByBrokerIdAndOwner] — groups by
+     * broker for the asset-brokers lookup (which broker(s) hold this asset).
+     */
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset " +
+            "join fetch t.tradeCurrency " +
+            "join fetch t.portfolio " +
+            "join fetch t.broker " +
+            "left join fetch t.cashAsset " +
+            "left join fetch t.cashCurrency " +
+            "where t.asset.id = ?1 " +
+            "and t.broker is not null " +
+            "and t.portfolio.owner = ?2 " +
+            "and t.status = ?3 " +
+            "and t.trnType in ('BUY', 'SELL', 'ADD', 'REDUCE') " +
+            "and t.asset.marketCode not in (" + EXCLUDED_MARKET_CODES + ") " +
+            "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
+            "order by t.broker.id, t.portfolio.code, t.tradeDate, t.createdAt"
+    )
+    fun findByAssetAndOwner(
+        assetId: String,
+        owner: SystemUser,
+        status: TrnStatus
+    ): Collection<Trn>
+
+    /**
+     * Find settled trade transactions for a specific asset with no broker assigned,
+     * for portfolios owned by the user. Reverse of [findWithNoBroker] — feeds the
+     * [TrnBrokerService.NO_BROKER] group of the asset-brokers lookup.
+     */
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset " +
+            "join fetch t.tradeCurrency " +
+            "join fetch t.portfolio " +
+            "left join fetch t.cashAsset " +
+            "left join fetch t.cashCurrency " +
+            "where t.asset.id = ?1 " +
+            "and t.broker is null " +
+            "and t.portfolio.owner = ?2 " +
+            "and t.status = ?3 " +
+            "and t.trnType in ('BUY', 'SELL', 'ADD', 'REDUCE') " +
+            "and t.asset.marketCode not in (" + EXCLUDED_MARKET_CODES + ") " +
+            "and t.asset.category not in ('CASH', 'ACCOUNT', 'TRADE', 'BANK ACCOUNT') " +
+            "order by t.portfolio.code, t.tradeDate, t.createdAt"
+    )
+    fun findWithNoBrokerByAssetAndOwner(
+        assetId: String,
+        owner: SystemUser,
+        status: TrnStatus
+    ): Collection<Trn>
+
+    /**
+     * Find broker-null SPLIT corporate actions for a specific asset, for portfolios
+     * owned by the user, up to the given date. Splits carry no broker so this is
+     * merged into whichever broker/NO_BROKER group the same portfolio's trades fall
+     * under — mirrors [findBrokerSplits] but scoped by asset instead of broker.
+     */
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset " +
+            "join fetch t.tradeCurrency " +
+            "join fetch t.portfolio " +
+            "left join fetch t.cashAsset " +
+            "left join fetch t.cashCurrency " +
+            "where t.asset.id = ?1 " +
+            "and t.broker is null " +
+            "and t.trnType = 'SPLIT' " +
+            "and t.portfolio.owner = ?2 " +
+            "and t.tradeDate <= ?3 " +
+            "and t.status = ?4 " +
+            "order by t.portfolio.code, t.tradeDate, t.createdAt"
+    )
+    fun findSplitsByAssetAndOwner(
+        assetId: String,
+        owner: SystemUser,
+        tradeDate: LocalDate,
+        status: TrnStatus
+    ): Collection<Trn>
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -157,6 +157,83 @@ class TrnBrokerService(
     }
 
     /**
+     * Reverse lookup: which broker(s) hold [assetId] for the calling user, shaped
+     * for the frontend's WeightedSellDialog. Mirrors [getBrokerHoldings]'s owner
+     * scoping, SETTLED-only status, and split-adjustment handling, but groups by
+     * broker for a single asset instead of by asset for a single broker.
+     *
+     * Unlike [buildPortfolioGroups] (used by the broker reconciliation view, which
+     * intentionally keeps sold-out portfolio groups for context), zero-quantity
+     * portfolio groups are excluded here — this feeds a sell picker, so only
+     * actionable holdings are relevant.
+     */
+    fun getAssetBrokerHoldings(assetId: String): AssetBrokerHoldingsResponse {
+        val user = systemUserService.getOrThrow()
+
+        val brokerTrades = trnRepository.findByAssetAndOwner(assetId, user, TrnStatus.SETTLED)
+        val noBrokerTrades = trnRepository.findWithNoBrokerByAssetAndOwner(assetId, user, TrnStatus.SETTLED)
+        if (brokerTrades.isEmpty() && noBrokerTrades.isEmpty()) {
+            return AssetBrokerHoldingsResponse()
+        }
+        val splits = trnRepository.findSplitsByAssetAndOwner(assetId, user, DateUtils().date, TrnStatus.SETTLED)
+
+        val groups = linkedMapOf<String, MutableList<Trn>>()
+        val brokerNames = mutableMapOf<String, String>()
+        for (trn in brokerTrades) {
+            val broker = trn.broker ?: continue
+            groups.getOrPut(broker.id) { mutableListOf() }.add(trn)
+            brokerNames[broker.id] = broker.name
+        }
+        if (noBrokerTrades.isNotEmpty()) {
+            groups[NO_BROKER] = noBrokerTrades.toMutableList()
+            brokerNames[NO_BROKER] = "No Broker"
+        }
+
+        val results = mutableListOf<AssetBrokerHolding>()
+        for ((brokerId, trns) in groups) {
+            val portfolioIds = trns.map { it.portfolio.id }.toSet()
+            val relevantSplits = splits.filter { it.portfolio.id in portfolioIds }
+            val holding = buildAssetHoldingPosition(assetId, trns + relevantSplits) ?: continue
+            results.add(
+                AssetBrokerHolding(
+                    brokerId = brokerId,
+                    brokerName = brokerNames.getValue(brokerId),
+                    holding = holding
+                )
+            )
+        }
+
+        return AssetBrokerHoldingsResponse(data = results.sortedBy { it.brokerName })
+    }
+
+    /**
+     * Aggregate [transactions] (all for the same [assetId]) into a single
+     * [BrokerHoldingPosition], excluding zero-quantity portfolio groups. Returns
+     * null when the asset's net quantity across all groups is zero, or every
+     * portfolio group nets to zero.
+     */
+    private fun buildAssetHoldingPosition(
+        assetId: String,
+        transactions: Collection<Trn>
+    ): BrokerHoldingPosition? {
+        val agg = aggregateByAsset(transactions)[assetId] ?: return null
+        if (agg.quantity.compareTo(BigDecimal.ZERO) == 0) return null
+        val portfolioGroups =
+            buildPortfolioGroups(agg.portfolioMap.values)
+                .filter { it.quantity.compareTo(BigDecimal.ZERO) != 0 }
+        if (portfolioGroups.isEmpty()) return null
+        return BrokerHoldingPosition(
+            assetId = agg.assetId,
+            assetCode = agg.assetCode,
+            assetName = agg.assetName,
+            market = agg.market,
+            quantity = agg.quantity,
+            boardLot = agg.boardLot,
+            portfolioGroups = portfolioGroups
+        )
+    }
+
+    /**
      * Create weighted PROPOSED SELL transactions from the broker reconciliation
      * view — one per portfolio holding [BrokerProposalRequest.assetId] at the
      * broker, sized as `weight` * that portfolio's split-adjusted broker holding,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnContracts.kt
@@ -64,6 +64,21 @@ data class BrokerHoldingsResponse(
 )
 
 /**
+ * A single asset's holding at one broker — the reverse view of
+ * [BrokerHoldingsResponse] used by the frontend's WeightedSellDialog to pick
+ * which broker(s) to sell an asset from.
+ */
+data class AssetBrokerHolding(
+    val brokerId: String,
+    val brokerName: String,
+    val holding: BrokerHoldingPosition
+)
+
+data class AssetBrokerHoldingsResponse(
+    val data: List<AssetBrokerHolding> = emptyList()
+)
+
+/**
  * Response for the rolling investment window summary.
  * [startDate]..[endDate] describe the trailing window the total covers.
  */

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnAssetBrokerHoldingsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnAssetBrokerHoldingsTest.kt
@@ -1,0 +1,236 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.auth.model.Registration
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Broker
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.Constants.Companion.NASDAQ
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.portfolio.PortfolioService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Reverse broker lookup for an asset — `GET /trns/asset/{assetId}/brokers` —
+ * used by the frontend's WeightedSellDialog to show which broker(s) hold a
+ * given asset before staging a weighted sell proposal.
+ */
+@SpringMvcDbTest
+class TrnAssetBrokerHoldingsTest {
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    private lateinit var trnBrokerService: TrnBrokerService
+
+    @Autowired
+    private lateinit var brokerRepository: BrokerRepository
+
+    @Autowired
+    private lateinit var portfolioService: PortfolioService
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    @Autowired
+    private lateinit var systemUserService: Registration
+
+    private fun login(email: String): SystemUser {
+        val user = SystemUser(id = email, email = email)
+        mockAuthConfig.login(user, systemUserService)
+        return user
+    }
+
+    private fun portfolio(code: String): Portfolio =
+        portfolioService
+            .save(listOf(PortfolioInput(code = code, name = code, currency = USD.code)))
+            .first()
+
+    private fun asset(code: String): Asset =
+        assetService
+            .handle(AssetRequest(AssetInput(NASDAQ.code, code), code))
+            .data[code]!!
+
+    private fun trade(
+        trnType: TrnType,
+        portfolio: Portfolio,
+        broker: Broker?,
+        asset: Asset,
+        quantity: String,
+        tradeDate: LocalDate = LocalDate.of(2026, 1, 1)
+    ) {
+        trnRepository.save(
+            Trn(
+                trnType = trnType,
+                asset = asset,
+                quantity = BigDecimal(quantity),
+                portfolio = portfolio,
+                broker = broker,
+                tradeDate = tradeDate
+            )
+        )
+    }
+
+    @Test
+    fun `asset held at two brokers returns two entries with correct per-broker quantities`() {
+        val user = login("abh-two-brokers@test.com")
+        val brokerA = brokerRepository.save(Broker(name = "ABH-BROKER-A", owner = user))
+        val brokerB = brokerRepository.save(Broker(name = "ABH-BROKER-B", owner = user))
+        val p1 = portfolio("ABH-P1")
+        val p2 = portfolio("ABH-P2")
+        val asset = asset("ABHA1")
+        trade(TrnType.BUY, p1, brokerA, asset, "100")
+        trade(TrnType.BUY, p2, brokerB, asset, "60")
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).hasSize(2)
+        val byBroker = response.data.associateBy { it.brokerId }
+        assertThat(byBroker[brokerA.id]!!.brokerName).isEqualTo("ABH-BROKER-A")
+        assertThat(byBroker[brokerA.id]!!.holding.quantity).isEqualByComparingTo("100")
+        assertThat(byBroker[brokerA.id]!!.holding.portfolioGroups).hasSize(1)
+        assertThat(
+            byBroker[brokerA.id]!!
+                .holding.portfolioGroups
+                .first()
+                .portfolioId
+        ).isEqualTo(p1.id)
+
+        assertThat(byBroker[brokerB.id]!!.brokerName).isEqualTo("ABH-BROKER-B")
+        assertThat(byBroker[brokerB.id]!!.holding.quantity).isEqualByComparingTo("60")
+        assertThat(byBroker[brokerB.id]!!.holding.portfolioGroups).hasSize(1)
+        assertThat(
+            byBroker[brokerB.id]!!
+                .holding.portfolioGroups
+                .first()
+                .portfolioId
+        ).isEqualTo(p2.id)
+    }
+
+    @Test
+    fun `broker with net-zero position for the asset is excluded`() {
+        val user = login("abh-net-zero-broker@test.com")
+        val brokerZero = brokerRepository.save(Broker(name = "ABH-BROKER-ZERO", owner = user))
+        val brokerHeld = brokerRepository.save(Broker(name = "ABH-BROKER-HELD", owner = user))
+        val p1 = portfolio("ABH-NZ-P1")
+        val p2 = portfolio("ABH-NZ-P2")
+        val asset = asset("ABHA2")
+        // brokerZero: bought and fully sold -> net zero
+        trade(TrnType.BUY, p1, brokerZero, asset, "50", LocalDate.of(2026, 1, 1))
+        trade(TrnType.SELL, p1, brokerZero, asset, "50", LocalDate.of(2026, 2, 1))
+        // brokerHeld: still holds
+        trade(TrnType.BUY, p2, brokerHeld, asset, "20")
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).hasSize(1)
+        assertThat(response.data.first().brokerId).isEqualTo(brokerHeld.id)
+    }
+
+    @Test
+    fun `zero-quantity portfolio group within a broker is excluded`() {
+        val user = login("abh-zero-portfolio-group@test.com")
+        val broker = brokerRepository.save(Broker(name = "ABH-BROKER-MIXED", owner = user))
+        val soldOutPortfolio = portfolio("ABH-ZG-P1")
+        val heldPortfolio = portfolio("ABH-ZG-P2")
+        val asset = asset("ABHA3")
+        // soldOutPortfolio: bought and fully sold at this broker -> zero group
+        trade(TrnType.BUY, soldOutPortfolio, broker, asset, "30", LocalDate.of(2026, 1, 1))
+        trade(TrnType.SELL, soldOutPortfolio, broker, asset, "30", LocalDate.of(2026, 2, 1))
+        // heldPortfolio: still holds at the same broker -> broker net quantity nonzero
+        trade(TrnType.BUY, heldPortfolio, broker, asset, "15")
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).hasSize(1)
+        val holding = response.data.first().holding
+        assertThat(holding.quantity).isEqualByComparingTo("15")
+        assertThat(holding.portfolioGroups).hasSize(1)
+        assertThat(holding.portfolioGroups.first().portfolioId).isEqualTo(heldPortfolio.id)
+    }
+
+    @Test
+    fun `another user's trns are invisible`() {
+        val owner = login("abh-owner@test.com")
+        val broker = brokerRepository.save(Broker(name = "ABH-BROKER-OWNER", owner = owner))
+        val ownedPortfolio = portfolio("ABH-OWN-P1")
+        val asset = asset("ABHA4")
+        trade(TrnType.BUY, ownedPortfolio, broker, asset, "10")
+
+        // Switch to a different user and reuse the same asset code — a different
+        // system user cannot see the first user's broker/portfolio/trn.
+        login("abh-other@test.com")
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).isEmpty()
+    }
+
+    @Test
+    fun `split adjustment is reflected in per-broker quantities`() {
+        val user = login("abh-split@test.com")
+        val broker = brokerRepository.save(Broker(name = "ABH-BROKER-SPLIT", owner = user))
+        val p1 = portfolio("ABH-SPLIT-P1")
+        val asset = asset("ABHA5")
+        // BUY 12, 4:1 SPLIT (no broker), SELL post-split shares
+        trade(TrnType.BUY, p1, broker, asset, "12", LocalDate.of(2026, 1, 1))
+        trade(TrnType.SPLIT, p1, null, asset, "4", LocalDate.of(2026, 4, 21))
+        trade(TrnType.SELL, p1, broker, asset, "40", LocalDate.of(2026, 6, 23))
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).hasSize(1)
+        // 12 -> *4 = 48, sell 40 -> net 8
+        assertThat(
+            response.data
+                .first()
+                .holding.quantity
+        ).isEqualByComparingTo("8")
+    }
+
+    @Test
+    fun `no-broker trns are grouped under the NO_BROKER sentinel`() {
+        val user = login("abh-no-broker@test.com")
+        val p1 = portfolio("ABH-NB-P1")
+        val asset = asset("ABHA6")
+        trade(TrnType.BUY, p1, null, asset, "25")
+
+        val response = trnBrokerService.getAssetBrokerHoldings(asset.id)
+
+        assertThat(response.data).hasSize(1)
+        val entry = response.data.first()
+        assertThat(entry.brokerId).isEqualTo(TrnBrokerService.NO_BROKER)
+        assertThat(entry.brokerName).isEqualTo("No Broker")
+        assertThat(entry.holding.quantity).isEqualByComparingTo("25")
+    }
+
+    @Test
+    fun `unknown asset returns an empty response`() {
+        login("abh-unknown-asset@test.com")
+
+        val response = trnBrokerService.getAssetBrokerHoldings("does-not-exist")
+
+        assertThat(response.data).isEmpty()
+    }
+}


### PR DESCRIPTION
Adds GET /trns/asset/{assetId}/brokers — reverse lookup of which
broker(s) hold a given asset, shaped for the frontend's
WeightedSellDialog. Mirrors getBrokerHoldings' owner scoping,
SETTLED-only status, and split-adjustment handling, but groups by
broker for a single asset. Zero-quantity portfolio groups and
net-zero brokers are excluded.