### PR TITLE
refactor(svc-data): extract asset/portfolio access control services

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetAccessControl.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetAccessControl.kt
@@ -1,0 +1,79 @@
+package com.beancounter.marketdata.assets
+
+import com.beancounter.common.exception.BusinessException
+import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.model.ShareStatus
+import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
+import com.beancounter.marketdata.registration.SystemUserService
+import com.beancounter.marketdata.trn.TrnRepository
+import org.springframework.stereotype.Service
+
+/**
+ * Access-control checks for user-owned (private) assets.
+ *
+ * Writes are owner-only ([verifyOwnership]). Reads additionally allow any
+ * user holding an ACTIVE portfolio share over a portfolio with transactions
+ * for the asset ([verifyReadAccess]) — this is what lets a shared-plan
+ * viewer resolve pension/policy configs without owning the asset.
+ */
+@Service
+class AssetAccessControl(
+    private val assetRepository: AssetRepository,
+    private val systemUserService: SystemUserService,
+    private val trnRepository: TrnRepository,
+    private val portfolioShareRepository: PortfolioShareRepository
+) {
+    /**
+     * Verify the current user owns the specified asset.
+     */
+    fun verifyOwnership(assetId: String) {
+        val user = activeUser()
+        val asset = findAsset(assetId)
+        if (asset.systemUser?.id != user.id) {
+            throw BusinessException("Asset not owned by current user")
+        }
+    }
+
+    /**
+     * Read-only counterpart to [verifyOwnership]. Allows the asset owner OR
+     * any user with an ACTIVE portfolio share covering a portfolio that holds
+     * transactions for this asset. Write paths must still call
+     * [verifyOwnership].
+     */
+    fun verifyReadAccess(assetId: String) {
+        val user = activeUser()
+        val asset = findAsset(assetId)
+        if (asset.systemUser?.id == user.id) return
+        if (hasSharedPortfolioReadAccess(assetId, user)) return
+        throw BusinessException("Asset not accessible to current user")
+    }
+
+    private fun activeUser(): SystemUser =
+        systemUserService.getActiveUser()
+            ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
+
+    private fun findAsset(assetId: String) =
+        assetRepository.findById(assetId).orElseThrow {
+            NotFoundException("Asset not found: $assetId")
+        }
+
+    private fun hasSharedPortfolioReadAccess(
+        assetId: String,
+        user: SystemUser
+    ): Boolean {
+        val sharedPortfolioIds =
+            portfolioShareRepository
+                .findBySharedWithAndStatus(
+                    user,
+                    ShareStatus.ACTIVE
+                ).mapNotNull { it.portfolio?.id }
+                .toSet()
+        if (sharedPortfolioIds.isEmpty()) return false
+        val assetIdsInSharedPortfolios =
+            trnRepository
+                .findDistinctAssetIdsByPortfolioIds(sharedPortfolioIds)
+                .toSet()
+        return assetId in assetIdsInSharedPortfolios
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -3,9 +3,6 @@ package com.beancounter.marketdata.assets
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.ForbiddenException
 import com.beancounter.common.exception.NotFoundException
-import com.beancounter.common.model.ShareStatus
-import com.beancounter.common.model.SystemUser
-import com.beancounter.marketdata.portfolio.PortfolioShareRepository
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
 import jakarta.transaction.Transactional
@@ -17,8 +14,8 @@ import java.time.LocalDate
 /**
  * Service for managing private asset configurations.
  *
- * Handles CRUD operations for asset-level income/expense settings,
- * ensuring users can only access configs for assets they own.
+ * Handles CRUD operations for asset-level income/expense settings.
+ * Ownership and shared-read checks are delegated to [AssetAccessControl].
  */
 @Service
 @Transactional
@@ -27,7 +24,7 @@ class PrivateAssetConfigService(
     private val assetRepository: AssetRepository,
     private val systemUserService: SystemUserService,
     private val trnRepository: TrnRepository,
-    private val portfolioShareRepository: PortfolioShareRepository
+    private val accessControl: AssetAccessControl
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -83,10 +80,10 @@ class PrivateAssetConfigService(
      *
      * Read access is allowed for either the asset owner OR a viewer of any
      * portfolio that holds transactions for the asset (active share). Writes
-     * remain owner-only via [verifyAssetOwnership].
+     * remain owner-only via [AssetAccessControl.verifyOwnership].
      */
     fun getConfig(assetId: String): PrivateAssetConfigResponse? {
-        verifyAssetReadAccess(assetId)
+        accessControl.verifyReadAccess(assetId)
         val config = configRepository.findById(assetId).orElse(null) ?: return null
         return PrivateAssetConfigResponse(config)
     }
@@ -98,7 +95,7 @@ class PrivateAssetConfigService(
         assetId: String,
         request: PrivateAssetConfigRequest
     ): PrivateAssetConfigResponse {
-        verifyAssetOwnership(assetId)
+        accessControl.verifyOwnership(assetId)
         logSaveRequest(assetId, request)
         validateSubAccountCodes(request.subAccounts)
         validateTaxTreatment(request)
@@ -379,7 +376,7 @@ class PrivateAssetConfigService(
      * Delete config for an asset.
      */
     fun deleteConfig(assetId: String) {
-        verifyAssetOwnership(assetId)
+        accessControl.verifyOwnership(assetId)
         if (!configRepository.existsById(assetId)) {
             throw NotFoundException("Config not found for asset: $assetId")
         }
@@ -393,63 +390,5 @@ class PrivateAssetConfigService(
     fun getConfigsForAssets(assetIds: Collection<String>): PrivateAssetConfigsResponse {
         val configs = configRepository.findByAssetIdIn(assetIds)
         return PrivateAssetConfigsResponse(configs)
-    }
-
-    /**
-     * Verify the current user owns the specified asset.
-     */
-    private fun verifyAssetOwnership(assetId: String) {
-        val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
-
-        val asset =
-            assetRepository.findById(assetId).orElseThrow {
-                NotFoundException("Asset not found: $assetId")
-            }
-
-        if (asset.systemUser?.id != user.id) {
-            throw BusinessException("Asset not owned by current user")
-        }
-    }
-
-    /**
-     * Read-only counterpart to [verifyAssetOwnership]. Allows the asset
-     * owner OR any user with an ACTIVE portfolio share covering a portfolio
-     * that holds transactions for this asset. Write paths must still call
-     * [verifyAssetOwnership].
-     */
-    private fun verifyAssetReadAccess(assetId: String) {
-        val user =
-            systemUserService.getActiveUser()
-                ?: throw BusinessException(SystemUserService.USER_NOT_AUTHENTICATED)
-
-        val asset =
-            assetRepository.findById(assetId).orElseThrow {
-                NotFoundException("Asset not found: $assetId")
-            }
-
-        if (asset.systemUser?.id == user.id) return
-        if (hasSharedPortfolioReadAccess(assetId, user)) return
-        throw BusinessException("Asset not accessible to current user")
-    }
-
-    private fun hasSharedPortfolioReadAccess(
-        assetId: String,
-        user: SystemUser
-    ): Boolean {
-        val sharedPortfolioIds =
-            portfolioShareRepository
-                .findBySharedWithAndStatus(
-                    user,
-                    ShareStatus.ACTIVE
-                ).mapNotNull { it.portfolio?.id }
-                .toSet()
-        if (sharedPortfolioIds.isEmpty()) return false
-        val assetIdsInSharedPortfolios =
-            trnRepository
-                .findDistinctAssetIdsByPortfolioIds(sharedPortfolioIds)
-                .toSet()
-        return assetId in assetIdsInSharedPortfolios
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioAccessControl.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioAccessControl.kt
@@ -1,0 +1,38 @@
+package com.beancounter.marketdata.portfolio
+
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.ShareStatus
+import com.beancounter.common.model.SystemUser
+import com.beancounter.marketdata.registration.SystemUserService
+import org.springframework.stereotype.Service
+
+/**
+ * Access-control checks for portfolios.
+ *
+ * A portfolio is viewable by the SYSTEM account, its owner, or any user
+ * holding an ACTIVE [com.beancounter.common.model.PortfolioShare] over it.
+ * Write paths remain owner-scoped via the owning services.
+ */
+@Service
+class PortfolioAccessControl(
+    private val systemUserService: SystemUserService,
+    private val portfolioShareRepository: PortfolioShareRepository
+) {
+    fun canView(portfolio: Portfolio): Boolean =
+        isViewable(
+            systemUserService.getOrThrow(),
+            portfolio
+        )
+
+    fun isViewable(
+        systemUser: SystemUser,
+        portfolio: Portfolio
+    ): Boolean {
+        if (systemUser.id == AuthConstants.SYSTEM || portfolio.owner.id == systemUser.id) {
+            return true
+        }
+        val share = portfolioShareRepository.findByPortfolioAndSharedWith(portfolio, systemUser)
+        return share.isPresent && share.get().status == ShareStatus.ACTIVE
+    }
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/portfolio/PortfolioService.kt
@@ -6,8 +6,6 @@ import com.beancounter.common.exception.ForbiddenException
 import com.beancounter.common.exception.NotFoundException
 import com.beancounter.common.input.PortfolioInput
 import com.beancounter.common.model.Portfolio
-import com.beancounter.common.model.ShareStatus
-import com.beancounter.common.model.SystemUser
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
@@ -23,14 +21,13 @@ import java.util.function.Consumer
  */
 @Service
 @Transactional
-@Suppress("TooManyFunctions") // PortfolioService has 12 functions, threshold is 11
 class PortfolioService(
     private val portfolioInputAdapter: PortfolioInputAdapter,
     private val portfolioRepository: PortfolioRepository,
     private val trnRepository: TrnRepository,
     private val systemUserService: SystemUserService,
     private val dateUtils: DateUtils,
-    private val portfolioShareRepository: PortfolioShareRepository
+    private val accessControl: PortfolioAccessControl
 ) {
     fun save(portfolios: Collection<PortfolioInput>): Collection<Portfolio> {
         val owner = systemUserService.getOrThrow()
@@ -43,25 +40,6 @@ class PortfolioService(
                 )
             ).forEach(Consumer { e: Portfolio -> results.add(e) })
         return results
-    }
-
-    fun canView(portfolio: Portfolio): Boolean {
-        val systemUser = systemUserService.getOrThrow()
-        return isViewable(
-            systemUser,
-            portfolio
-        )
-    }
-
-    fun isViewable(
-        systemUser: SystemUser,
-        portfolio: Portfolio
-    ): Boolean {
-        if (systemUser.id == AuthConstants.SYSTEM || portfolio.owner.id == systemUser.id) {
-            return true
-        }
-        val share = portfolioShareRepository.findByPortfolioAndSharedWith(portfolio, systemUser)
-        return share.isPresent && share.get().status == ShareStatus.ACTIVE
     }
 
     /**
@@ -135,7 +113,7 @@ class PortfolioService(
             found.orElseThrow {
                 NotFoundException("Portfolio not found: $id")
             }
-        if (canView(portfolio)) {
+        if (accessControl.canView(portfolio)) {
             return portfolio
         }
         throw NotFoundException("Portfolio not found: $id")
@@ -160,7 +138,7 @@ class PortfolioService(
             found.orElseThrow {
                 NotFoundException("Portfolio not found: $code")
             }
-        if (canView(portfolio)) {
+        if (accessControl.canView(portfolio)) {
             return portfolio
         }
         throw NotFoundException("Portfolio not found: $code")
@@ -216,7 +194,7 @@ class PortfolioService(
     ): PortfoliosResponse {
         val all = findWhereHeld(assetId, tradeDate).data
         val systemUser = systemUserService.getOrThrow()
-        val viewable = all.filter { isViewable(systemUser, it) }
+        val viewable = all.filter { accessControl.isViewable(systemUser, it) }
         log.trace(
             "Filtered {} -> {} viewable holders for assetId: {} on behalf of {}",
             all.size,

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnPostProcessor.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnPostProcessor.kt
@@ -1,7 +1,7 @@
 package com.beancounter.marketdata.trn
 
 import com.beancounter.common.model.Trn
-import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.portfolio.PortfolioAccessControl
 import com.beancounter.marketdata.registration.SystemUserService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -23,7 +23,7 @@ class TrnPostProcessor(
     private val trnRepository: TrnRepository,
     private val balanceContributionStamper: BalanceContributionStamper,
     private val systemUserService: SystemUserService,
-    private val portfolioService: PortfolioService
+    private val portfolioAccessControl: PortfolioAccessControl
 ) {
     private val log = LoggerFactory.getLogger(TrnPostProcessor::class.java)
 
@@ -51,7 +51,7 @@ class TrnPostProcessor(
             val systemUser = systemUserService.getOrThrow()
             val filteredTrns =
                 trns.filter {
-                    portfolioService.isViewable(systemUser, it.portfolio)
+                    portfolioAccessControl.isViewable(systemUser, it.portfolio)
                 }
             return postProcess(filteredTrns)
         } else {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -10,6 +10,7 @@ import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Trn
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.cash.CashAutoSettleService
+import com.beancounter.marketdata.portfolio.PortfolioAccessControl
 import com.beancounter.marketdata.portfolio.PortfolioService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -31,6 +32,7 @@ class TrnService(
     private val trnRepository: TrnRepository,
     private val trnInputMapper: TrnInputMapper,
     private val portfolioService: PortfolioService,
+    private val portfolioAccessControl: PortfolioAccessControl,
     private val cacheInvalidationProducer: CacheInvalidationProducer,
     private val cashAutoSettleService: CashAutoSettleService,
     private val trnFinder: TrnFinder
@@ -120,7 +122,7 @@ class TrnService(
     fun delete(trnId: String): Collection<String> {
         val result = trnRepository.getOrThrow(trnId)
         val deleted = mutableListOf<Trn>()
-        if (portfolioService.canView(result.portfolio)) {
+        if (portfolioAccessControl.canView(result.portfolio)) {
             trnRepository.delete(result)
             deleted.add(result)
             cacheInvalidationProducer.sendTransactionEvent(result.portfolio.id, result.tradeDate)
@@ -135,7 +137,7 @@ class TrnService(
      */
     fun deleteWithSiblings(trnId: String): TrnDeleteResponse {
         val parent = trnRepository.getOrThrow(trnId)
-        if (!portfolioService.canView(parent.portfolio)) {
+        if (!portfolioAccessControl.canView(parent.portfolio)) {
             // Match unsettle / delete-existing behaviour — surface as 404
             // rather than a silent empty success.
             throw NotFoundException("Transaction not found: $trnId")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnSettlementService.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.cash.CashAutoSettleService
+import com.beancounter.marketdata.portfolio.PortfolioAccessControl
 import com.beancounter.marketdata.portfolio.PortfolioService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -34,6 +35,7 @@ class TrnSettlementService(
     private val fxTransactions: FxTransactions,
     private val cashAutoSettleService: CashAutoSettleService,
     private val portfolioService: PortfolioService,
+    private val portfolioAccessControl: PortfolioAccessControl,
     private val cacheInvalidationProducer: CacheInvalidationProducer,
     private val dateUtils: DateUtils,
     private val trnPostProcessor: TrnPostProcessor
@@ -97,7 +99,7 @@ class TrnSettlementService(
      */
     fun unsettle(trnId: String): TrnStatusUpdateResponse {
         val parent = trnRepository.getOrThrow(trnId)
-        if (!portfolioService.canView(parent.portfolio)) {
+        if (!portfolioAccessControl.canView(parent.portfolio)) {
             throw NotFoundException("Transaction not found: $trnId")
         }
         require(parent.status == TrnStatus.SETTLED) {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigServiceTest.kt
@@ -51,7 +51,12 @@ class PrivateAssetConfigServiceTest {
                 assetRepository,
                 systemUserService,
                 trnRepository,
-                portfolioShareRepository
+                AssetAccessControl(
+                    assetRepository,
+                    systemUserService,
+                    trnRepository,
+                    portfolioShareRepository
+                )
             )
     }
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettleTest.kt
@@ -75,6 +75,7 @@ class TrnSettleTest {
                 fxTransactions = fxTransactions,
                 cashAutoSettleService = cashAutoSettleService,
                 portfolioService = portfolioService,
+                portfolioAccessControl = mock(),
                 cacheInvalidationProducer = cacheInvalidationProducer,
                 dateUtils = dateUtils,
                 trnPostProcessor = trnPostProcessor

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnSettlementServiceTest.kt
@@ -49,6 +49,7 @@ class TrnSettlementServiceTest {
                 org.mockito.kotlin.mock(),
                 org.mockito.kotlin.mock(),
                 org.mockito.kotlin.mock(),
+                org.mockito.kotlin.mock(),
                 org.mockito.kotlin.mock()
             )
     }


### PR DESCRIPTION
Extracts sharing/access-control logic out of two bulky services into dedicated collaborators, no behavior change.

- New `AssetAccessControl`: owner-only write check (`verifyOwnership`) and shared-portfolio read check (`verifyReadAccess`) previously private in `PrivateAssetConfigService`. Service is now pure CRUD and drops its `PortfolioShareRepository` dependency.
- New `PortfolioAccessControl`: `canView` / `isViewable` (SYSTEM / owner / ACTIVE share) moved out of `PortfolioService`, which drops `@Suppress("TooManyFunctions")`.
- Callers rewired: `TrnPostProcessor` swaps `PortfolioService` for `PortfolioAccessControl`; `TrnService` and `TrnSettlementService` inject it alongside `PortfolioService`.
- Tests updated for new constructors; all sharing-path tests unchanged.

Gates: `:svc-data:test`, `:svc-data:contractTest`, `formatKotlin`, `lintKotlin` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
