### PR TITLE
fix(data): bulk prices top up PRIVATE assets outside lookback window

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -397,6 +397,9 @@ class PriceService(
             window
                 .groupBy { it.asset.id }
                 .mapValues { (_, series) -> adjustSeriesForSplits(series) }
+                .toMutableMap()
+
+        topUpMissingPrivateAssets(assets, byAsset, maxDate)
 
         val result = mutableMapOf<String, List<MarketData>>()
         for (date in dates) {
@@ -409,6 +412,31 @@ class PriceService(
             result[date.toString()] = mdList
         }
         return result
+    }
+
+    /**
+     * PRIVATE-market assets (user-entered prices for real estate, art, etc.) can go
+     * months between updates — the FALLBACK_LOOKBACK_DAYS window that suits listed
+     * markets is far too narrow to reach their single price row. Top up any PRIVATE
+     * asset that came back empty from the windowed load with its single latest
+     * on-or-before-maxDate row, so the existing [nearestOnOrBefore] resolution below
+     * picks it up for every requested date instead of silently omitting the asset
+     * (which pushed svc-position back onto its purchase-cost fallback, see #1045).
+     * One extra query per missing PRIVATE asset — they are rare (typically 1-2 per
+     * user) so this doesn't reintroduce the N+1 pattern the window query replaced.
+     */
+    private fun topUpMissingPrivateAssets(
+        assets: Collection<Asset>,
+        byAsset: MutableMap<String, List<MarketData>>,
+        maxDate: LocalDate
+    ) {
+        for (asset in assets) {
+            if (asset.market.code != PrivateMarketDataProvider.ID) continue
+            if (!byAsset[asset.id].isNullOrEmpty()) continue
+            marketDataRepo
+                .findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(asset, maxDate)
+                .ifPresent { latest -> byAsset[asset.id] = listOf(latest) }
+        }
     }
 
     /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/BulkPriceServiceTest.kt
@@ -1,9 +1,11 @@
 package com.beancounter.marketdata.providers
 
 import com.beancounter.common.model.MarketData
+import com.beancounter.common.utils.AssetUtils.Companion.getTestAsset
 import com.beancounter.common.utils.CashUtils
 import com.beancounter.marketdata.Constants.Companion.AAPL
 import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.PRIVATE_MARKET
 import com.beancounter.marketdata.assets.AssetFinder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -11,9 +13,11 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.Optional
 
 /**
  * Bulk price retrieval is the hot path for wealth-performance prefetch. The implementation
@@ -148,5 +152,58 @@ class BulkPriceServiceTest {
 
         assertThat(result).hasSize(1)
         assertThat(result["2024-01-01"]).isEmpty()
+    }
+
+    @Test
+    fun `bulk prices include private asset latest price when row predates lookback window`() {
+        // PRIVATE-market assets (real estate, art, etc) get a single user-entered price
+        // that can sit months old. The windowed load only reaches back
+        // FALLBACK_LOOKBACK_DAYS, so such rows are otherwise invisible to the bulk
+        // response and svc-position falls back to purchase-cost averaging (#1045 gap).
+        val privateAsset = getTestAsset(PRIVATE_MARKET, "REALESTATE")
+        val requestDate1 = LocalDate.of(2024, 1, 15)
+        val requestDate2 = LocalDate.of(2024, 2, 15)
+        val assets = listOf(privateAsset)
+        val dates = listOf(requestDate1, requestDate2)
+
+        // Row predates the window start (requestDate1 - FALLBACK_LOOKBACK_DAYS) by months.
+        val oldPriceDate = requestDate1.minusMonths(5)
+        val oldPrice =
+            MarketData(asset = privateAsset, priceDate = oldPriceDate, close = BigDecimal("500000"))
+
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
+            .thenReturn(emptyList())
+        whenever(
+            marketDataRepo.findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(
+                eq(privateAsset),
+                eq(requestDate2)
+            )
+        ).thenReturn(Optional.of(oldPrice))
+
+        val result = priceService.getBulkMarketData(assets, dates)
+
+        assertThat(result["2024-01-15"]).hasSize(1)
+        assertThat(result["2024-01-15"]!![0].close).isEqualByComparingTo(BigDecimal("500000"))
+        assertThat(result["2024-02-15"]).hasSize(1)
+        assertThat(result["2024-02-15"]!![0].close).isEqualByComparingTo(BigDecimal("500000"))
+    }
+
+    @Test
+    fun `bulk prices leave non-private asset absent when its only row predates lookback window`() {
+        // Behaviour for listed-market assets is unchanged: an out-of-window row with no
+        // top-up path simply leaves the asset absent from the bulk response.
+        val requestDate = LocalDate.of(2024, 1, 15)
+        val assets = listOf(AAPL)
+
+        whenever(marketDataRepo.findByAssetInAndPriceDateBetween(eq(assets), any(), any()))
+            .thenReturn(emptyList())
+
+        val result = priceService.getBulkMarketData(assets, listOf(requestDate))
+
+        assertThat(result["2024-01-15"]).isEmpty()
+        verify(
+            marketDataRepo,
+            org.mockito.kotlin.never()
+        ).findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc(any(), any())
     }
 }


### PR DESCRIPTION
## Problem

`POST /prices/bulk` serves prices from a windowed DB read (`[min(dates) − 10d, max(dates)]`). PRIVATE-market assets carry a single user-entered price row that can be months old, so the row falls outside the window and the asset is silently absent from the response. svc-position's PRIVATE latest-price fallback (#1045) only searches the returned cache, so those assets were still valued at purchase averageCost across the whole performance series.

## Fix

After the windowed load, any requested PRIVATE-market asset with no rows is topped up with its latest on-or-before-window-end row (`findTop1ByAssetAndPriceDateLessThanEqualOrderByPriceDateDesc` — same method PrivateMarketDataProvider uses). The existing nearestOnOrBefore date resolution then serves it for every requested date. One extra query per missing PRIVATE asset; non-PRIVATE behaviour unchanged.

## Tests

- `bulk prices include private asset latest price when row predates lookback window` — single months-old PRIVATE row served for all requested dates.
- `bulk prices leave non-private asset absent when its only row predates lookback window` — guards unchanged non-PRIVATE behaviour (top-up query never invoked).
- Full testSmart + formatKotlin + lintKotlin green.

## Verification after deploy

`DELETE /api/{code}/performance/cache` for the affected portfolio, then GET the performance series — PRIVATE holdings should value at their latest off-market price instead of cost.
