### PR TITLE
fix(docker): apk upgrade base image to patch p11-kit/expat CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ ENV OTEL_LOGS_EXPORTER="none"
 
 WORKDIR /app
 
-RUN apk add --no-cache --virtual .build-deps curl && \
+# Patch OS packages in the base layer first. Temurin's published
+# 25-jre-alpine tag lags Alpine security bumps, so `apk upgrade` pulls the
+# fixed p11-kit (SNYK-ALPINE323-P11KIT-17486696, High) and expat
+# (SNYK-ALPINE323-EXPAT-17675120, Medium) now rather than waiting for the
+# upstream image rebuild. Propagates to every service via this shared base.
+RUN apk --no-cache upgrade && \
+    apk add --no-cache --virtual .build-deps curl && \
     curl -o /app/sentry-opentelemetry-agent-${SENTRY_VERSION}.jar -L \
       https://repo1.maven.org/maven2/io/sentry/sentry-opentelemetry-agent/${SENTRY_VERSION}/sentry-opentelemetry-agent-${SENTRY_VERSION}.jar && \
     apk del .build-deps


### PR DESCRIPTION
Snyk container scan of eclipse-temurin:25-jre-alpine flagged two OS-package
CVEs the upstream tag hasn't rebuilt for yet:
- p11-kit / p11-kit-trust 0.25.5-r2 -> 0.26.2-r0 (High, uninit pointer)
- expat/libexpat 2.8.1-r0 -> 2.8.2-r0 (Medium, use-after-free)

Add 'apk --no-cache upgrade' to the shared base Dockerfile so both are
patched at build time; fix propagates to all five services via the ghcr
base image. Sentry agent left at 8.40.0 — already aligned with the
gradle-forced SDK version, so no change needed here.