### PR TITLE
feat(assets): US 401k/IRA + UK ISA policy types and tax settings (#1032)

### DIFF
--- a/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/composite/CompositeValuationTest.kt
@@ -83,6 +83,46 @@ class CompositeValuationTest {
     }
 
     @Test
+    fun `US_401K rolls up sub-account balances`() {
+        val result =
+            valuation.value(
+                policyType = "US_401K",
+                subAccounts =
+                    listOf(
+                        SubAccountBalance(code = "TRADITIONAL", balance = BigDecimal("120000"), liquid = true),
+                        SubAccountBalance(code = "ROTH", balance = BigDecimal("30000"), liquid = true)
+                    )
+            )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.total).isEqualByComparingTo(BigDecimal("150000"))
+        assertThat(result.liquid).isEqualByComparingTo(BigDecimal("150000"))
+        assertThat(result.byCode).containsOnly(
+            entry("TRADITIONAL", BigDecimal("120000")),
+            entry("ROTH", BigDecimal("30000"))
+        )
+    }
+
+    @Test
+    fun `US_IRA and UK_ISA are supported policy types`() {
+        val ira =
+            valuation.value(
+                policyType = "US_IRA",
+                subAccounts = listOf(SubAccountBalance(code = "IRA", balance = BigDecimal("55000")))
+            )
+        val isa =
+            valuation.value(
+                policyType = "UK_ISA",
+                subAccounts = listOf(SubAccountBalance(code = "ISA", balance = BigDecimal("20000")))
+            )
+
+        assertThat(ira).isNotNull
+        assertThat(ira!!.total).isEqualByComparingTo(BigDecimal("55000"))
+        assertThat(isa).isNotNull
+        assertThat(isa!!.total).isEqualByComparingTo(BigDecimal("20000"))
+    }
+
+    @Test
     fun `CPF with empty sub-accounts is zero`() {
         val result = valuation.value(policyType = "CPF", subAccounts = emptyList())
 

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/composite/CompositeValuation.kt
@@ -50,8 +50,14 @@ class CompositeValuation {
     }
 
     companion object {
-        /** Policy types this support class knows how to roll up. */
-        val supportedPolicyTypes: Set<String> = setOf("CPF")
+        /**
+         * Policy types this support class knows how to roll up. US_401K /
+         * US_IRA / UK_ISA sub-account balances use the same simple sum as
+         * CPF — anything absent from this set is silently dropped by
+         * callers' composite roll-up, so new composite policy types MUST be
+         * registered here.
+         */
+        val supportedPolicyTypes: Set<String> = setOf("CPF", "US_401K", "US_IRA", "UK_ISA")
     }
 }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PolicyType.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PolicyType.kt
