### PR TITLE
fix(fx): scheduled FX pre-fetch emits cache-invalidation event

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/FxRateSchedule.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/fx/FxRateSchedule.kt
@@ -1,9 +1,11 @@
 package com.beancounter.marketdata.fx
 
 import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.fx.fxrates.FxProviderService
 import io.sentry.spring7.tracing.SentryTransaction
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
@@ -43,6 +45,17 @@ class FxRateSchedule(
         private val log = LoggerFactory.getLogger(FxRateSchedule::class.java)
     }
 
+    // Optional: absent when messaging is disabled (mirrors FxRateService). When
+    // present, a freshly pre-warmed date publishes an FX event so svc-position
+    // revalues portfolios against the new rates instead of holding stale FX
+    // until the next valuation cron.
+    private var cacheInvalidationProducer: CacheInvalidationProducer? = null
+
+    @Autowired(required = false)
+    fun setCacheInvalidationProducer(producer: CacheInvalidationProducer?) {
+        this.cacheInvalidationProducer = producer
+    }
+
     @SentryTransaction(operation = "scheduled", name = "FxRateSchedule.prefetchRates")
     @Scheduled(
         cron = "#{@fxRateScheduleCron}",
@@ -70,6 +83,7 @@ class FxRateSchedule(
             val rates = fxProviderService.getRates(date.toString(), providerId = null)
             if (rates.isNotEmpty()) {
                 fxRateRepository.saveAll(rates)
+                cacheInvalidationProducer?.sendFxEvent(date)
                 hits++
                 log.info("Pre-warmed FX rates for {}: {} rates", date, rates.size)
             } else {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/fx/FxRateScheduleTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/fx/FxRateScheduleTest.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.fx
 import com.beancounter.common.model.Currency
 import com.beancounter.common.model.FxRate
 import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.fx.fxrates.FxProviderService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -23,6 +24,7 @@ import java.time.LocalDate
 class FxRateScheduleTest {
     private val fxProviderService = mock<FxProviderService>()
     private val fxRateRepository = mock<FxRateRepository>()
+    private val cacheInvalidationProducer = mock<CacheInvalidationProducer>()
     private val dateUtils = DateUtils()
 
     private val usd = Currency("USD")
@@ -45,7 +47,7 @@ class FxRateScheduleTest {
             fxRateRepository = fxRateRepository,
             dateUtils = dateUtils,
             backfillDays = backfillDays
-        )
+        ).apply { setCacheInvalidationProducer(cacheInvalidationProducer) }
 
     @Test
     fun `fetches today plus backfill range and saves uncached dates`() {
@@ -107,5 +109,43 @@ class FxRateScheduleTest {
         verify(fxProviderService, times(1)).getRates(eq(today.toString()), isNull())
         verify(fxRateRepository, times(1)).saveAll(any<Iterable<FxRate>>())
         assertThat(true).isTrue() // anchor: idempotency is asserted via call counts above
+    }
+
+    @Test
+    fun `emits an FX cache-invalidation event for each newly-saved date`() {
+        val today = LocalDate.now(dateUtils.zoneId)
+        val yesterday = today.minusDays(1)
+        whenever(fxRateRepository.findByDateRange(any(), any())).thenReturn(emptyList())
+        whenever(fxProviderService.getRates(any<String>(), isNull())).thenAnswer { invocation ->
+            sampleRates(LocalDate.parse(invocation.arguments[0] as String))
+        }
+
+        newSchedule(backfillDays = 1).prefetchRates()
+
+        // svc-position revalues portfolios off these events, so a freshly
+        // pre-warmed FX date must publish one — otherwise persisted
+        // portfolio.marketValue keeps stale FX until the next cron.
+        verify(cacheInvalidationProducer).sendFxEvent(today)
+        verify(cacheInvalidationProducer).sendFxEvent(yesterday)
+    }
+
+    @Test
+    fun `does not emit an event for cached dates`() {
+        val today = LocalDate.now(dateUtils.zoneId)
+        whenever(fxRateRepository.findByDateRange(today)).thenReturn(sampleRates(today))
+
+        newSchedule(backfillDays = 0).prefetchRates()
+
+        verify(cacheInvalidationProducer, never()).sendFxEvent(any())
+    }
+
+    @Test
+    fun `does not emit an event when the provider returns no rates`() {
+        whenever(fxRateRepository.findByDateRange(any(), any())).thenReturn(emptyList())
+        whenever(fxProviderService.getRates(any<String>(), isNull())).thenReturn(emptyList())
+
+        newSchedule(backfillDays = 0).prefetchRates()
+
+        verify(cacheInvalidationProducer, never()).sendFxEvent(any())
     }
 }


### PR DESCRIPTION
The daily FxRateSchedule pre-warm saved new rates but never published an
FX cache-invalidation event, so svc-position never revalued portfolios
against the fresh rates. Persisted portfolio.marketValue kept the prior
day's FX until the next valuation cron — Net Worth and holdings drill-down
disagreed by the intraday FX drift.

Emit sendFxEvent(date) after each newly-saved date (mirrors the on-demand
FxRateService path), so CacheInvalidationConsumer triggers revaluation.
Producer injected optionally (@Autowired(required=false)) — no-op when
messaging is disabled.
