### PR TITLE
fix(position): ROI over capital deployed, not residual holding cost

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/RoiCalculator.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/RoiCalculator.kt
@@ -1,7 +1,6 @@
 package com.beancounter.position.valuation
 
 import com.beancounter.common.model.MoneyValues
-import com.beancounter.common.model.Totals
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -9,19 +8,20 @@ import java.math.RoundingMode
  * Provides functionality to calculate the Return on Investment (ROI) for financial positions.
  * This class calculates ROI based on the market value, cost basis, and dividends of an investment.
  *
- * <p>The ROI is computed as the ratio of the net gains (or losses) and the dividends received
- * to the original investment cost. This provides a measure of the profitability of an investment
- * and is expressed as a percentage of the initial amount invested.</p>
+ * <p>The ROI is the total return (realised gain + unrealised gain + dividends) expressed as a
+ * ratio of the total capital deployed over the life of the position. This is a money-weighted
+ * "total return on cost" and pairs with the annualised IRR reported alongside it.</p>
  *
  * <p>Method {@code calculateROI}:
  * <ul>
  *     <li>Computes the ROI based on the provided {@link MoneyValues}, which encapsulate all
  *     relevant financial metrics of an asset.</li>
- *     <li>Returns zero if the cost value of the investment is zero to prevent division by zero errors.</li>
- *     <li>Calculates net gains as the difference between the market value and cost value of the asset,
- *     adds any dividends received, and divides this total by the cost value to derive the ROI.</li>
- *     <li>The division is performed with a precision up to 8 decimal places and uses {@link RoundingMode#HALF_UP}
- *     to round the result.</li>
+ *     <li>Divides {@code totalGain} by {@code purchases} — the cumulative cost of every acquisition,
+ *     which is never reduced by sells. This keeps the numerator (gains on both sold and held shares)
+ *     and the denominator (cost of all shares ever bought) on the same scope, so partially-sold
+ *     positions are not inflated by dividing lifetime gains by only the residual holding cost.</li>
+ *     <li>Returns zero when there are no purchases, to prevent division by zero.</li>
+ *     <li>The division is performed to 6 decimal places using {@link RoundingMode#HALF_UP}.</li>
  * </ul>
  * </p>
  *
@@ -29,15 +29,7 @@ import java.math.RoundingMode
  * or comparing different investment opportunities is required.</p>
  */
 class RoiCalculator {
-    fun calculateROI(moneyValues: MoneyValues): BigDecimal {
-        val costBasis = costBasis(moneyValues)
-
-        if (costBasis.compareTo(BigDecimal.ZERO) == 0) {
-            return BigDecimal.ZERO
-        }
-        val returns = moneyValues.totalGain
-        return calculate(returns, costBasis)
-    }
+    fun calculateROI(moneyValues: MoneyValues): BigDecimal = calculate(moneyValues.totalGain, moneyValues.purchases)
 
     private fun calculate(
         returns: BigDecimal,
@@ -53,13 +45,4 @@ class RoiCalculator {
                 RoundingMode.HALF_UP
             )
     }
-
-    private fun costBasis(moneyValues: MoneyValues): BigDecimal =
-        if (moneyValues.costValue.compareTo(BigDecimal.ZERO) == 0) {
-            moneyValues.purchases
-        } else {
-            moneyValues.costValue
-        }
-
-    fun calculateROI(totals: Totals): BigDecimal = calculate(totals.gain, totals.purchases - totals.sales)
 }

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionCalculationSupportTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionCalculationSupportTest.kt
@@ -88,9 +88,8 @@ class PositionCalculationSupportTest {
         // When
         val result = calculationSupport.calculateRoi(moneyValues)
 
-        // Then
-        assertThat(result).isNotNull()
-        // Note: The actual ROI calculation depends on the RoiCalculator implementation
+        // Then — total gain over capital deployed: 400 / 800 = 0.50 (sales do not reduce the basis).
+        assertThat(result).isEqualByComparingTo(BigDecimal("0.50"))
     }
 
     @Test
@@ -107,9 +106,8 @@ class PositionCalculationSupportTest {
         // When
         val result = calculationSupport.calculatePortfolioRoi(totals)
 
-        // Then
-        assertThat(result).isNotNull()
-        // Note: The actual ROI calculation depends on the RoiCalculator implementation
+        // Then — portfolio gain over capital deployed: 400 / 800 = 0.50 (same basis as position ROI).
+        assertThat(result).isEqualByComparingTo(BigDecimal("0.50"))
     }
 
     @Test

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/RoiCalculationTests.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/RoiCalculationTests.kt
@@ -45,11 +45,40 @@ class RoiCalculationTests {
         val positions = Positions(portfolio)
         val position = positions.getOrCreate(asset)
         val moneyValues = position.moneyValues[Position.In.BASE]!!
+        // Never-sold position: purchases equals the residual cost of the holding.
+        moneyValues.purchases = initialInvestment
         moneyValues.costValue = initialInvestment
         moneyValues.dividends = dividends
         moneyValues.marketValue = finalValue
         moneyValues.totalGain = finalValue.subtract(initialInvestment).add(dividends)
         return moneyValues
+    }
+
+    @Test
+    fun `ROI on a partially-sold position uses total capital deployed, not residual cost`() {
+        val positions = Positions(portfolio)
+        val position = positions.getOrCreate(asset)
+        val moneyValues = position.moneyValues[Position.In.BASE]!!
+        // Bought 6000 of capital over the life of the position (never decremented).
+        moneyValues.purchases = BigDecimal("6000")
+        // Sold most of it, banking a realised gain.
+        moneyValues.sales = BigDecimal("5000")
+        moneyValues.realisedGain = BigDecimal("1000")
+        // The residual holding costs 1200 and is now worth 1500.
+        moneyValues.costValue = BigDecimal("1200")
+        moneyValues.marketValue = BigDecimal("1500")
+        moneyValues.unrealisedGain = BigDecimal("300")
+        moneyValues.dividends = BigDecimal("100")
+        moneyValues.totalGain = BigDecimal("1400") // 300 unrealised + 100 dividends + 1000 realised
+
+        val result =
+            RoiCalculator()
+                .calculateROI(moneyValues)
+                .setScale(4, RoundingMode.HALF_UP)
+
+        // 1400 / 6000 = 0.2333 (total return on capital deployed).
+        // The residual-cost basis would wrongly yield 1400 / 1200 = 1.1667.
+        assertThat(result).isEqualTo(BigDecimal("0.2333"))
     }
 
     @Test


### PR DESCRIPTION
ROI divided total gain (realised + unrealised + dividends) by costValue —
the residual cost of only the shares still held. On partially-sold
positions this inflated ROI: realised gains from sold shares over the tiny
remaining basis. A real position reported 102.7% instead of ~20%.

Denominator is now `purchases` — cumulative cost of every acquisition,
never reduced by sells — so numerator and denominator share scope
(total-return-on-cost). Removed the unused calculateROI(Totals) overload.