@@ -6,5 +6,8 @@ package com.beancounter.marketdata.assets
  */
 enum class PolicyType {
     CPF,
-    GENERIC
+    GENERIC,
+    US_401K,
+    US_IRA,
+    UK_ISA
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
@@ -101,6 +101,23 @@ data class PrivateAssetConfig(
     val cpfLifePlan: String? = null,
     @Column(name = "cpf_payout_start_age")
     val cpfPayoutStartAge: Int? = null,
+    // US 401k/IRA + UK ISA specific settings (relevant when policyType is
+    // US_401K, US_IRA or UK_ISA, but kept permissive for other types — MVP).
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tax_treatment", length = 20)
+    val taxTreatment: TaxTreatment? = null,
+    // % of gross salary deferred into the account (e.g. 0.0600 = 6%)
+    @Column(name = "employee_deferral_percent", precision = 5, scale = 4)
+    val employeeDeferralPercent: BigDecimal? = null,
+    // Employer match as a % of salary (e.g. 0.5000 = 50c per $1 deferred)
+    @Column(name = "employer_match_percent", precision = 5, scale = 4)
+    val employerMatchPercent: BigDecimal? = null,
+    // Salary % cap on the employer match (e.g. 0.0600 = match capped at 6% of salary)
+    @Column(name = "employer_match_cap_percent", precision = 5, scale = 4)
+    val employerMatchCapPercent: BigDecimal? = null,
+    // Effective flat tax rate applied to TRADITIONAL withdrawals at projection time
+    @Column(name = "withdrawal_tax_rate", precision = 5, scale = 4)
+    val withdrawalTaxRate: BigDecimal? = null,
     @OneToMany(
         cascade = [CascadeType.ALL],
         orphanRemoval = true,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigContracts.kt
@@ -46,6 +46,15 @@ data class PrivateAssetConfigRequest(
     // CPF-specific settings
     val cpfLifePlan: String? = null,
     val cpfPayoutStartAge: Int? = null,
+    // US 401k/IRA + UK ISA specific settings.
+    // taxTreatment is validated (not typed as an enum) so an invalid value
+    // surfaces as a clear BusinessException rather than a generic Jackson
+    // deserialization 400. Valid values: TRADITIONAL | ROTH | TAX_FREE.
+    val taxTreatment: String? = null,
+    val employeeDeferralPercent: BigDecimal? = null,
+    val employerMatchPercent: BigDecimal? = null,
+    val employerMatchCapPercent: BigDecimal? = null,
+    val withdrawalTaxRate: BigDecimal? = null,
     val subAccounts: List<SubAccountRequest>? = null
 )
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -101,6 +101,7 @@ class PrivateAssetConfigService(
         verifyAssetOwnership(assetId)
         logSaveRequest(assetId, request)
         validateSubAccountCodes(request.subAccounts)
+        validateTaxTreatment(request)
 
         val existing = configRepository.findById(assetId).orElse(null)
         val config =
@@ -178,6 +179,7 @@ class PrivateAssetConfigService(
                 .mergeTransactionSettings(request)
                 .mergePensionSettings(request)
                 .mergeCpfSettings(request)
+                .mergeUsUkPolicySettings(request)
         mergeSubAccounts(updated, assetId, request.subAccounts)
         return updated
     }
@@ -226,6 +228,20 @@ class PrivateAssetConfigService(
         )
 
     /**
+     * Merge US 401k/IRA + UK ISA settings. Kept permissive (MVP): fields are
+     * accepted regardless of [PrivateAssetConfig.policyType] and are harmless
+     * (unused) on policy types that don't consume them.
+     */
+    private fun PrivateAssetConfig.mergeUsUkPolicySettings(request: PrivateAssetConfigRequest) =
+        copy(
+            taxTreatment = request.taxTreatment?.let { TaxTreatment.valueOf(it) } ?: taxTreatment,
+            employeeDeferralPercent = request.employeeDeferralPercent ?: employeeDeferralPercent,
+            employerMatchPercent = request.employerMatchPercent ?: employerMatchPercent,
+            employerMatchCapPercent = request.employerMatchCapPercent ?: employerMatchCapPercent,
+            withdrawalTaxRate = request.withdrawalTaxRate ?: withdrawalTaxRate
+        )
+
+    /**
      * Create a new config with request values and sensible defaults.
      */
     private fun createNewConfig(
@@ -260,6 +276,11 @@ class PrivateAssetConfigService(
             lockedUntilDate = request.lockedUntilDate,
             cpfLifePlan = request.cpfLifePlan,
             cpfPayoutStartAge = request.cpfPayoutStartAge,
+            taxTreatment = request.taxTreatment?.let { TaxTreatment.valueOf(it) },
+            employeeDeferralPercent = request.employeeDeferralPercent,
+            employerMatchPercent = request.employerMatchPercent,
+            employerMatchCapPercent = request.employerMatchCapPercent,
+            withdrawalTaxRate = request.withdrawalTaxRate,
             subAccounts = toSubAccountEntities(assetId, request.subAccounts),
             createdDate = LocalDate.now(),
             updatedDate = LocalDate.now()
@@ -274,6 +295,21 @@ class PrivateAssetConfigService(
         val duplicates = codes.groupBy { it }.filter { it.value.size > 1 }.keys
         if (duplicates.isNotEmpty()) {
             throw BusinessException("Duplicate sub-account codes: ${duplicates.joinToString()}")
+        }
+    }
+
+    /**
+     * Reject an unknown [PrivateAssetConfigRequest.taxTreatment] string.
+     * Permissive on which [PolicyType] it's attached to (MVP) — only the
+     * value itself is validated against [TaxTreatment].
+     */
+    private fun validateTaxTreatment(request: PrivateAssetConfigRequest) {
+        val value = request.taxTreatment ?: return
+        if (TaxTreatment.entries.none { it.name == value }) {
+            throw BusinessException(
+                "Invalid taxTreatment: $value. Must be one of: " +
+                    TaxTreatment.entries.joinToString { it.name }
+            )
         }
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/TaxTreatment.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/TaxTreatment.kt
@@ -1,0 +1,22 @@
+package com.beancounter.marketdata.assets
+
+/**
+ * Tax treatment applied to a retirement/pension account's contributions and
+ * withdrawals.
+ *
+ * - TRADITIONAL: pre-tax contributions; withdrawals taxed as income
+ *   (US 401k/IRA "Traditional").
+ * - ROTH: post-tax contributions; qualified withdrawals tax-free
+ *   (US Roth 401k/IRA).
+ * - TAX_FREE: contributions and growth both tax-free (UK ISA).
+ *
+ * Kept as its own column rather than folded into [PolicyType] because policy
+ * type doesn't uniquely determine tax treatment — e.g. a US_401K can be
+ * either TRADITIONAL or ROTH. Persisted with `@Enumerated(EnumType.STRING)`,
+ * mirroring how [PolicyType] is stored on [PrivateAssetConfig].
+ */
+enum class TaxTreatment {
+    TRADITIONAL,
+    ROTH,
+    TAX_FREE
+}

--- a/svc-data/src/main/resources/db/migration/V31__add_us_uk_policy_tax_settings.sql
+++ b/svc-data/src/main/resources/db/migration/V31__add_us_uk_policy_tax_settings.sql
@@ -1,0 +1,18 @@
+-- V31: US 401k/IRA + UK ISA support (svc-retire#152 parent).
+-- Adds tax-treatment + accumulation assumption columns to private_asset_config
+-- so composite policy configs can model pre-tax/Roth/tax-free retirement
+-- accounts alongside the existing CPF/GENERIC types.
+ALTER TABLE private_asset_config
+    ADD COLUMN IF NOT EXISTS tax_treatment VARCHAR(20);
+
+ALTER TABLE private_asset_config
+    ADD COLUMN IF NOT EXISTS employee_deferral_percent DECIMAL(5,4);
+
+ALTER TABLE private_asset_config
+    ADD COLUMN IF NOT EXISTS employer_match_percent DECIMAL(5,4);
+
+ALTER TABLE private_asset_config
+    ADD COLUMN IF NOT EXISTS employer_match_cap_percent DECIMAL(5,4);
+
+ALTER TABLE private_asset_config
+    ADD COLUMN IF NOT EXISTS withdrawal_tax_rate DECIMAL(5,4);

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
@@ -921,4 +921,126 @@ class PrivateAssetConfigServiceTest {
                 .code
         ).isEqualTo("FUND-A")
     }
+
+    // ============ US 401k/IRA + UK ISA Tests ============
+
+    @Test
+    fun `saveConfig persists US_401K config with taxTreatment TRADITIONAL and employer match fields`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                policyType = PolicyType.US_401K,
+                taxTreatment = "TRADITIONAL",
+                employeeDeferralPercent = BigDecimal("0.0600"),
+                employerMatchPercent = BigDecimal("0.5000"),
+                employerMatchCapPercent = BigDecimal("0.0600"),
+                withdrawalTaxRate = BigDecimal("0.2200")
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.empty())
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.policyType).isEqualTo(PolicyType.US_401K)
+        assertThat(response.data.taxTreatment).isEqualTo(TaxTreatment.TRADITIONAL)
+        assertThat(response.data.employeeDeferralPercent).isEqualByComparingTo(BigDecimal("0.0600"))
+        assertThat(response.data.employerMatchPercent).isEqualByComparingTo(BigDecimal("0.5000"))
+        assertThat(response.data.employerMatchCapPercent).isEqualByComparingTo(BigDecimal("0.0600"))
+        assertThat(response.data.withdrawalTaxRate).isEqualByComparingTo(BigDecimal("0.2200"))
+
+        // Read back: GET reflects what was just saved.
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.of(response.data))
+        val readBack = configService.getConfig(assetId)
+
+        assertThat(readBack).isNotNull
+        assertThat(readBack!!.data.taxTreatment).isEqualTo(TaxTreatment.TRADITIONAL)
+        assertThat(readBack.data.employeeDeferralPercent).isEqualByComparingTo(BigDecimal("0.0600"))
+    }
+
+    @Test
+    fun `saveConfig persists UK_ISA config with taxTreatment TAX_FREE`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                policyType = PolicyType.UK_ISA,
+                taxTreatment = "TAX_FREE"
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.empty())
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.policyType).isEqualTo(PolicyType.UK_ISA)
+        assertThat(response.data.taxTreatment).isEqualTo(TaxTreatment.TAX_FREE)
+    }
+
+    @Test
+    fun `saveConfig rejects invalid taxTreatment`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                policyType = PolicyType.US_IRA,
+                taxTreatment = "BOGUS"
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+
+        assertThatThrownBy {
+            configService.saveConfig(assetId, request)
+        }.isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining("Invalid taxTreatment")
+    }
+
+    @Test
+    fun `saveConfig allows tax-treatment and match fields on GENERIC policy type (permissive MVP)`() {
+        val asset = createTestAsset()
+        val request =
+            PrivateAssetConfigRequest(
+                policyType = PolicyType.GENERIC,
+                taxTreatment = "ROTH",
+                employeeDeferralPercent = BigDecimal("0.10")
+            )
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.empty())
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.taxTreatment).isEqualTo(TaxTreatment.ROTH)
+        assertThat(response.data.employeeDeferralPercent).isEqualByComparingTo(BigDecimal("0.10"))
+    }
+
+    @Test
+    fun `saveConfig preserves existing taxTreatment and match fields when request omits them`() {
+        val asset = createTestAsset()
+        val existing =
+            PrivateAssetConfig(
+                assetId = assetId,
+                policyType = PolicyType.US_401K,
+                taxTreatment = TaxTreatment.TRADITIONAL,
+                employeeDeferralPercent = BigDecimal("0.0600"),
+                employerMatchPercent = BigDecimal("0.5000")
+            )
+        val request = PrivateAssetConfigRequest(payoutAge = 65)
+
+        whenever(systemUserService.getActiveUser()).thenReturn(user)
+        whenever(assetRepository.findById(assetId)).thenReturn(Optional.of(asset))
+        whenever(configRepository.findById(assetId)).thenReturn(Optional.of(existing))
+        whenever(configRepository.save(any<PrivateAssetConfig>())).thenAnswer { it.arguments[0] }
+
+        val response = configService.saveConfig(assetId, request)
+
+        assertThat(response.data.taxTreatment).isEqualTo(TaxTreatment.TRADITIONAL)
+        assertThat(response.data.employeeDeferralPercent).isEqualByComparingTo(BigDecimal("0.0600"))
+        assertThat(response.data.employerMatchPercent).isEqualByComparingTo(BigDecimal("0.5000"))
+    }
 }


