### PR TITLE
fix(trns): hide auto-settle cash legs from proposed transactions view

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -217,6 +217,10 @@ interface TrnRepository :
      * those whose tradeDate is on or before [asAt]. Used for the cross-portfolio proposed-review
      * view — `asAt` defaults to today at the controller, so not-yet-due (future-dated) proposed
      * transactions stay hidden until their date arrives.
+     *
+     * Auto-settle cash legs (provider BC-AUTO) are excluded: they are derivative
+     * of their parent trade and settle in sync with it, so they are not
+     * independently actionable in the proposed/unsettled review.
      */
     @Query(
         "select t from Trn t " +
@@ -228,6 +232,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate <= ?3 " +
+            "and t.callerRef.provider <> 'BC-AUTO' " +
             "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioOwner(
@@ -244,7 +249,8 @@ interface TrnRepository :
         "select count(t) from Trn t " +
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
-            "and t.tradeDate <= ?3"
+            "and t.tradeDate <= ?3 " +
+            "and t.callerRef.provider <> 'BC-AUTO'"
     )
     fun countByStatusAndPortfolioOwner(
         status: TrnStatus,
@@ -262,6 +268,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
             "and t.tradeDate <= ?3 " +
+            "and t.callerRef.provider <> 'BC-AUTO' " +
             "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioIdIn(
@@ -274,7 +281,8 @@ interface TrnRepository :
         "select count(t) from Trn t " +
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
-            "and t.tradeDate <= ?3"
+            "and t.tradeDate <= ?3 " +
+            "and t.callerRef.provider <> 'BC-AUTO'"
     )
     fun countByStatusAndPortfolioIdIn(
         status: TrnStatus,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.marketdata.cash.CashAutoSettleService.Companion.AUTO_PROVIDER
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
@@ -232,7 +233,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate <= ?3 " +
-            "and t.callerRef.provider <> 'BC-AUTO' " +
+            "and t.callerRef.provider <> '" + AUTO_PROVIDER + "' " +
             "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioOwner(
@@ -250,7 +251,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate <= ?3 " +
-            "and t.callerRef.provider <> 'BC-AUTO'"
+            "and t.callerRef.provider <> '" + AUTO_PROVIDER + "'"
     )
     fun countByStatusAndPortfolioOwner(
         status: TrnStatus,
@@ -268,7 +269,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
             "and t.tradeDate <= ?3 " +
-            "and t.callerRef.provider <> 'BC-AUTO' " +
+            "and t.callerRef.provider <> '" + AUTO_PROVIDER + "' " +
             "order by t.tradeDate desc, t.createdAt desc"
     )
     fun findByStatusAndPortfolioIdIn(
@@ -282,7 +283,7 @@ interface TrnRepository :
             "where t.status = ?1 " +
             "and t.portfolio.id in ?2 " +
             "and t.tradeDate <= ?3 " +
-            "and t.callerRef.provider <> 'BC-AUTO'"
+            "and t.callerRef.provider <> '" + AUTO_PROVIDER + "'"
     )
     fun countByStatusAndPortfolioIdIn(
         status: TrnStatus,
@@ -309,7 +310,7 @@ interface TrnRepository :
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate >= ?3 " +
             "and t.tradeDate <= ?4 " +
-            "and t.callerRef.provider <> 'BC-AUTO' " +
+            "and t.callerRef.provider <> '" + AUTO_PROVIDER + "' " +
             "order by t.portfolio.code, t.asset.code, t.createdAt"
     )
     fun findByStatusAndPortfolioOwnerAndTradeDateBetween(
@@ -420,7 +421,7 @@ interface TrnRepository :
             "and t.trnType in (:types) " +
             "and not exists (" +
             "select 1 from Trn l " +
-            "where l.callerRef.provider = 'BC-AUTO' " +
+            "where l.callerRef.provider = '" + AUTO_PROVIDER + "' " +
             "and l.callerRef.batch = t.callerRef.callerId" +
             ")"
     )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -294,6 +294,9 @@ interface TrnRepository :
      * Find all transactions with a specific status whose tradeDate falls within the
      * inclusive [from]..[to] window, for portfolios owned by the given user. Used by
      * the cross-portfolio Transactions review page, which filters by a date range.
