### PR TITLE
fix(trn): derive settlement account for weighted broker sell proposals

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -301,6 +301,10 @@ class TrnBrokerService(
                     price = request.price,
                     tradeAmount = tradeAmount,
                     cashAmount = tradeAmount,
+                    // Settle in the trade currency so the mapper can resolve the
+                    // broker's per-currency settlement account (getCashAsset needs
+                    // brokerId AND cashCurrency); without it the settlement is null.
+                    cashCurrency = tradeCurrencyCode,
                     status = TrnStatus.PROPOSED,
                     brokerId = brokerId,
                     tradeDate = tradeDate

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
@@ -20,6 +20,8 @@ import com.beancounter.marketdata.assets.AccountingTypeService
 import com.beancounter.marketdata.assets.AssetRepository
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccount
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.portfolio.PortfolioService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -60,6 +62,9 @@ class TrnBrokerServiceProposeTest {
 
     @Autowired
     private lateinit var trnRepository: TrnRepository
+
+    @Autowired
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
 
     @Autowired
     private lateinit var mockAuthConfig: MockAuthConfig
@@ -168,6 +173,34 @@ class TrnBrokerServiceProposeTest {
         assertThat(byPortfolio[p1.id]!!.tradeAmount).isEqualByComparingTo("500.00")
         assertThat(byPortfolio[p2.id]!!.quantity).isEqualByComparingTo("30")
         assertThat(byPortfolio[p2.id]!!.tradeAmount).isEqualByComparingTo("300.00")
+    }
+
+    @Test
+    fun `should settle proposed SELL to the broker's configured settlement account`() {
+        val user = login("propose-settlement@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-SETTLE", owner = user))
+        val p1 = portfolio("PWSET-P1")
+        val asset = asset("PWSETA1")
+        buy(p1, broker, asset, "100")
+        // Broker settles USD trades to this designated account.
+        val settlementAccount = asset("PWSET-USD-CASH")
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = settlementAccount)
+        )
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("1"),
+                    price = BigDecimal("10.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(1)
+        assertThat(trns.first().cashAssetId).isEqualTo(settlementAccount.id)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Selling from the **Brokerage** view (per-broker holdings page → `WeightedSellDialog` → `POST /trns/broker/{brokerId}/propose`) produced proposed SELLs with **no settlement account** — the Transactions view showed `--` under SETTLEMENT. Selling the same asset from a **portfolio** (the `TradeInputForm` path) resolved settlement correctly.

## Root cause

`TrnBrokerService.proposeWeighted` built each `TrnInput` with `brokerId` set but **`cashCurrency` unset**. `CashTrnServices.getCashAsset` needs **both** `brokerId` and `cashCurrency` to look up the broker's per-currency `broker_settlement_account`; with `cashCurrency` empty the broker tier was skipped and the generic fallback returned `null` → `cashAsset` null → `--`.

The `TradeInputForm` path works because the frontend sends an explicit `cashAssetId`.

## Fix

Set `cashCurrency = tradeCurrencyCode` on the proposed `TrnInput`, so the mapper resolves the broker's configured settlement account (e.g. `DBSW-USD`), matching the per-portfolio path.

## Tests

- New: `TrnBrokerServiceProposeTest.should settle proposed SELL to the broker's configured settlement account` (Red → Green).
- Full `./gradlew testAll` green; `formatKotlin` + `lintKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QxrM8N6CNm221DVaC55TN
