### PR TITLE
fix(trn): default broker settlement currency; warn on skipped auto-settle

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
@@ -32,10 +32,14 @@ import java.time.LocalDate
  *           uses this to find and prompt the user to remove the cash legs.
  *
  * Skip conditions (no transactions emitted; warnings may be returned):
- *   - non-trigger trnType
- *   - cashAsset null or cashAmount == 0
- *   - no funding portfolio resolved
- *   - master == trade.portfolio
+ *   - non-trigger trnType — silent, no warning (auto-settle is opt-in via
+ *     funding portfolio, this isn't a settlement-eligible type)
+ *   - no funding portfolio resolved, or master == trade.portfolio — silent,
+ *     no warning (auto-settle simply isn't configured for this trade)
+ *   - cashAsset null or cashAmount == 0, evaluated AFTER a funding portfolio
+ *     is confirmed — returns a warning, since the user opted into central
+ *     funding but the trade can't be settled (e.g. #1040: brokerId set but
+ *     no settlement account/currency resolved a cash asset)
  *
  * Leg status mirrors the parent trade: a PROPOSED trade emits PROPOSED legs
  * (no settled cash impact), a SETTLED trade emits SETTLED legs.
@@ -59,14 +63,33 @@ class CashAutoSettleService(
 
     fun emitCompensatingTransfer(trade: Trn): AutoSettleResult {
         if (trade.trnType !in triggerTypes) return AutoSettleResult()
-        val cashAsset = trade.cashAsset ?: return AutoSettleResult()
-        if (trade.cashAmount.signum() == 0) return AutoSettleResult()
 
         val masterId =
             trade.portfolio.cashPortfolioId
                 ?: trade.portfolio.owner.cashPortfolioId
                 ?: return AutoSettleResult()
         if (masterId == trade.portfolio.id) return AutoSettleResult()
+
+        // A funding portfolio IS configured, so from here on a skip is
+        // surfaced as a warning rather than silently swallowed — the user
+        // opted into central funding and the trade wasn't settled (#1040).
+        val cashAsset =
+            trade.cashAsset ?: return AutoSettleResult(
+                warnings =
+                    listOf(
+                        "Trade ${trade.id} (${trade.trnType} ${trade.asset.code}) has no " +
+                            "settlement account; cash auto-settle skipped"
+                    )
+            )
+        if (trade.cashAmount.signum() == 0) {
+            return AutoSettleResult(
+                warnings =
+                    listOf(
+                        "Trade ${trade.id} (${trade.trnType} ${trade.asset.code}) has " +
+                            "zero cash amount; cash auto-settle skipped"
+                    )
+            )
+        }
 
         // findOrNull (not find) — stream-consumer threads have no JWT, and
         // `find` calls `canView` which throws via `systemUserService.getOrThrow()`.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnInputMapper.kt
@@ -53,12 +53,35 @@ class TrnInputMapper(
         )
 
         val broker = getBroker(trnInput, existing)
+        val asset = getAsset(trnInput, existing)
+
+        // A broker was supplied but no explicit settlement account/currency —
+        // default the settlement currency to the trade currency so
+        // CashTrnServices.getCashAsset can resolve the broker's per-currency
+        // settlement account. Without this, brokerId-only SELL/BUY/etc saves
+        // resolve cashAsset = null and CashAutoSettleService silently skips
+        // the compensating transfer (#1040). FX_BUY is excluded — its cash
+        // leg currency is the SOLD currency, not the trade (bought) currency,
+        // so defaulting here would corrupt it.
+        val effectiveCashCurrency =
+            if (trnInput.cashCurrency.isNullOrEmpty() &&
+                trnInput.cashAssetId.isNullOrEmpty() &&
+                broker != null &&
+                TrnType.isCashImpacted(trnInput.trnType) &&
+                !TrnType.isCash(trnInput.trnType) &&
+                trnInput.trnType != TrnType.FX_BUY
+            ) {
+                resolveTradeCurrency(asset, trnInput.tradeCurrency).code
+            } else {
+                trnInput.cashCurrency
+            }
+
         // Preserve existing cashAsset if no new one is provided (similar to broker handling)
         val cashAsset =
             cashTrnServices.getCashAsset(
                 trnInput.trnType,
                 trnInput.cashAssetId,
-                trnInput.cashCurrency,
+                effectiveCashCurrency,
                 portfolio.owner.id,
                 broker?.id
             ) ?: existing?.cashAsset
@@ -102,7 +125,6 @@ class TrnInputMapper(
                 trnInput,
                 tradeAmount
             )
-        val asset = getAsset(trnInput, existing)
         val tradeCurrency = resolveTradeCurrency(asset, trnInput.tradeCurrency)
         return Trn(
             id = existing?.id ?: keyGenUtils.id,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.AccountingType
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetCategory
+import com.beancounter.common.model.Broker
 import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.Trn
@@ -20,9 +21,11 @@ import com.beancounter.marketdata.Constants.Companion.MSFT
 import com.beancounter.marketdata.Constants.Companion.NZD
 import com.beancounter.marketdata.Constants.Companion.SGD
 import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.Constants.Companion.systemUser
 import com.beancounter.marketdata.Constants.Companion.usdCashBalance
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.broker.BrokerSettlementAccount
 import com.beancounter.marketdata.currency.CurrencyService
 import com.beancounter.marketdata.markets.MarketConfig
 import com.beancounter.marketdata.portfolio.PortfolioService
@@ -38,6 +41,7 @@ import java.math.BigDecimal.ONE
 import java.math.BigDecimal.TEN
 import java.math.BigDecimal.ZERO
 import java.util.Locale
+import java.util.Optional
 
 /**
  * TRN Adapter tests.
@@ -447,5 +451,99 @@ internal class TrnInputMapperTest {
         assertThat(trnResponse).hasSize(1)
         assertThat(trnResponse.first())
             .hasFieldOrPropertyWithValue("tradeCurrency", SGD)
+    }
+
+    @Test
+    fun `should default settlement to broker account when cash currency omitted`() {
+        // #1040: a SELL saved with brokerId but no cashCurrency/cashAssetId used to
+        // resolve cashAsset = null (CashTrnServices.getCashAsset needs BOTH brokerId
+        // AND cashCurrency for the broker settlement-account tier) — silently
+        // dropping the compensating auto-settle transfer. The mapper must default
+        // the settlement currency to the trade currency so the broker's configured
+        // per-currency account is found.
+        val broker = Broker(id = "broker-1", name = "IBKR", owner = systemUser)
+        Mockito
+            .`when`(brokerRepository.findById(broker.id))
+            .thenReturn(Optional.of(broker))
+        Mockito
+            .`when`(
+                brokerSettlementAccountRepository.findByBrokerIdAndCurrencyCode(
+                    broker.id,
+                    USD.code
+                )
+            ).thenReturn(
+                BrokerSettlementAccount(
+                    broker = broker,
+                    currencyCode = USD.code,
+                    account = usdCashBalance
+                )
+            )
+
+        val trnInput =
+            TrnInput(
+                CallerRef(
+                    portfolioId.uppercase(Locale.getDefault()),
+                    one,
+                    one
+                ),
+                assetId = asset.id, // MSFT, market currency USD
+                trnType = TrnType.SELL,
+                brokerId = broker.id,
+                quantity = TEN,
+                price = price,
+                tradeBaseRate = ONE,
+                tradeCashRate = ONE,
+                tradePortfolioRate = ONE
+            )
+
+        val trnResponse =
+            trnInputMapper.convert(
+                portfolioService.find(portfolioId),
+                TrnRequest(portfolioId, listOf(trnInput))
+            )
+
+        assertThat(trnResponse).hasSize(1)
+        assertThat(trnResponse.first())
+            .hasFieldOrPropertyWithValue("cashAsset.id", usdCashBalance.id)
+            .hasFieldOrPropertyWithValue("cashCurrency", USD)
+    }
+
+    @Test
+    fun `should not default cash currency for FX_BUY`() {
+        // FX_BUY's cash leg currency is the SOLD currency, not the trade (bought)
+        // currency — defaulting to trade currency here would corrupt it. When no
+        // cashCurrency/cashAssetId is supplied, FX_BUY must keep today's behaviour:
+        // no broker settlement-account tier is consulted, cashAsset stays null.
+        val broker = Broker(id = "broker-fx", name = "FX-BROKER", owner = systemUser)
+        Mockito
+            .`when`(brokerRepository.findById(broker.id))
+            .thenReturn(Optional.of(broker))
+
+        val trnInput =
+            TrnInput(
+                CallerRef(
+                    portfolioId.uppercase(Locale.getDefault()),
+                    one,
+                    one
+                ),
+                assetId = asset.id,
+                trnType = TrnType.FX_BUY,
+                brokerId = broker.id,
+                quantity = TEN,
+                price = price,
+                tradeBaseRate = ONE,
+                tradeCashRate = ONE,
+                tradePortfolioRate = ONE
+            )
+
+        val trnResponse =
+            trnInputMapper.convert(
+                portfolioService.find(portfolioId),
+                TrnRequest(portfolioId, listOf(trnInput))
+            )
+
+        assertThat(trnResponse).hasSize(1)
+        assertThat(trnResponse.first().cashAsset).isNull()
+        assertThat(trnResponse.first().cashCurrency).isNull()
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashAutoSettleServiceTest.kt
@@ -13,6 +13,8 @@ import com.beancounter.common.input.AssetInput
 import com.beancounter.common.input.PortfolioInput
 import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Broker
+import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.SystemUser
@@ -24,6 +26,9 @@ import com.beancounter.marketdata.Constants
 import com.beancounter.marketdata.SpringMvcDbTest
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.assets.figi.FigiProxy
+import com.beancounter.marketdata.broker.BrokerRepository
+import com.beancounter.marketdata.broker.BrokerSettlementAccount
+import com.beancounter.marketdata.broker.BrokerSettlementAccountRepository
 import com.beancounter.marketdata.cash.AutoSettleBackfill
 import com.beancounter.marketdata.cash.CashAutoSettleService
 import com.beancounter.marketdata.fx.FxRateService
@@ -90,6 +95,12 @@ class CashAutoSettleServiceTest {
 
     @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var brokerRepository: BrokerRepository
+
+    @Autowired
+    private lateinit var brokerSettlementAccountRepository: BrokerSettlementAccountRepository
 
     private lateinit var bcMvcHelper: BcMvcHelper
     private lateinit var testUser: SystemUser
@@ -282,6 +293,122 @@ class CashAutoSettleServiceTest {
             )
         val deposit = deposits.single()
         assertThat(findAutoSiblings(deposit)).isEmpty()
+    }
+
+    @Test
+    fun `should warn when funding portfolio configured but trade has no settlement account`() {
+        // #1040: a SELL saved with brokerId but no settlement account resolved
+        // ends up with cashAsset = null. Once a funding portfolio IS configured
+        // (invest.cashPortfolioId == master.id), that must surface as a warning
+        // rather than silently dropping the compensating transfer.
+        val trade =
+            Trn(
+                trnType = TrnType.SELL,
+                asset = aaplAsset,
+                quantity = BigDecimal("5"),
+                portfolio = invest,
+                cashAsset = null,
+                cashAmount = BigDecimal("1100"),
+                callerRef = CallerRef(callerId = "no-settlement-1")
+            )
+
+        val result = autoSettleService.emitCompensatingTransfer(trade)
+
+        assertThat(result.transactions).isEmpty()
+        assertThat(result.warnings).hasSize(1)
+        assertThat(result.warnings.first()).contains("no settlement account")
+    }
+
+    @Test
+    fun `should warn when funding portfolio configured but cash amount is zero`() {
+        val trade =
+            Trn(
+                trnType = TrnType.SELL,
+                asset = aaplAsset,
+                quantity = BigDecimal("5"),
+                portfolio = invest,
+                cashAsset = usdCashAsset,
+                cashAmount = BigDecimal.ZERO,
+                callerRef = CallerRef(callerId = "zero-cash-1")
+            )
+
+        val result = autoSettleService.emitCompensatingTransfer(trade)
+
+        assertThat(result.transactions).isEmpty()
+        assertThat(result.warnings).hasSize(1)
+        assertThat(result.warnings.first()).contains("zero cash amount")
+    }
+
+    @Test
+    fun `should stay silent when no funding portfolio is linked`() {
+        // master has no cashPortfolioId, and testUser (its owner) has no
+        // account-wide cashPortfolioId either — auto-settle was never opted
+        // into, so a trade with no settlement account must not generate
+        // warning noise for users who never linked a funding portfolio.
+        val trade =
+            Trn(
+                trnType = TrnType.SELL,
+                asset = aaplAsset,
+                quantity = BigDecimal("5"),
+                portfolio = master,
+                cashAsset = null,
+                cashAmount = BigDecimal("1100"),
+                callerRef = CallerRef(callerId = "no-funding-1")
+            )
+
+        val result = autoSettleService.emitCompensatingTransfer(trade)
+
+        assertThat(result.transactions).isEmpty()
+        assertThat(result.warnings).isEmpty()
+    }
+
+    @Test
+    fun `SELL with only brokerId settles to broker's account and auto-settle posts the compensating pair`() {
+        // #1040 end-to-end: production bug was brokerId set, cashCurrency/
+        // cashAssetId omitted -> cashAsset resolved null -> auto-settle silently
+        // skipped. TrnInputMapper now defaults the settlement currency to the
+        // trade currency so the broker's configured account is found, and
+        // CashAutoSettleService posts the compensating pair for it.
+        mockAuthConfig.login(testUser, systemUserService)
+        val broker = brokerRepository.save(Broker(name = "IBKR-1040", owner = testUser))
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = "USD", account = usdCashAsset)
+        )
+
+        val sells =
+            trnService.save(
+                invest,
+                TrnRequest(
+                    invest.id,
+                    listOf(
+                        TrnInput(
+                            assetId = aaplAsset.id,
+                            brokerId = broker.id,
+                            trnType = TrnType.SELL,
+                            quantity = BigDecimal("5"),
+                            price = BigDecimal("220"),
+                            tradeAmount = BigDecimal("1100"),
+                            cashAmount = BigDecimal("1100"),
+                            tradeCashRate = BigDecimal.ONE,
+                            tradeDate = LocalDate.now(),
+                            status = TrnStatus.SETTLED
+                        )
+                    )
+                )
+            )
+
+        val sell = sells.single()
+        assertThat(sell.cashAsset?.id).isEqualTo(usdCashAsset.id)
+        assertThat(sell.cashCurrency).isEqualTo(Constants.USD)
+
+        val siblings = findAutoSiblings(sell)
+        assertThat(siblings).hasSize(2)
+        val withdrawal = siblings.single { it.trnType == TrnType.WITHDRAWAL }
+        val deposit = siblings.single { it.trnType == TrnType.DEPOSIT }
+        assertThat(withdrawal.portfolio.id).isEqualTo(invest.id)
+        assertThat(deposit.portfolio.id).isEqualTo(master.id)
+        assertThat(withdrawal.tradeAmount).isEqualByComparingTo("1100")
+        assertThat(deposit.tradeAmount).isEqualByComparingTo("1100")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix silent auto-settle skips on broker-only trades (#1040). Broker trades without explicit cashCurrency/cashAssetId now default settlement currency to trade currency; logging added when auto-settle is skipped due to missing funding portfolio or zero cash amount.

## Changes

- **TrnInputMapper**: Default settlement currency to trade currency when a broker is set and no cashCurrency/cashAssetId supplied (FX_BUY excluded per existing policy)
- **CashAutoSettleService**: Log warning instead of silently skipping when a funding portfolio is configured but cashAsset is null or cashAmount is zero

## Test Plan

- [x] TrnInputMapperTest: broker settlement defaults validate trade currency used
- [x] CashAutoSettleServiceTest: warning logged on skip; silent when no funding portfolio
- [x] Gradle testAll passes