+     *
+     * Auto-settle cash legs (provider BC-AUTO) are excluded — they are derivative
+     * of their parent trade, so the review shows the trade, not its plumbing.
      */
     @Query(
         "select t from Trn t " +
@@ -306,6 +309,7 @@ interface TrnRepository :
             "and t.portfolio.owner = ?2 " +
             "and t.tradeDate >= ?3 " +
             "and t.tradeDate <= ?4 " +
+            "and t.callerRef.provider <> 'BC-AUTO' " +
             "order by t.portfolio.code, t.asset.code, t.createdAt"
     )
     fun findByStatusAndPortfolioOwnerAndTradeDateBetween(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
@@ -241,6 +241,66 @@ class ProposedTransactionsTest {
     }
 
     @Test
+    fun `settled transactions review excludes auto-settle cash legs`() {
+        // The settled review must also show the trade, not its auto-settle plumbing.
+        val msft = bcMvcHelper.asset(AssetRequest(msftInput))
+        val usdCash =
+            assetService
+                .handle(AssetRequest(mapOf(USD.code to AssetUtils.getCash(USD.code))))
+                .data[USD.code]!!
+        val master =
+            bcMvcHelper.portfolio(PortfolioInput("SETLEG-MASTER", "Master", currency = USD.code))
+        val invest =
+            bcMvcHelper.portfolio(
+                PortfolioInput(
+                    "SETLEG-INV",
+                    "Invest",
+                    currency = USD.code,
+                    cashPortfolioId = master.id
+                )
+            )
+
+        val buy =
+            TrnInput(
+                CallerRef(batch = "SETLEG", callerId = "setleg-parent"),
+                msft.id,
+                cashAssetId = usdCash.id,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal.ONE,
+                tradeCurrency = USD.code,
+                cashCurrency = USD.code,
+                cashAmount = BigDecimal("-100"),
+                tradeCashRate = BigDecimal.ONE,
+                tradeDate = dateUtils.getFormattedDate("2024-03-10"),
+                price = BigDecimal("100"),
+                status = TrnStatus.SETTLED
+            )
+        trnService.save(invest, TrnRequest(invest.id, listOf(buy)))
+
+        val autoLegs =
+            trnRepository.findByCallerRefProviderAndCallerRefBatch("BC-AUTO", "setleg-parent")
+        assertThat(autoLegs)
+            .hasSize(2)
+            .allSatisfy { assertThat(it.status).isEqualTo(TrnStatus.SETTLED) }
+
+        val result =
+            mockMvc
+                .perform(
+                    get("$TRNS_ROOT/settled")
+                        .param("from", "2024-03-10")
+                        .param("to", "2024-03-10")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+        val response =
+            objectMapper.readValue(result.response.contentAsString, TrnResponse::class.java)
+
+        assertThat(response.data.trns)
+            .anyMatch { it.callerRef?.callerId == "setleg-parent" && it.trnType == TrnType.BUY }
+        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == "BC-AUTO" }
+    }
+
+    @Test
     fun `should return proposed transaction count across all portfolios`() {
         // Given: A portfolio with proposed transactions
         val msft = bcMvcHelper.asset(AssetRequest(msftInput))

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
@@ -24,6 +24,7 @@ import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.assets.DefaultEnricher
 import com.beancounter.marketdata.assets.EnrichmentFactory
 import com.beancounter.marketdata.assets.figi.FigiProxy
+import com.beancounter.marketdata.cash.CashAutoSettleService.Companion.AUTO_PROVIDER
 import com.beancounter.marketdata.currency.CurrencyService
 import com.beancounter.marketdata.utils.BcMvcHelper
 import com.beancounter.marketdata.utils.RegistrationUtils
@@ -208,7 +209,7 @@ class ProposedTransactionsTest {
 
         // Guard: the two PROPOSED BC-AUTO legs really exist in the DB.
         val autoLegs =
-            trnRepository.findByCallerRefProviderAndCallerRefBatch("BC-AUTO", "autoleg-parent")
+            trnRepository.findByCallerRefProviderAndCallerRefBatch(AUTO_PROVIDER, "autoleg-parent")
         assertThat(autoLegs)
             .hasSize(2)
             .allSatisfy { assertThat(it.status).isEqualTo(TrnStatus.PROPOSED) }
@@ -226,7 +227,7 @@ class ProposedTransactionsTest {
         // Parent trade is shown; neither BC-AUTO leg is.
         assertThat(response.data.trns)
             .anyMatch { it.callerRef?.callerId == "autoleg-parent" && it.trnType == TrnType.BUY }
-        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == "BC-AUTO" }
+        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == AUTO_PROVIDER }
 
         // Count matches the filtered list (no auto legs inflating it).
         val countResult =
@@ -278,7 +279,7 @@ class ProposedTransactionsTest {
         trnService.save(invest, TrnRequest(invest.id, listOf(buy)))
 
         val autoLegs =
-            trnRepository.findByCallerRefProviderAndCallerRefBatch("BC-AUTO", "setleg-parent")
+            trnRepository.findByCallerRefProviderAndCallerRefBatch(AUTO_PROVIDER, "setleg-parent")
         assertThat(autoLegs)
             .hasSize(2)
             .allSatisfy { assertThat(it.status).isEqualTo(TrnStatus.SETTLED) }
@@ -297,7 +298,7 @@ class ProposedTransactionsTest {
 
         assertThat(response.data.trns)
             .anyMatch { it.callerRef?.callerId == "setleg-parent" && it.trnType == TrnType.BUY }
-        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == "BC-AUTO" }
+        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == AUTO_PROVIDER }
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedTransactionsTest.kt
@@ -13,12 +13,14 @@ import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.AssetUtils
 import com.beancounter.common.utils.BcJson.Companion.objectMapper
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants
 import com.beancounter.marketdata.Constants.Companion.USD
 import com.beancounter.marketdata.Constants.Companion.msftInput
 import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.assets.DefaultEnricher
 import com.beancounter.marketdata.assets.EnrichmentFactory
 import com.beancounter.marketdata.assets.figi.FigiProxy
@@ -71,6 +73,12 @@ class ProposedTransactionsTest {
 
     @Autowired
     private lateinit var trnService: TrnService
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var trnRepository: TrnRepository
 
     @Autowired
     private lateinit var enrichmentFactory: EnrichmentFactory
@@ -154,6 +162,82 @@ class ProposedTransactionsTest {
             )
         assertThat(response.data.trns).isNotEmpty
         assertThat(response.data.trns.filter { it.status == TrnStatus.PROPOSED }).hasSizeGreaterThanOrEqualTo(2)
+    }
+
+    @Test
+    fun `proposed view and count exclude auto-settle cash legs`() {
+        // A PROPOSED trade in a funded portfolio now emits PROPOSED BC-AUTO cash
+        // legs. They are derivative of the parent (settle in sync), so must NOT
+        // appear as independent items in the proposed/unsettled review.
+        val msft = bcMvcHelper.asset(AssetRequest(msftInput))
+        val usdCash =
+            assetService
+                .handle(AssetRequest(mapOf(USD.code to AssetUtils.getCash(USD.code))))
+                .data[USD.code]!!
+
+        val master =
+            bcMvcHelper.portfolio(
+                PortfolioInput("AUTOLEG-MASTER", "Master", currency = USD.code)
+            )
+        val invest =
+            bcMvcHelper.portfolio(
+                PortfolioInput(
+                    "AUTOLEG-INV",
+                    "Invest",
+                    currency = USD.code,
+                    cashPortfolioId = master.id
+                )
+            )
+
+        val buy =
+            TrnInput(
+                CallerRef(batch = "AUTOLEG", callerId = "autoleg-parent"),
+                msft.id,
+                cashAssetId = usdCash.id,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal.ONE,
+                tradeCurrency = USD.code,
+                cashCurrency = USD.code,
+                cashAmount = BigDecimal("-100"),
+                tradeCashRate = BigDecimal.ONE,
+                tradeDate = dateUtils.getFormattedDate("2024-03-10"),
+                price = BigDecimal("100"),
+                status = TrnStatus.PROPOSED
+            )
+        trnService.save(invest, TrnRequest(invest.id, listOf(buy)))
+
+        // Guard: the two PROPOSED BC-AUTO legs really exist in the DB.
+        val autoLegs =
+            trnRepository.findByCallerRefProviderAndCallerRefBatch("BC-AUTO", "autoleg-parent")
+        assertThat(autoLegs)
+            .hasSize(2)
+            .allSatisfy { assertThat(it.status).isEqualTo(TrnStatus.PROPOSED) }
+
+        val result =
+            mockMvc
+                .perform(
+                    get("$TRNS_ROOT/proposed")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+        val response =
+            objectMapper.readValue(result.response.contentAsString, TrnResponse::class.java)
+
+        // Parent trade is shown; neither BC-AUTO leg is.
+        assertThat(response.data.trns)
+            .anyMatch { it.callerRef?.callerId == "autoleg-parent" && it.trnType == TrnType.BUY }
+        assertThat(response.data.trns).noneMatch { it.callerRef?.provider == "BC-AUTO" }
+
+        // Count matches the filtered list (no auto legs inflating it).
+        val countResult =
+            mockMvc
+                .perform(
+                    get("$TRNS_ROOT/proposed/count")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt().jwt(token))
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+        val count = objectMapper.readTree(countResult.response.contentAsString).get("count").asInt()
+        assertThat(count).isEqualTo(response.data.trns.size)
     }
 
     @Test


### PR DESCRIPTION
Auto-settle cash legs (provider BC-AUTO) are derivative of their parent trade and settle in sync with it, so they shouldn't appear as independent items in the transactions review. Excludes them from the proposed list + badge count AND the settled date-range review (owner and managed scopes). `'BC-AUTO'` is referenced via the `AUTO_PROVIDER` constant.

Only the review queries are touched; per-portfolio lists, cash ladder, and holdings are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