### PR DESCRIPTION
Schema layer for US 401(k)/IRA + UK ISA support (monowai/svc-retire#152; tracked here as #1032 groundwork).

- `PolicyType` += `US_401K`, `US_IRA`, `UK_ISA`
- `PrivateAssetConfig` += `taxTreatment` (`TaxTreatment` enum: TRADITIONAL | ROTH | TAX_FREE), `employeeDeferralPercent`, `employerMatchPercent`, `employerMatchCapPercent`, `withdrawalTaxRate` — nullable, permissive across policy types (MVP); invalid `taxTreatment` strings rejected with `BusinessException`
- Flyway `V30__add_us_uk_policy_tax_settings.sql` (`ADD COLUMN IF NOT EXISTS`, mirrors V8 style)
- jar-contracts `CompositeValuation.supportedPolicyTypes` = `{CPF, US_401K, US_IRA, UK_ISA}` — previously any other type's sub-account balances were silently dropped from plan roll-ups
- Not in scope: an svc-position `CompositeValuation` strategy for the new types (`/positions/composite/{assetId}` still returns null data for them) — follow-up with monowai/svc-retire#153

svc-retire consumes this via `jar-common 0.1.3-SNAPSHOT` — merge republishes the snapshot; the svc-retire engine PR depends on it only for sub-account roll-up display totals, not for projection math.