### PR TITLE
feat(position): earmarked cash on holdings from proposed cash legs

### DIFF
--- a/jar-client/src/main/kotlin/com/beancounter/client/services/TrnService.kt
+++ b/jar-client/src/main/kotlin/com/beancounter/client/services/TrnService.kt
@@ -58,6 +58,23 @@ class TrnService(
             ?: throw BusinessException("Failed to query portfolio transactions")
 
     /**
+     * PROPOSED cash legs (DEPOSIT / WITHDRAWAL) for a portfolio as at a date.
+     * Feeds the svc-position "earmarked cash" figure.
+     */
+    @CircuitBreaker(name = "default")
+    fun queryProposedCash(
+        portfolioId: String,
+        asAt: String = "today"
+    ): TrnResponse =
+        restClient
+            .get()
+            .uri("/trns/portfolio/{portfolioId}/proposed-cash?asAt={asAt}", portfolioId, asAt)
+            .header(HttpHeaders.AUTHORIZATION, tokenService.bearerToken)
+            .retrieve()
+            .body(TrnResponse::class.java)
+            ?: throw BusinessException("Failed to query proposed cash legs")
+
+    /**
      * Query transactions for a specific broker as of a given date.
      * Returns all transaction types needed for position building with split adjustments.
      */

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/MoneyValues.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/MoneyValues.kt
@@ -23,6 +23,12 @@ data class MoneyValues(
     var purchases: BigDecimal = BigDecimal.ZERO
     var sales: BigDecimal = BigDecimal.ZERO
     var marketValue: BigDecimal = BigDecimal.ZERO
+
+    // Cash reserved by PROPOSED (unsettled) cash legs that will move this cash
+    // asset once they settle. Signed and in the same currency/bucket as
+    // marketValue, so marketValue + earmarked = the "nominal" balance. Zero for
+    // non-cash positions.
+    var earmarked: BigDecimal = BigDecimal.ZERO
     var weight: BigDecimal = BigDecimal.ZERO
     var irr: BigDecimal = BigDecimal.ZERO
     var roi: BigDecimal = BigDecimal.ZERO

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/Position.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/Position.kt
@@ -39,6 +39,13 @@ class Position(
 
     var subAccounts: MutableMap<String, java.math.BigDecimal> = mutableMapOf()
 
+    // Signed net quantity of PROPOSED cash legs (DEPOSIT +, WITHDRAWAL −) in this
+    // cash asset's own currency. Accumulation-time scalar; MarketValue mints the
+    // per-bucket money figure (MoneyValues.earmarked) from it using the same FX
+    // rate as marketValue. @JsonIgnore — only the derived money is serialized.
+    @JsonIgnore
+    var earmarkedQuantity: java.math.BigDecimal = java.math.BigDecimal.ZERO
+
     /**
      * Per-portfolio contribution for aggregated views.
      * Empty for single-portfolio positions; populated only by the aggregated

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnController.kt
@@ -808,6 +808,19 @@ class TrnController(
     ): TrnResponse = TrnResponse(trnFinder.getCashLadder(portfolioId, cashAssetId))
 
     @GetMapping(
+        value = ["/portfolio/{portfolioId}/proposed-cash"],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(summary = "Proposed cash legs (DEPOSIT/WITHDRAWAL) for a portfolio as at a date")
+    fun findProposedCash(
+        @PathVariable portfolioId: String,
+        @RequestParam(required = false) asAt: String? = null
+    ): TrnResponse =
+        TrnResponse(
+            trnFinder.findProposedCash(portfolioId, dateUtils.getFormattedDate(asAt ?: dateUtils.today()))
+        )
+
+    @GetMapping(
         value = ["/portfolio/{portfolioId}/model/{modelId}"],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
@@ -179,6 +179,21 @@ class TrnFinder(
     }
 
     /**
+     * PROPOSED DEPOSIT / WITHDRAWAL legs for a portfolio as at a date. Resolves
+     * the portfolio for authorisation, then post-processes the legs so the
+     * consumer (svc-position earmark) sees the same shape as other finders.
+     */
+    fun findProposedCash(
+        portfolioId: String,
+        asAt: LocalDate
+    ): Collection<Trn> {
+        val portfolio = portfolioService.find(portfolioId)
+        return trnPostProcessor.postProcess(
+            trnRepository.findProposedCashLegs(portfolio.id, asAt).toList()
+        )
+    }
+
+    /**
      * Find all transactions for a portfolio that belong to a specific rebalance model.
      */
     fun findByPortfolioAndModel(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnRepository.kt
@@ -338,6 +338,28 @@ interface TrnRepository :
     ): Collection<Trn>
 
     /**
+     * PROPOSED DEPOSIT / WITHDRAWAL legs for a portfolio, bounded to those due on
+     * or before [asAt]. Feeds the "earmarked cash" figure: cash reserved by
+     * unsettled cash legs that will move a cash asset once they settle.
+     */
+    @Query(
+        "select t from Trn t " +
+            "join fetch t.asset join fetch t.tradeCurrency join fetch t.portfolio " +
+            "left join fetch t.cashAsset left join fetch t.cashCurrency " +
+            "where t.portfolio.id = ?1 " +
+            "and t.status = com.beancounter.common.model.TrnStatus.PROPOSED " +
+            "and t.trnType in (" +
+            "com.beancounter.common.model.TrnType.DEPOSIT, " +
+            "com.beancounter.common.model.TrnType.WITHDRAWAL) " +
+            "and t.tradeDate <= ?2 " +
+            "order by t.tradeDate asc, t.createdAt asc"
+    )
+    fun findProposedCashLegs(
+        portfolioId: String,
+        asAt: java.time.LocalDate
+    ): Collection<Trn>
+
+    /**
      * Find all transactions for a portfolio that belong to a specific rebalance model.
      * Used for model-level position tracking to show only quantities attributable to a model.
      */

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedCashTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ProposedCashTest.kt
@@ -1,0 +1,215 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.auth.MockAuthConfig
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.contracts.AssetRequest
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.contracts.TrnResponse
+import com.beancounter.common.input.AssetInput
+import com.beancounter.common.input.PortfolioInput
+import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.AssetUtils
+import com.beancounter.common.utils.BcJson.Companion.objectMapper
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants
+import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.NYSE
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.SpringMvcDbTest
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.assets.DefaultEnricher
+import com.beancounter.marketdata.assets.EnrichmentFactory
+import com.beancounter.marketdata.assets.figi.FigiProxy
+import com.beancounter.marketdata.utils.BcMvcHelper
+import com.beancounter.marketdata.utils.TRNS_ROOT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.math.BigDecimal
+
+/**
+ * MVC tests for GET /trns/portfolio/{id}/proposed-cash — the earmarked-cash feed.
+ * Only PROPOSED DEPOSIT/WITHDRAWAL legs due on or before asAt are returned:
+ * SETTLED legs, BUY/SELL trades and future-dated legs are excluded.
+ */
+@SpringMvcDbTest
+class ProposedCashTest {
+    private val dateUtils = DateUtils()
+
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @MockitoBean
+    private lateinit var figiProxy: FigiProxy
+
+    @MockitoBean
+    private lateinit var fxTransactions: FxTransactions
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var assetService: AssetService
+
+    @Autowired
+    private lateinit var trnService: TrnService
+
+    @Autowired
+    private lateinit var enrichmentFactory: EnrichmentFactory
+
+    @Autowired
+    private lateinit var defaultEnricher: DefaultEnricher
+
+    @Autowired
+    private lateinit var mockAuthConfig: MockAuthConfig
+
+    private lateinit var bcMvcHelper: BcMvcHelper
+
+    @BeforeEach
+    fun configure() {
+        enrichmentFactory.register(defaultEnricher)
+        bcMvcHelper = BcMvcHelper(mockMvc, mockAuthConfig.getUserToken(Constants.systemUser))
+        bcMvcHelper.registerUser()
+    }
+
+    @Test
+    fun `returns only PROPOSED deposit and withdrawal legs bounded by asAt`() {
+        val usdCash =
+            assetService
+                .handle(AssetRequest(mapOf(USD.code to AssetUtils.getCash(USD.code))))
+                .data[USD.code]!!
+        val equity =
+            assetService
+                .handle(AssetRequest(AssetInput(NYSE.code, MSFT.code), MSFT.code))
+                .data[MSFT.code]!!
+
+        val portfolio =
+            bcMvcHelper.portfolio(
+                PortfolioInput("PROPOSED-CASH", "Proposed cash", currency = USD.code)
+            )
+
+        val proposedDeposit =
+            TrnInput(
+                CallerRef(batch = "PC", callerId = "1"),
+                assetId = usdCash.id,
+                cashAssetId = usdCash.id,
+                cashCurrency = USD.code,
+                trnType = TrnType.DEPOSIT,
+                quantity = BigDecimal("300"),
+                tradeAmount = BigDecimal("300"),
+                price = BigDecimal.ONE,
+                tradeDate = dateUtils.getFormattedDate("2024-03-01"),
+                status = TrnStatus.PROPOSED
+            )
+        val proposedWithdrawal =
+            TrnInput(
+                CallerRef(batch = "PC", callerId = "2"),
+                assetId = usdCash.id,
+                cashAssetId = usdCash.id,
+                cashCurrency = USD.code,
+                trnType = TrnType.WITHDRAWAL,
+                quantity = BigDecimal("100"),
+                tradeAmount = BigDecimal("100"),
+                price = BigDecimal.ONE,
+                tradeDate = dateUtils.getFormattedDate("2024-03-02"),
+                status = TrnStatus.PROPOSED
+            )
+        val settledDeposit =
+            TrnInput(
+                CallerRef(batch = "PC", callerId = "3"),
+                assetId = usdCash.id,
+                cashAssetId = usdCash.id,
+                cashCurrency = USD.code,
+                trnType = TrnType.DEPOSIT,
+                quantity = BigDecimal("999"),
+                tradeAmount = BigDecimal("999"),
+                price = BigDecimal.ONE,
+                tradeDate = dateUtils.getFormattedDate("2024-03-03"),
+                status = TrnStatus.SETTLED
+            )
+        val proposedBuy =
+            TrnInput(
+                CallerRef(batch = "PC", callerId = "4"),
+                assetId = equity.id,
+                cashAssetId = usdCash.id,
+                cashCurrency = USD.code,
+                trnType = TrnType.BUY,
+                quantity = BigDecimal("10"),
+                price = BigDecimal("150.00"),
+                tradeAmount = BigDecimal("1500.00"),
+                tradeDate = dateUtils.getFormattedDate("2024-03-04"),
+                status = TrnStatus.PROPOSED
+            )
+        val futureDate = dateUtils.date.plusDays(8)
+        val futureDeposit =
+            TrnInput(
+                CallerRef(batch = "PC", callerId = "5"),
+                assetId = usdCash.id,
+                cashAssetId = usdCash.id,
+                cashCurrency = USD.code,
+                trnType = TrnType.DEPOSIT,
+                quantity = BigDecimal("50"),
+                tradeAmount = BigDecimal("50"),
+                price = BigDecimal.ONE,
+                tradeDate = futureDate,
+                status = TrnStatus.PROPOSED
+            )
+
+        trnService.save(
+            portfolio,
+            TrnRequest(
+                portfolio.id,
+                listOf(proposedDeposit, proposedWithdrawal, settledDeposit, proposedBuy, futureDeposit)
+            )
+        )
+
+        // Default asAt = today: only the two past PROPOSED cash legs.
+        val defaultLegs = proposedCash(portfolio.id, asAt = null)
+        assertThat(defaultLegs).hasSize(2)
+        assertThat(defaultLegs.map { it.trnType })
+            .containsExactlyInAnyOrder(TrnType.DEPOSIT, TrnType.WITHDRAWAL)
+        assertThat(defaultLegs).allSatisfy { trn ->
+            assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+        }
+
+        // asAt covering the future-dated leg includes it (3 legs).
+        val futureLegs = proposedCash(portfolio.id, asAt = futureDate.toString())
+        assertThat(futureLegs).hasSize(3)
+        assertThat(futureLegs).allSatisfy { trn ->
+            assertThat(trn.trnType).isIn(TrnType.DEPOSIT, TrnType.WITHDRAWAL)
+            assertThat(trn.status).isEqualTo(TrnStatus.PROPOSED)
+        }
+    }
+
+    private fun proposedCash(
+        portfolioId: String,
+        asAt: String?
+    ) = objectMapper
+        .readValue(
+            mockMvc
+                .perform(
+                    get("$TRNS_ROOT/portfolio/$portfolioId/proposed-cash" + (asAt?.let { "?asAt=$it" } ?: ""))
+                        .with(
+                            SecurityMockMvcRequestPostProcessors.jwt().jwt(
+                                mockAuthConfig.getUserToken(Constants.systemUser)
+                            )
+                        )
+                ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(
+                    MockMvcResultMatchers.content().contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                ).andReturn()
+                .response.contentAsString,
+            TrnResponse::class.java
+        ).data
+        .toTrns()
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/EarmarkService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/EarmarkService.kt
@@ -1,0 +1,74 @@
+package com.beancounter.position.valuation
+
+import com.beancounter.client.services.TrnService
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Positions
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.AssetKeyUtils.Companion.toKey
+import com.beancounter.common.utils.CashUtils
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+/**
+ * Stamps each cash [com.beancounter.common.model.Position] with the signed net
+ * quantity of PROPOSED DEPOSIT / WITHDRAWAL legs on that cash asset
+ * (DEPOSIT +, WITHDRAWAL −) in the cash asset's own currency.
+ *
+ * The scalar lives on [com.beancounter.common.model.Position.earmarkedQuantity];
+ * MarketValue mints the per-bucket money figure (MoneyValues.earmarked) from it
+ * using the SAME per-bucket close it uses for marketValue, so the two stay
+ * FX-consistent. Earmarked deliberately does NOT flow through CashAccumulator
+ * (that would apply trade-date rates).
+ */
+@Service
+class EarmarkService(
+    private val trnService: TrnService,
+    private val cashUtils: CashUtils = CashUtils()
+) {
+    private val log = LoggerFactory.getLogger(EarmarkService::class.java)
+
+    fun stamp(
+        portfolio: Portfolio,
+        positions: Positions,
+        asAt: String
+    ) {
+        if (!positions.hasPositions()) return
+        // Earmark is a supplementary overlay on the cash position; a failure to
+        // fetch the PROPOSED legs must never break the core valuation, so degrade
+        // to "no earmark" on any client/server error rather than propagating. The
+        // bc-data RestClient maps HTTP errors to BC RuntimeExceptions
+        // (NotFoundException etc.), so the catch is deliberately broad.
+        @Suppress("TooGenericExceptionCaught")
+        val legs =
+            try {
+                trnService.queryProposedCash(portfolio.id, asAt).data.toTrns()
+            } catch (e: RuntimeException) {
+                log.warn("Earmark skipped for {}: {}", portfolio.code, e.message)
+                return
+            }
+        if (legs.isEmpty()) return
+
+        // Signed net cash-ccy quantity per cash asset, keyed the same way
+        // positions.positions is keyed (AssetKeyUtils.toKey) so lookups hit.
+        val netByAssetKey =
+            legs
+                .groupBy { toKey(it.asset) }
+                .mapValues { (_, trns) ->
+                    trns.fold(BigDecimal.ZERO) { acc, t ->
+                        acc +
+                            if (TrnType.isCashCredited(t.trnType)) {
+                                t.quantity.abs()
+                            } else {
+                                t.quantity.abs().negate()
+                            }
+                    }
+                }
+
+        positions.positions.forEach { (key, position) ->
+            if (cashUtils.isCash(position.asset)) {
+                netByAssetKey[key]?.let { position.earmarkedQuantity = it }
+            }
+        }
+    }
+}

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
@@ -111,6 +111,15 @@ class MarketValue(
             moneyValues.unrealisedGain = BigDecimal.ZERO // moneyValues.marketValue.subtract(moneyValues.costBasis)
             moneyValues.totalGain = BigDecimal.ZERO
             // moneyValues.realisedGain.add(moneyValues.unrealisedGain) // moneyValues.marketValue
+            // Signed earmark, priced with the SAME per-bucket close as marketValue so
+            // marketValue + earmarked = nominal in the same currency. Zero-guard: MathUtils
+            // .multiply(x, ZERO) returns x (treats a zero rate as "unset"), NOT 0.
+            moneyValues.earmarked =
+                if (position.earmarkedQuantity.signum() == 0) {
+                    BigDecimal.ZERO
+                } else {
+                    multiply(moneyValues.priceData.close, position.earmarkedQuantity) ?: BigDecimal.ZERO
+                }
         } else if (mktData.asset.assetCategory.id == "POLICY" &&
             moneyValues.costBasis.signum() == 0
         ) {

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/ValuationService.kt
@@ -55,7 +55,8 @@ class ValuationService
         private val classificationClient: ClassificationClient,
         private val fxRateService: FxService,
         private val tokenService: TokenService,
-        private val dateUtils: DateUtils
+        private val dateUtils: DateUtils,
+        private val earmarkService: EarmarkService
     ) : Valuation {
         private val log = LoggerFactory.getLogger(ValuationService::class.java)
         private val averageCost = AverageCost()
@@ -116,6 +117,9 @@ class ValuationService
             ) {
                 positionResponse.data.asAt = valuationDate
             }
+            // Stamp signed earmarked cash-ccy quantity BEFORE market-value runs so
+            // MarketValue can mint MoneyValues.earmarked from it per bucket.
+            earmarkService.stamp(portfolio, positionResponse.data, valuationDate)
             return positionResponse
         }
 
@@ -179,7 +183,11 @@ class ValuationService
                     if (trns.isEmpty()) {
                         null
                     } else {
-                        portfolio to positionService.build(portfolio, PositionRequest(portfolio.id, trns)).data
+                        val built = positionService.build(portfolio, PositionRequest(portfolio.id, trns)).data
+                        // Stamp each per-portfolio Positions with ITS own portfolio's
+                        // proposed cash legs before the merge sums earmarkedQuantity.
+                        earmarkService.stamp(portfolio, built, valuationDate)
+                        portfolio to built
                     }
                 }
 
@@ -358,6 +366,7 @@ class ValuationService
             target.quantityValues.purchased = target.quantityValues.purchased.add(source.quantityValues.purchased)
             target.quantityValues.sold = target.quantityValues.sold.add(source.quantityValues.sold)
             target.quantityValues.adjustment = target.quantityValues.adjustment.add(source.quantityValues.adjustment)
+            target.earmarkedQuantity = target.earmarkedQuantity.add(source.earmarkedQuantity)
         }
 
         private fun mergeMoneyValues(

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/EarmarkServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/EarmarkServiceTest.kt
@@ -1,0 +1,155 @@
+package com.beancounter.position.valuation
+
+import com.beancounter.client.services.TrnService
+import com.beancounter.common.contracts.TrnResponse
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Positions
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
+import com.beancounter.common.utils.PortfolioUtils.Companion.getPortfolio
+import com.beancounter.position.Constants.Companion.NASDAQ
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+/**
+ * Verifies EarmarkService stamps the signed net PROPOSED cash-leg quantity onto
+ * each cash position, keyed the same way positions are keyed, and never touches
+ * non-cash positions.
+ */
+@ExtendWith(MockitoExtension::class)
+class EarmarkServiceTest {
+    @Mock
+    private lateinit var trnService: TrnService
+
+    private val portfolio: Portfolio = getPortfolio()
+
+    private fun cash(code: String): Asset =
+        getTestAsset(NASDAQ, code).apply {
+            assetCategory = AssetCategory(AssetCategory.CASH, "Cash")
+        }
+
+    private fun leg(
+        asset: Asset,
+        type: TrnType,
+        qty: BigDecimal
+    ): Trn =
+        Trn(
+            trnType = type,
+            asset = asset,
+            quantity = qty,
+            portfolio = portfolio
+        )
+
+    private fun service() = EarmarkService(trnService)
+
+    @Test
+    fun `stamps signed net of deposit and withdrawal on the cash asset`() {
+        val usd = cash("USD")
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(usd)
+
+        whenever(trnService.queryProposedCash(eq(portfolio.id), any())).thenReturn(
+            TrnResponse(
+                listOf(
+                    leg(usd, TrnType.DEPOSIT, BigDecimal("300")),
+                    leg(usd, TrnType.WITHDRAWAL, BigDecimal("100"))
+                )
+            )
+        )
+
+        service().stamp(portfolio, positions, "today")
+
+        assertThat(position.earmarkedQuantity)
+            .describedAs("DEPOSIT 300 - WITHDRAWAL 100 = net +200")
+            .isEqualByComparingTo(BigDecimal("200"))
+    }
+
+    @Test
+    fun `stamps each cash asset independently`() {
+        val usd = cash("USD")
+        val sgd = cash("SGD")
+        val positions = Positions(portfolio)
+        val usdPos = positions.getOrCreate(usd)
+        val sgdPos = positions.getOrCreate(sgd)
+
+        whenever(trnService.queryProposedCash(eq(portfolio.id), any())).thenReturn(
+            TrnResponse(
+                listOf(
+                    leg(usd, TrnType.DEPOSIT, BigDecimal("500")),
+                    leg(sgd, TrnType.WITHDRAWAL, BigDecimal("250"))
+                )
+            )
+        )
+
+        service().stamp(portfolio, positions, "today")
+
+        assertThat(usdPos.earmarkedQuantity).isEqualByComparingTo(BigDecimal("500"))
+        assertThat(sgdPos.earmarkedQuantity).isEqualByComparingTo(BigDecimal("-250"))
+    }
+
+    @Test
+    fun `never stamps a non-cash position`() {
+        val usd = cash("USD")
+        val equity = getTestAsset(NASDAQ, "ABC") // default category Equity -> not cash
+        val positions = Positions(portfolio)
+        val cashPos = positions.getOrCreate(usd)
+        val equityPos = positions.getOrCreate(equity)
+
+        whenever(trnService.queryProposedCash(eq(portfolio.id), any())).thenReturn(
+            TrnResponse(listOf(leg(usd, TrnType.DEPOSIT, BigDecimal("400"))))
+        )
+
+        service().stamp(portfolio, positions, "today")
+
+        assertThat(cashPos.earmarkedQuantity).isEqualByComparingTo(BigDecimal("400"))
+        assertThat(equityPos.earmarkedQuantity)
+            .describedAs("equity position is never earmarked")
+            .isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `no-op when there are no proposed legs`() {
+        val usd = cash("USD")
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(usd)
+
+        whenever(trnService.queryProposedCash(eq(portfolio.id), any()))
+            .thenReturn(TrnResponse(emptyList()))
+
+        service().stamp(portfolio, positions, "today")
+
+        assertThat(position.earmarkedQuantity).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `leg for an asset without a built position is ignored`() {
+        val usd = cash("USD")
+        val eur = cash("EUR") // proposed leg exists but no position built for it
+        val positions = Positions(portfolio)
+        val usdPos = positions.getOrCreate(usd)
+
+        whenever(trnService.queryProposedCash(eq(portfolio.id), any())).thenReturn(
+            TrnResponse(
+                listOf(
+                    leg(usd, TrnType.DEPOSIT, BigDecimal("100")),
+                    leg(eur, TrnType.DEPOSIT, BigDecimal("999"))
+                )
+            )
+        )
+
+        service().stamp(portfolio, positions, "today")
+
+        assertThat(usdPos.earmarkedQuantity).isEqualByComparingTo(BigDecimal("100"))
+        assertThat(positions.positions).hasSize(1) // EUR leg did not create a phantom position
+    }
+}

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
@@ -464,6 +464,105 @@ internal class MarketValueTest {
         assertThat(position.quantityValues.getTotal()).isEqualTo(hundred)
     }
 
+    private fun cashAsset(): Asset =
+        getTestAsset(NASDAQ, "USD").apply {
+            assetCategory =
+                com.beancounter.common.model
+                    .AssetCategory(com.beancounter.common.model.AssetCategory.CASH, "Cash")
+        }
+
+    /**
+     * Build a valued cash position: [settled] shares as the settled balance and
+     * [earmarkedQty] as the signed PROPOSED cash-leg quantity. Returns the
+     * position after MarketValue has run with a non-ONE PORTFOLIO fx rate.
+     */
+    private fun valuedCashPosition(
+        settled: BigDecimal,
+        earmarkedQty: BigDecimal,
+        close: BigDecimal = BigDecimal("1.00")
+    ): Pair<Position, BigDecimal> {
+        val cash = cashAsset()
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(cash)
+        position.quantityValues.purchased = settled
+        position.earmarkedQuantity = earmarkedQty
+
+        val marketData = MarketData(cash, close = close)
+        MarketValue(Gains()).value(positions, marketData, getRates(portfolio, cash, simpleRate))
+        return position to simpleRate
+    }
+
+    @Test
+    fun `cash earmarked is close times earmarkedQuantity per bucket`() {
+        val settled = BigDecimal("1000.00")
+        val earmarkedQty = BigDecimal("300.00")
+        val (position, rate) = valuedCashPosition(settled, earmarkedQty)
+
+        // TRADE and BASE share USD (rate ONE); PORTFOLIO is NZD at simpleRate.
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { bucket ->
+            val mv = position.getMoneyValues(bucket)
+            val close = mv.priceData.close
+            // earmarked minted from the SAME per-bucket close as marketValue.
+            assertThat(mv.earmarked)
+                .describedAs("earmarked == close x earmarkedQuantity for $bucket")
+                .isEqualByComparingTo(close.multiply(earmarkedQty).setScale(2))
+            // marketValue + earmarked == close x (settled + earmarkedQty) == nominal.
+            assertThat(mv.marketValue.add(mv.earmarked))
+                .describedAs("marketValue + earmarked == nominal for $bucket")
+                .isEqualByComparingTo(close.multiply(settled.add(earmarkedQty)).setScale(2))
+        }
+        // PORTFOLIO bucket applied the non-ONE rate.
+        assertThat(position.getMoneyValues(Position.In.PORTFOLIO).earmarked)
+            .isEqualByComparingTo(BigDecimal("300.00").multiply(rate))
+    }
+
+    @Test
+    fun `cash withdrawal produces negative earmarked`() {
+        val (position, _) = valuedCashPosition(BigDecimal("1000.00"), BigDecimal("-250.00"))
+        val trade = position.getMoneyValues(Position.In.TRADE)
+        assertThat(trade.earmarked)
+            .describedAs("negative earmarkedQuantity (withdrawal) yields negative earmarked")
+            .isEqualByComparingTo(BigDecimal("-250.00"))
+    }
+
+    @Test
+    fun `zero settled balance still reports earmarked from close`() {
+        val (position, _) = valuedCashPosition(BigDecimal.ZERO, BigDecimal("300.00"))
+        val trade = position.getMoneyValues(Position.In.TRADE)
+        assertThat(trade.marketValue)
+            .describedAs("zero settled balance -> zero market value")
+            .isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(trade.earmarked)
+            .describedAs("earmarked still derived from close even with zero settled balance")
+            .isEqualByComparingTo(BigDecimal("300.00"))
+    }
+
+    @Test
+    fun `non-cash position never earmarks`() {
+        val positions = Positions(portfolio)
+        val position =
+            buyBehaviour.accumulate(
+                Trn(
+                    trnType = TrnType.BUY,
+                    asset = asset,
+                    quantity = hundred,
+                    tradeAmount = twoThousand,
+                    tradePortfolioRate = simpleRate,
+                    portfolio = portfolio
+                ),
+                positions
+            )
+        // Even if a stray earmarkedQuantity is present, the non-cash branch ignores it.
+        position.earmarkedQuantity = BigDecimal("500.00")
+        val marketData = MarketData(asset, close = BigDecimal("10.00"))
+        MarketValue(Gains()).value(positions, marketData, getRates(portfolio, asset, simpleRate))
+        listOf(Position.In.TRADE, Position.In.BASE, Position.In.PORTFOLIO).forEach { bucket ->
+            assertThat(position.getMoneyValues(bucket).earmarked)
+                .describedAs("non-cash earmarked stays ZERO for $bucket")
+                .isEqualByComparingTo(BigDecimal.ZERO)
+        }
+    }
+
     private fun getRates(
         portfolio: Portfolio,
         asset: Asset,

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MergePositionsCompletenessTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MergePositionsCompletenessTest.kt
@@ -25,7 +25,8 @@ class MergePositionsCompletenessTest {
             "periodicCashFlows", // addAll
             "held", // per-broker quantities, summed by broker name
             "subAccounts", // per-sub-account balances, summed by code
-            "dateValues" // mergeDates (earliest firstTransaction/opened)
+            "dateValues", // mergeDates (earliest firstTransaction/opened)
+            "earmarkedQuantity" // signed net PROPOSED cash-leg qty, summed in mergeQuantities
         )
 
     /** Properties intentionally not merged. */

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/ValuationServiceTest.kt
@@ -81,6 +81,9 @@ class ValuationServiceTest {
     @Mock
     private lateinit var tokenService: TokenService
 
+    @Mock
+    private lateinit var earmarkService: EarmarkService
+
     @Captor
     private lateinit var portfolioCaptor: ArgumentCaptor<Portfolio>
 
@@ -113,7 +116,8 @@ class ValuationServiceTest {
                 classificationClient,
                 fxRateService,
                 tokenService,
-                dateUtils
+                dateUtils,
+                earmarkService
             )
     }
 
@@ -724,7 +728,8 @@ class ValuationServiceTest {
                 classificationClient,
                 fxRateService,
                 tokenService,
-                dateUtils
+                dateUtils,
+                earmarkService
             )
 
         val pfA = TestHelpers.createTestPortfolio("PF-A")


### PR DESCRIPTION
Adds an `earmarked` figure to cash holdings: the signed net of PROPOSED (unsettled) cash legs (DEPOSIT/WITHDRAWAL) that will move a cash asset once they settle, so the UI can show Current + Earmarked = Nominal.

**How**
- `MoneyValues.earmarked` + `Position.earmarkedQuantity` (@JsonIgnore scalar) in jar-contracts.
- svc-data: `GET /trns/portfolio/{id}/proposed-cash` returns PROPOSED DEPOSIT/WITHDRAWAL bounded by asAt.
- svc-position `EarmarkService` fetches those, stamps signed net (DEPOSIT +, WITHDRAWAL −) onto cash positions; `MarketValue` mints `earmarked = priceData.close × earmarkedQuantity` per bucket — same FX rate as marketValue, so Current + earmarked = nominal holds in every currency bucket. Non-cash = 0. Fetch is best-effort: a proposed-cash outage degrades to no earmark, never breaks valuation.

Frontend (bc-view #1090) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
