### PR TITLE
fix(position): perf cache staleness gate + PRIVATE asset latest-price fallback

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PerformanceService.kt
@@ -79,8 +79,23 @@ class PerformanceService(
         val cached = tryLoadFromCache(portfolio.id)
         if (cached != null) {
             val earliestCached = cached.minOf { it.valuationDate }
+            val latestCached = cached.maxOf { it.valuationDate }
             val hasInWindow = cached.any { !it.valuationDate.isBefore(startDate) }
-            if (!earliestCached.isAfter(startDate) && hasInWindow) {
+            // `earliestCached <= startDate` alone is not enough: if every cached
+            // snapshot predates startDate, `anchorToStartDate` returns just the
+            // synthesised anchor (single-point series), producing 0% TWR and 0
+            // gain. Require at least one snapshot in `[startDate, endDate]`.
+            val hasSufficientHistory = !earliestCached.isAfter(startDate) && hasInWindow
+            // RabbitMQ invalidation (CacheInvalidationConsumer.invalidateFrom) deletes
+            // snapshots >= a trn's tradeDate; the surviving older rows can still
+            // satisfy `hasSufficientHistory`, leaving the series frozen before that
+            // date forever. Require the newest cached snapshot to reach endDate too.
+            // determineValuationDates always includes endDate in its result (it's
+            // unconditionally unioned in before the range filter), and buildSnapshots
+            // emits one snapshot per valuation date, so a fresh cache always has a
+            // snapshot dated endDate.
+            val isFresh = !latestCached.isBefore(endDate)
+            if (hasSufficientHistory && isFresh) {
                 val anchored = anchorToStartDate(cached, startDate)
                 log.debug(
                     "Cache HIT: portfolio={}, snapshots={} (filtered from {})",
@@ -90,16 +105,14 @@ class PerformanceService(
                 )
                 return buildResponseFromCache(portfolio, anchored)
             }
-            // `earliestCached <= startDate` alone is not enough: if every cached
-            // snapshot predates startDate, `anchorToStartDate` returns just the
-            // synthesised anchor (single-point series), producing 0% TWR and 0
-            // gain. Require at least one snapshot in `[startDate, endDate]`.
             log.debug(
-                "Cache PARTIAL: portfolio={}, earliest={}, latest={}, requested from {}, recomputing",
+                "Cache PARTIAL: portfolio={}, earliest={}, latest={}, requested from {} to {}, reason={}, recomputing",
                 portfolio.code,
                 earliestCached,
-                cached.maxOf { it.valuationDate },
-                startDate
+                latestCached,
+                startDate,
+                endDate,
+                if (!hasSufficientHistory) "insufficient history" else "stale tail"
             )
         }
 
@@ -278,6 +291,10 @@ class PerformanceService(
         var trnIndex = 0
         var netContributions = BigDecimal.ZERO
         var cumulativeDividends = BigDecimal.ZERO
+        // Computed once per pass (not per date) — PRIVATE-market assets only
+        // ever get one price row (see valuePositionsFromCache), so every other
+        // valuation date needs this fallback.
+        val latestPriceIndex = buildLatestPriceIndex(priceCache)
 
         for (valDate in valuationDates) {
             // Accumulate transactions up to and including this date
@@ -295,7 +312,8 @@ class PerformanceService(
             netContributions = acc.netContributions
             cumulativeDividends = acc.cumulativeDividends
 
-            val marketValue = valuePositionsFromCache(positions, valDate, portfolio, priceCache, fxCache)
+            val marketValue =
+                valuePositionsFromCache(positions, valDate, portfolio, priceCache, fxCache, latestPriceIndex)
 
             snapshots.add(
                 ValuationSnapshot(
@@ -375,6 +393,28 @@ class PerformanceService(
     }
 
     /**
+     * Indexes the most recent [MarketData] per asset across every date present
+     * in [priceCache]. PRIVATE-market assets (off-market property, etc.) are
+     * stamped by PrivateMarketDataProvider with a single latest-price row and
+     * no daily history, so the per-date lookup in [valuePositionsFromCache]
+     * only ever finds a row on that one date — every other valuation date
+     * needs this fallback instead of purchase cost.
+     */
+    private fun buildLatestPriceIndex(priceCache: Map<String, Collection<MarketData>>): Map<String, MarketData> {
+        val latest = mutableMapOf<String, MarketData>()
+        for (marketDataForDate in priceCache.values) {
+            for (marketData in marketDataForDate) {
+                val key = "${marketData.asset.market.code}:${marketData.asset.code}"
+                val existing = latest[key]
+                if (existing == null || marketData.priceDate.isAfter(existing.priceDate)) {
+                    latest[key] = marketData
+                }
+            }
+        }
+        return latest
+    }
+
+    /**
      * Calculates total portfolio market value at a given date in the portfolio's
      * reference currency, using pre-fetched price and FX caches.
      *
@@ -388,7 +428,8 @@ class PerformanceService(
         date: LocalDate,
         portfolio: Portfolio,
         priceCache: Map<String, Collection<MarketData>>,
-        fxCache: Map<String, FxPairResults>
+        fxCache: Map<String, FxPairResults>,
+        latestPriceIndex: Map<String, MarketData>
     ): BigDecimal {
         val dateStr = date.toString()
         val fxRates = findNearestFxRates(dateStr, fxCache)
@@ -432,6 +473,19 @@ class PerformanceService(
             val price =
                 if (marketData != null) {
                     marketData.close
+                } else if (pos.asset.market.code == PRIVATE_MARKET && latestPriceIndex[key] != null) {
+                    // PRIVATE assets only ever get one price row (stamped today by
+                    // PrivateMarketDataProvider) — use it in preference to purchase
+                    // cost for every other valuation date.
+                    val latest = latestPriceIndex.getValue(key)
+                    log.debug(
+                        "No price for PRIVATE asset {} on {}, using latest known price {} from {}",
+                        key,
+                        dateStr,
+                        latest.close,
+                        latest.priceDate
+                    )
+                    latest.close
                 } else {
                     // Fall back to average cost when no market price is available
                     val avgCost = pos.moneyValues[Position.In.TRADE]?.averageCost ?: BigDecimal.ZERO
@@ -944,6 +998,10 @@ class PerformanceService(
 
     companion object {
         private val log = LoggerFactory.getLogger(PerformanceService::class.java)
+
+        // Matches PrivateMarketDataProvider.ID in svc-data: single latest-price
+        // row, no daily history.
+        private const val PRIVATE_MARKET = "PRIVATE"
 
         /**
          * External cash flows are money entering or leaving the portfolio from outside.

--- a/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/cache/PerformanceServiceCacheTest.kt
@@ -441,6 +441,70 @@ class PerformanceServiceCacheTest {
     }
 
     @Test
+    fun `cache hit requires newest snapshot to reach end date`() {
+        // Regression: RabbitMQ invalidation (CacheInvalidationConsumer.invalidateFrom)
+        // deletes snapshots >= a trn's tradeDate. The surviving older rows still
+        // satisfy the old HIT conditions (earliest <= startDate, something
+        // in-window), so the series stayed frozen before that date forever and
+        // never re-extended to today. HIT must also require the newest cached
+        // snapshot to reach endDate.
+        whenever(cacheService.isAvailable()).thenReturn(true)
+
+        val now = LocalDate.now()
+        val cachedSnapshots =
+            listOf(
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(12),
+                    marketValue = BigDecimal("10000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                ),
+                CachedSnapshot(
+                    valuationDate = now.minusMonths(2),
+                    marketValue = BigDecimal("11000"),
+                    externalCashFlow = BigDecimal.ZERO,
+                    netContributions = BigDecimal("10000"),
+                    cumulativeDividends = BigDecimal.ZERO
+                )
+            )
+        whenever(cacheService.findAllSnapshots(eq(portfolio.id)))
+            .thenReturn(cachedSnapshots)
+
+        val buyTrn =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = testAsset,
+                tradeDate = now.minusMonths(1),
+                quantity = BigDecimal("100"),
+                tradeAmount = BigDecimal("15000")
+            )
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse(listOf(buyTrn)))
+        whenever(accumulator.accumulate(any(), any()))
+            .thenAnswer { invocation ->
+                val positions = invocation.getArgument<com.beancounter.common.model.Positions>(1)
+                positions.getOrCreate(testAsset)
+            }
+        lenient()
+            .`when`(priceService.getBulkPrices(any(), any()))
+            .thenReturn(BulkPriceResponse(emptyMap()))
+        lenient()
+            .`when`(fxRateService.getBulkRates(any(), any()))
+            .thenReturn(BulkFxResponse(emptyMap()))
+
+        // 12-month window: earliest cached snapshot covers startDate, and one
+        // snapshot falls in-window — the OLD HIT conditions are satisfied. But
+        // the newest cached snapshot (-2M) is well short of endDate (today),
+        // so this must MISS and recompute rather than serve a stale series.
+        performanceService.calculate(portfolio, 12)
+
+        verify(trnService).query(any<Portfolio>(), any())
+        verify(priceService).getBulkPrices(any(), any())
+        verify(cacheService).storeSnapshots(eq(portfolio.id), any())
+    }
+
+    @Test
     fun `cache with insufficient history triggers recomputation`() {
         whenever(cacheService.isAvailable()).thenReturn(true)
 

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PerformanceServiceTest.kt
@@ -348,6 +348,70 @@ class PerformanceServiceTest {
     }
 
     @Test
+    fun `values private asset at latest known price when date has no price row`() {
+        // PRIVATE-market assets (e.g. off-market property) get a single
+        // latest-price row stamped by PrivateMarketDataProvider (priceDate=today,
+        // no daily history). Every earlier valuation date has no row in
+        // priceCache for the asset, so it must fall back to the latest known
+        // PRIVATE price across the whole cache — not purchase cost.
+        val privateMarket = Market("PRIVATE")
+        val privateAsset =
+            Asset(
+                code = "HOUSE",
+                id = "house-id",
+                name = "Property",
+                market = privateMarket
+            )
+        val buyDate = LocalDate.now().minusYears(2)
+        val buyTrn =
+            Trn(
+                trnType = TrnType.BUY,
+                asset = privateAsset,
+                tradeDate = buyDate,
+                quantity = BigDecimal("1"),
+                price = BigDecimal("1565000"),
+                tradeAmount = BigDecimal("1565000"),
+                cashAmount = BigDecimal("-1565000")
+            )
+
+        whenever(trnService.query(any<Portfolio>(), eq(DateUtils.TODAY)))
+            .thenReturn(TrnResponse(listOf(buyTrn)))
+
+        whenever(accumulator.accumulate(any(), any()))
+            .thenAnswer { invocation ->
+                val positions = invocation.getArgument<com.beancounter.common.model.Positions>(1)
+                val pos = positions.getOrCreate(privateAsset)
+                pos.quantityValues.purchased = BigDecimal("1")
+                pos.moneyValues[Position.In.TRADE]!!.averageCost = BigDecimal("1565000")
+                pos
+            }
+
+        val today = LocalDate.now()
+        val latestPrice =
+            com.beancounter.common.model.MarketData(
+                asset = privateAsset,
+                priceDate = today,
+                close = BigDecimal("1450000")
+            )
+
+        // Only today's date has a price row — every other valuation date must
+        // fall back to the latest-known-price index, not averageCost.
+        lenient()
+            .`when`(priceService.getBulkPrices(any(), any()))
+            .thenReturn(BulkPriceResponse(mapOf(today.toString() to listOf(latestPrice))))
+        lenient()
+            .`when`(fxRateService.getBulkRates(any(), any()))
+            .thenReturn(BulkFxResponse(emptyMap()))
+
+        val result = performanceService.calculate(portfolio, 12)
+
+        assertThat(result.data.series).isNotEmpty
+        val earlierPoint = result.data.series.first { it.date.isBefore(today) }
+        assertThat(earlierPoint.marketValue.toDouble())
+            .isCloseTo(1450000.0, Offset.offset(0.01))
+    }
+
+    @Test
     fun `growth of 1000 starts at 1000`() {
         // Setup: single BUY transaction, price is available
         val buyDate = LocalDate.now().minusMonths(6)


### PR DESCRIPTION
## Problem

The aggregate performance endpoint (`POST /performance/aggregate`) reported net contributions inconsistent with the transaction ledger. Two svc-position bugs:

1. **Frozen per-portfolio perf caches.** `CacheInvalidationConsumer.invalidateFrom` deletes snapshots `>= tradeDate`, but the surviving older rows still satisfied the cache-HIT test (`earliest <= startDate` + any in-window row). A portfolio's series froze just before its last edited date, with each portfolio frozen at a different date. In the aggregate, auto-settle WITHDRAWAL/DEPOSIT pairs then count on the fresh side only, producing phantom `netContributions`.
2. **PRIVATE assets valued at purchase cost.** `valuePositionsFromCache` falls back to `averageCost` when a date has no price row. PRIVATE-market assets have a single latest-price row (no daily history), so historical valuation points were valued at purchase cost instead of the current off-market price, overstating market value whenever the two diverge.

## Fix

- Cache HIT additionally requires `latestCached >= endDate` (`determineValuationDates` always emits an endDate snapshot, so a fresh compute HITs for the rest of the day). PARTIAL log states the reason (insufficient history vs stale tail).
- For PRIVATE-market assets with no per-date price row, fall back to the latest known price across the fetched price cache before `averageCost`. Non-PRIVATE fallback unchanged.

## Tests

- `cache hit requires newest snapshot to reach end date` — stale-tail series must recompute + re-store, not serve frozen cache.
- `values private asset at latest known price when date has no price row` — PRIVATE asset with only a latest-price row values earlier points at that price, not cost.
- Full `testSmart` + formatKotlin + lintKotlin green; existing HIT/anchor/avgCost-fallback tests untouched.

## Not covered here

GET vs aggregate freshness divergence collapses into fix 1 (both paths share `calculate()`); verify after deploy.
