### PR TITLE
refactor(trn): single cash-leg factory; drop dead delete; lean on mapper settlement default

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
@@ -1,7 +1,6 @@
 package com.beancounter.marketdata.cash
 
 import com.beancounter.common.contracts.TrnRequest
-import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
@@ -10,6 +9,7 @@ import com.beancounter.common.utils.KeyGenUtils
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.trn.TrnInputMapper
 import com.beancounter.marketdata.trn.TrnRepository
+import com.beancounter.marketdata.trn.cashLegInput
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -51,6 +51,9 @@ import java.time.LocalDate
  * Debit case where master has never held this cash asset: the transfer is
  * still posted (central funding was opted into) and the master is allowed to
  * overdraw; a warning is returned so the negative balance is surfaced.
+ *
+ * Not to be confused with [com.beancounter.marketdata.trn.AutoSettleService] —
+ * that class is the scheduled job which settles due PROPOSED DIVI/SPLIT trns.
  */
 @Service
 class CashAutoSettleService(
@@ -138,22 +141,19 @@ class CashAutoSettleService(
         if (stale.isNotEmpty()) trnRepository.deleteAll(stale)
 
         fun leg(type: TrnType) =
-            TrnInput(
-                callerRef = autoCallerRef(groupBatch),
-                assetId = cashAsset.id,
+            cashLegInput(
                 cashAssetId = cashAsset.id,
                 trnType = type,
-                tradeAmount = amount,
-                tradeCurrency = ccy,
-                cashCurrency = ccy,
-                tradeCashRate = BigDecimal.ONE,
-                price = BigDecimal.ONE,
+                amount = amount,
+                currency = ccy,
                 tradeDate = tradeDate,
                 // Legs mirror the parent trade's status so settled/proposed move
                 // in sync — a PROPOSED trade carries PROPOSED cash legs (no settled
                 // cash impact), a SETTLED trade carries SETTLED legs.
                 status = trade.status,
-                comments = "Auto-settle for ${trade.trnType} ${trade.asset.code}"
+                comments = "Auto-settle for ${trade.trnType} ${trade.asset.code}",
+                callerRef = autoCallerRef(groupBatch),
+                tradeCashRate = BigDecimal.ONE
             )
         val withdrawalInput = leg(TrnType.WITHDRAWAL)
         val depositInput = leg(TrnType.DEPOSIT)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferService.kt
@@ -1,14 +1,13 @@
 package com.beancounter.marketdata.cash
 
 import com.beancounter.common.contracts.TrnRequest
-import com.beancounter.common.input.TrnInput
-import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.trn.TrnService
+import com.beancounter.marketdata.trn.cashLegInput
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -68,15 +67,11 @@ class CashTransferService(
         // Create WITHDRAWAL transaction (amount sent from source)
         // Set cashAssetId = fromAsset.id so the cash ladder can track this transaction
         val withdrawalInput =
-            TrnInput(
-                callerRef = CallerRef(),
-                assetId = fromAsset.id,
+            cashLegInput(
                 cashAssetId = fromAsset.id,
                 trnType = TrnType.WITHDRAWAL,
-                tradeAmount = request.sentAmount,
-                tradeCurrency = fromCurrency,
-                cashCurrency = fromCurrency,
-                price = BigDecimal.ONE,
+                amount = request.sentAmount,
+                currency = fromCurrency,
                 tradeDate = request.tradeDate,
                 status = TrnStatus.SETTLED,
                 comments = request.description ?: "Transfer to ${toAsset.code}"
@@ -95,15 +90,11 @@ class CashTransferService(
         // Create DEPOSIT transaction (amount received at destination)
         // Set cashAssetId = toAsset.id so the cash ladder can track this transaction
         val depositInput =
-            TrnInput(
-                callerRef = CallerRef(),
-                assetId = toAsset.id,
+            cashLegInput(
                 cashAssetId = toAsset.id,
                 trnType = TrnType.DEPOSIT,
-                tradeAmount = request.receivedAmount,
-                tradeCurrency = toCurrency,
-                cashCurrency = toCurrency,
-                price = BigDecimal.ONE,
+                amount = request.receivedAmount,
+                currency = toCurrency,
                 tradeDate = request.tradeDate,
                 status = TrnStatus.SETTLED,
                 comments = request.description ?: "Transfer from ${fromAsset.code}"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/AutoSettleService.kt
@@ -18,6 +18,10 @@ import org.springframework.stereotype.Service
  * Honours the per-owner `autoSettle` preference: rows whose portfolio owner has
  * disabled auto-settlement are left in PROPOSED so the user can confirm them
  * manually.
+ *
+ * Not to be confused with [com.beancounter.marketdata.cash.CashAutoSettleService] —
+ * that class emits the compensating WITHDRAWAL+DEPOSIT pair against a linked
+ * funding portfolio.
  */
 @Service
 @Transactional

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
@@ -83,6 +83,12 @@ class BcRowAdapter(
                 // the bought currency and silently drop the sell-side leg.
                 asset
             } else {
+                // Resolve at import time (rather than leaving cashAssetId null for the
+                // mapper to fill in later) so the self-settle branches above can compare
+                // against this resolved trade asset. TrnInputMapper.map subsequently calls
+                // CashTrnServices.getCashAsset again with this resolved UUID — an
+                // intentional double-pass, cheap because the UUID tier short-circuits
+                // before the broker/generic-currency tiers run a second time.
                 cashTrnServices.getCashAsset(trnType, cashAccount, cashCurrency, ownerId, getBrokerId(row))
             }
         return cashAsset?.id

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/CashLegInput.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/CashLegInput.kt
@@ -1,0 +1,51 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Build a WITHDRAWAL/DEPOSIT cash-leg [TrnInput] — the shape shared by
+ * [com.beancounter.marketdata.cash.CashAutoSettleService],
+ * [com.beancounter.marketdata.cash.CashTransferService], and
+ * [PositionMoveService]'s compensating-cash transactions.
+ *
+ * Cash-leg invariants: the leg's asset settles to itself
+ * (`assetId == cashAssetId`), and its trade currency and cash currency are
+ * identical (`tradeCurrency == cashCurrency == [currency]`) — a cash leg
+ * never carries an FX conversion of its own.
+ */
+fun cashLegInput(
+    cashAssetId: String,
+    trnType: TrnType,
+    amount: BigDecimal,
+    currency: String,
+    tradeDate: LocalDate,
+    status: TrnStatus,
+    comments: String?,
+    callerRef: CallerRef = CallerRef(),
+    price: BigDecimal = BigDecimal.ONE,
+    tradeCashRate: BigDecimal? = null
+): TrnInput {
+    val trnInput =
+        TrnInput(
+            callerRef = callerRef,
+            assetId = cashAssetId,
+            cashAssetId = cashAssetId,
+            trnType = trnType,
+            tradeAmount = amount,
+            tradeCurrency = currency,
+            cashCurrency = currency,
+            tradeDate = tradeDate,
+            status = status,
+            comments = comments,
+            price = price
+        )
+    if (tradeCashRate != null) {
+        trnInput.tradeCashRate = tradeCashRate
+    }
+    return trnInput
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
@@ -193,17 +193,18 @@ class PositionMoveService(
         tradeCurrency: String,
         comment: String
     ): TrnInput =
-        TrnInput(
-            callerRef = CallerRef(),
-            assetId = cashAssetId,
+        cashLegInput(
             cashAssetId = cashAssetId,
             trnType = trnType,
-            tradeAmount = amount,
-            tradeCurrency = tradeCurrency,
-            cashCurrency = tradeCurrency,
+            amount = amount,
+            currency = tradeCurrency,
             tradeDate = LocalDate.now(),
             status = TrnStatus.SETTLED,
-            comments = comment
+            comments = comment,
+            // Preserve historical behaviour: this call site never set price, so
+            // persisted trns got TrnInput's own default (ZERO), not the
+            // factory's ONE default used by CashAutoSettleService/CashTransferService.
+            price = BigDecimal.ZERO
         )
 
     private fun recalculateFxRates(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnBrokerService.kt
@@ -301,10 +301,6 @@ class TrnBrokerService(
                     price = request.price,
                     tradeAmount = tradeAmount,
                     cashAmount = tradeAmount,
-                    // Settle in the trade currency so the mapper can resolve the
-                    // broker's per-currency settlement account (getCashAsset needs
-                    // brokerId AND cashCurrency); without it the settlement is null.
-                    cashCurrency = tradeCurrencyCode,
                     status = TrnStatus.PROPOSED,
                     brokerId = brokerId,
                     tradeDate = tradeDate

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnService.kt
@@ -119,17 +119,6 @@ class TrnService(
         return count
     }
 
-    fun delete(trnId: String): Collection<String> {
-        val result = trnRepository.getOrThrow(trnId)
-        val deleted = mutableListOf<Trn>()
-        if (portfolioAccessControl.canView(result.portfolio)) {
-            trnRepository.delete(result)
-            deleted.add(result)
-            cacheInvalidationProducer.sendTransactionEvent(result.portfolio.id, result.tradeDate)
-        }
-        return deleted.map { it.id }
-    }
-
     /**
      * Delete one trn and surface its auto-settled siblings (without cascading).
      * The UI uses [TrnDeleteResponse.siblings] to prompt the user before

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnBrokerServiceProposeTest.kt
@@ -176,6 +176,58 @@ class TrnBrokerServiceProposeTest {
     }
 
     @Test
+    fun `should reject price not greater than zero`() {
+        val user = login("propose-zero-price@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-ZERO-PRICE", owner = user))
+        val p1 = portfolio("PWZP-P1")
+        val asset = asset("PWZPA1")
+        buy(p1, broker, asset, "10")
+
+        assertThatThrownBy {
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("0.5"),
+                    price = BigDecimal.ZERO
+                )
+            )
+        }.isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining("Price must be greater than 0")
+    }
+
+    @Test
+    fun `should default settlement currency to the trade currency via the mapper`() {
+        // Locks in the mapper-default path (#1041 effectiveCashCurrency) now that
+        // proposeWeighted no longer sets cashCurrency on the TrnInput itself —
+        // TrnInputMapper is the single authority for defaulting settlement currency.
+        val user = login("propose-mapper-default@test.com")
+        val broker = brokerRepository.save(Broker(name = "PW-BROKER-MAPPER-DEFAULT", owner = user))
+        val p1 = portfolio("PWMD-P1")
+        val asset = asset("PWMDA1")
+        buy(p1, broker, asset, "100")
+        val settlementAccount = asset("PWMD-USD-CASH")
+        brokerSettlementAccountRepository.save(
+            BrokerSettlementAccount(broker = broker, currencyCode = USD.code, account = settlementAccount)
+        )
+
+        val response =
+            trnBrokerService.proposeWeighted(
+                broker.id,
+                BrokerProposalRequest(
+                    assetId = asset.id,
+                    weight = BigDecimal("1"),
+                    price = BigDecimal("10.00")
+                )
+            )
+
+        val trns = response.data.trns
+        assertThat(trns).hasSize(1)
+        assertThat(trns.first().cashCurrencyCode).isEqualTo(USD.code)
+        assertThat(trns.first().cashAssetId).isEqualTo(settlementAccount.id)
+    }
+
+    @Test
     fun `should settle proposed SELL to the broker's configured settlement account`() {
         val user = login("propose-settlement@test.com")
         val broker = brokerRepository.save(Broker(name = "PW-BROKER-SETTLE", owner = user))

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnInputMapperTest.kt
@@ -509,6 +509,86 @@ internal class TrnInputMapperTest {
     }
 
     @Test
+    fun `patch path preserves prior broker and cashAsset`() {
+        // Patching without brokerId/cashAssetId/cashCurrency must not clobber the
+        // trn's existing broker or cashAsset — getBroker/cashAsset fall back to
+        // `existing` when the input omits them. cashTrnServices.getCashAsset()
+        // resolves null here (unstubbed broker-settlement + generic-cash mocks),
+        // so the `?: existing?.cashAsset` fallback is what preserves it.
+        val broker = Broker(id = "broker-existing", name = "IBKR", owner = systemUser)
+        val existing =
+            Trn(
+                trnType = TrnType.SELL,
+                asset = asset,
+                broker = broker,
+                cashAsset = usdCashBalance,
+                cashCurrency = USD,
+                portfolio = getPortfolio(portfolioId)
+            )
+        val trnInput =
+            TrnInput(
+                CallerRef(
+                    portfolioId.uppercase(Locale.getDefault()),
+                    one,
+                    one
+                ),
+                assetId = asset.id,
+                trnType = TrnType.SELL,
+                quantity = TEN,
+                price = price,
+                tradeBaseRate = ONE,
+                tradeCashRate = ONE,
+                tradePortfolioRate = ONE
+            )
+
+        val trn =
+            trnInputMapper.map(
+                getPortfolio(portfolioId),
+                trnInput,
+                existing
+            )
+
+        assertThat(trn.broker).isEqualTo(broker)
+        assertThat(trn.cashAsset).isEqualTo(usdCashBalance)
+    }
+
+    @Test
+    fun `explicit cashCurrency differing from trade currency wins`() {
+        // Precedence order for cashCurrency: explicit trnInput.cashCurrency >
+        // existing.cashCurrency (patch) > the resolved cash asset's own currency.
+        Mockito.`when`(currencyService.getCode(SGD.code)).thenReturn(SGD)
+
+        val trnInput =
+            TrnInput(
+                CallerRef(
+                    portfolioId.uppercase(Locale.getDefault()),
+                    one,
+                    one
+                ),
+                assetId = asset.id, // MSFT, trade currency USD
+                trnType = TrnType.BUY,
+                cashAssetId = toKey("USD-X", "USER"), // resolves via assetFinder tier-2 UUID short-circuit
+                cashCurrency = SGD.code,
+                quantity = TEN,
+                price = price,
+                tradeAmount = BigDecimal("100"),
+                tradeBaseRate = ONE,
+                tradeCashRate = ONE,
+                tradePortfolioRate = ONE
+            )
+
+        val trnResponse =
+            trnInputMapper.convert(
+                portfolioService.find(portfolioId),
+                TrnRequest(portfolioId, listOf(trnInput))
+            )
+
+        assertThat(trnResponse).hasSize(1)
+        assertThat(trnResponse.first())
+            .hasFieldOrPropertyWithValue("cashCurrency", SGD)
+    }
+
+    @Test
     fun `should not default cash currency for FX_BUY`() {
         // FX_BUY's cash leg currency is the SOLD currency, not the trade (bought)
         // currency — defaulting to trade currency here would corrupt it. When no

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashTrnServicesTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/cash/CashTrnServicesTest.kt
@@ -108,6 +108,42 @@ internal class CashTrnServicesTest {
     }
 
     @Test
+    fun `should return null when brokerId present but cashCurrency is null`() {
+        // brokerId alone can't resolve the broker-settlement tier (needs cashCurrency
+        // too), and no cashCurrency means the generic-balance fallback has nothing
+        // to look up either — both tiers are skipped, result is null.
+        assertThat(
+            cashTrnServices.getCashAsset(
+                trnType = TrnType.BUY,
+                cashAccountCode = null,
+                cashCurrency = null,
+                ownerId = systemUser.id,
+                brokerId = broker.id
+            )
+        ).isNull()
+        Mockito.verifyNoInteractions(brokerSettlementAccountRepository)
+        Mockito.verifyNoInteractions(assetService)
+    }
+
+    @Test
+    fun `should short-circuit on a known asset UUID without touching broker or generic tiers`() {
+        Mockito
+            .`when`(assetFinder.find(ibrkUsd.id))
+            .thenReturn(ibrkUsd)
+        assertThat(
+            cashTrnServices.getCashAsset(
+                trnType = TrnType.BUY,
+                cashAccountCode = ibrkUsd.id,
+                cashCurrency = USD.code,
+                ownerId = systemUser.id,
+                brokerId = broker.id
+            )
+        ).isEqualTo(ibrkUsd)
+        Mockito.verifyNoInteractions(brokerSettlementAccountRepository)
+        Mockito.verifyNoInteractions(assetService)
+    }
+
+    @Test
     fun is_CashBalanceFromTradeCurrency() {
         // Trade Currency, but no defined Cash Asset, resolves to a generic Balance asset.
         val trnInput =


### PR DESCRIPTION
## Settlement-path review: dedupe + simplify + coverage

Outcome of a full review of the trade → cash-leg pipeline (entry points → `TrnInputMapper` → `CashTrnServices` → `CashAutoSettleService`). Behavior-preserving; no API or schema changes.

### Simplifications

- **`cashLegInput()` factory** (`trn/CashLegInput.kt`) — three services hand-rolled the same WITHDRAWAL/DEPOSIT `TrnInput` shape (`assetId == cashAssetId`, `tradeCurrency == cashCurrency`): `CashAutoSettleService.leg()`, `CashTransferService.transfer`, `PositionMoveService.createCashInput`. One factory now owns the shape and documents the cash-leg invariants. Each site passes exactly the field values it produced before (PositionMove keeps `price = ZERO`, auto-settle keeps `tradeCashRate = ONE`).
- **`proposeWeighted` leans on the mapper default** — the explicit `cashCurrency = tradeCurrencyCode` (added in #1038) became redundant once #1041 taught `TrnInputMapper` to default settlement currency to trade currency for broker-bearing inputs. Removed; the mapper is the single authority. Guarded by the existing "settles to broker's configured settlement account" test plus a new lock-in test.
- **Dead code removed** — `TrnService.delete(trnId)` had zero callers (only `deleteWithSiblings` is wired to the controller).
- **Naming disambiguation** — KDoc cross-references between `AutoSettleService` (scheduled due-DIVI/SPLIT settle) and `CashAutoSettleService` (compensating W+D pair emitter).
- **Documented double-pass** — `BcRowAdapter` resolves the cash asset at import time so self-settle branches can use the resolved trade asset; the mapper's re-resolve short-circuits on the UUID tier. Now stated in a comment instead of looking accidental.

### Coverage-only test additions (no existing assertions changed)

- `TrnInputMapperTest`: patch preserves prior broker + cashAsset when input omits them; explicit `cashCurrency` differing from trade currency wins precedence.
- `CashTrnServicesTest`: brokerId with null cashCurrency falls through to null; explicit UUID cashAccountCode short-circuits before broker/generic tiers.
- `TrnBrokerServiceProposeTest`: `price <= 0` rejected; created proposal's cashCurrency/settlement account locked to the mapper-default path.

### Gates

`./gradlew testAll` ✅ (incl. contractTest source sets) · `formatKotlin` ✅ · `lintKotlin` ✅

Companion docs update (TRN.md/SETTLEMENT.md/CLAUDE.md staleness: unsettle revert-not-delete, 5-arg `getCashAsset` tiers, broker default, earmark downstream) committed to bc-claude.
