### PR TITLE
fix(agent): close chat DOM-XSS fallback; document svc-admin CSRF intent

### DIFF
--- a/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
+++ b/svc-admin/src/main/kotlin/com/beancounter/admin/SecurityConfig.kt
@@ -87,6 +87,9 @@ class SecurityConfig(
                 "$contextPath/actuator/health/**",
                 "$contextPath/actuator/info"
             ).authorizeHttpRequests { it.anyRequest().permitAll() }
+            // deepcode ignore DisablesCSRFProtection: probe chain serves only
+            // unauthenticated, read-only K8s health/info endpoints — no state
+            // change and no cookie session for a forged request to ride.
             .csrf { it.disable() }
         return http.build()
     }
@@ -99,6 +102,10 @@ class SecurityConfig(
             .securityMatcher("$contextPath/instances/**", "$contextPath/actuator/**")
             .authorizeHttpRequests { it.anyRequest().authenticated() }
             .httpBasic(withDefaults())
+            // deepcode ignore DisablesCSRFProtection: SBA clients (bc-data,
+            // bc-position, …) authenticate these paths with stateless HTTP
+            // Basic, not a browser cookie session. The interactive UI chain
+            // below retains CSRF via CookieCsrfTokenRepository.
             .csrf { it.disable() }
         return http.build()
     }

--- a/svc-agent/src/main/resources/static/chat.html
+++ b/svc-agent/src/main/resources/static/chat.html
@@ -636,9 +636,14 @@
     // DOM. `setHtmlSafe` is used everywhere that HTML needs to be injected —
     // never call .innerHTML directly on untrusted content.
     function setHtmlSafe(element, html) {
-        const clean = window.DOMPurify
-            ? DOMPurify.sanitize(html, { ADD_ATTR: ['target'] })
-            : html;
+        // If DOMPurify failed to load (e.g. the CDN is blocked), NEVER fall
+        // back to injecting the raw HTML — that reopens the XSS hole this
+        // function exists to close. Degrade to plain text instead.
+        if (!window.DOMPurify) {
+            element.textContent = html;
+            return;
+        }
+        const clean = DOMPurify.sanitize(html, { ADD_ATTR: ['target'] });
         // DOMPurify returns a sanitized string; parse it into a fragment and
         // append, so we don't need to touch innerHTML directly.
         const template = document.createElement('template');


### PR DESCRIPTION
Snyk SAST triage of svc-agent/svc-admin:
- chat.html setHtmlSafe fell back to raw-HTML injection when DOMPurify
  failed to load (CDN blocked) -> real DOM-XSS. Degrade to textContent
  instead. Snyk DOM-XSS 1 -> 0.
- svc-admin SecurityConfig: annotate the two by-design csrf.disable()
  chains (K8s probes; stateless HTTP-Basic client registration) with
  deepcode-ignore rationale. Interactive UI chain keeps CSRF via
  CookieCsrfTokenRepository.

Remaining Snyk SAST findings are analysed false positives:
- AgentController XSS: query is html-escaped; SSE is text/event-stream,
  not HTML; client sanitises via DOMPurify.
- TrnExportController CRLF: sanitizeFilename strips CR/LF.
- CSRF x3: stateless JWT/Basic chains, no cookie session.