### PR TITLE
feat(auth): honour Boot actuator access properties in WebAuthFilterConfig

### DIFF
--- a/jar-auth/src/main/kotlin/com/beancounter/auth/server/WebAuthFilterConfig.kt
+++ b/jar-auth/src/main/kotlin/com/beancounter/auth/server/WebAuthFilterConfig.kt
@@ -4,11 +4,15 @@ import com.beancounter.auth.AuthConfig
 import com.beancounter.auth.OAuthConfig
 import com.beancounter.auth.TokenService
 import com.beancounter.auth.model.AuthConstants
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.EnumerablePropertySource
+import org.springframework.core.env.Environment
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -53,6 +57,40 @@ class WebAuthFilterConfig {
     @Value("\${cors.exposedHeaders:Authorization}")
     private lateinit var exposedHeaders: List<String>
 
+    @Autowired
+    private lateinit var environment: Environment
+
+    private val unrestricted = "unrestricted"
+
+    /**
+     * Honour Spring Boot's actuator access model. When
+     * `management.endpoints.access.default=unrestricted` the whole actuator
+     * surface is anonymous (local profile use); otherwise the ADMIN/SYSTEM
+     * rule stands, with per-endpoint `management.endpoint.<id>.access`
+     * overrides opening individual endpoints.
+     */
+    private fun actuatorDefaultUnrestricted(): Boolean =
+        unrestricted.equals(
+            environment.getProperty("management.endpoints.access.default"),
+            ignoreCase = true
+        )
+
+    private fun unrestrictedEndpointIds(): List<String> {
+        val configurable = environment as? ConfigurableEnvironment ?: return emptyList()
+        val accessKey = Regex("management\\.endpoint\\.([a-zA-Z0-9-]+)\\.access")
+        return configurable.propertySources
+            .filterIsInstance<EnumerablePropertySource<*>>()
+            .flatMap { it.propertyNames.asList() }
+            .mapNotNull { accessKey.matchEntire(it)?.groupValues?.get(1) }
+            .distinct()
+            .filter {
+                unrestricted.equals(
+                    environment.getProperty("management.endpoint.$it.access"),
+                    ignoreCase = true
+                )
+            }
+    }
+
     @Bean
     fun configureBcSecurity(http: HttpSecurity): SecurityFilterChain {
         val corsConfiguration = CorsConfiguration()
@@ -86,9 +124,16 @@ class WebAuthFilterConfig {
                         AuthConstants.SCOPE_SYSTEM,
                         AuthConstants.SCOPE_ADMIN
                     ) // Deny by default: only known, scoped callers
-                auth
-                    .requestMatchers("$actuatorPath/**")
-                    .hasAnyAuthority(AuthConstants.SCOPE_ADMIN, AuthConstants.SCOPE_SYSTEM) // Admin or System users
+                if (actuatorDefaultUnrestricted()) {
+                    auth.requestMatchers("$actuatorPath/**").permitAll()
+                } else {
+                    unrestrictedEndpointIds().forEach { id ->
+                        auth.requestMatchers("$actuatorPath/$id", "$actuatorPath/$id/**").permitAll()
+                    }
+                    auth
+                        .requestMatchers("$actuatorPath/**")
+                        .hasAnyAuthority(AuthConstants.SCOPE_ADMIN, AuthConstants.SCOPE_SYSTEM) // Admin or System users
+                }
                 auth.anyRequest().permitAll() //
             }.csrf { csrf ->
                 csrf.disable()

--- a/jar-auth/src/test/kotlin/com/beancounter/auth/ActuatorAccessTest.kt
+++ b/jar-auth/src/test/kotlin/com/beancounter/auth/ActuatorAccessTest.kt
@@ -1,0 +1,122 @@
+package com.beancounter.auth
+
+import com.beancounter.auth.model.AuthConstants
+import com.beancounter.auth.server.WebAuthFilterConfig
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.cache.CacheManager
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.WebApplicationContext
+
+/**
+ * Verifies WebAuthFilterConfig honours Spring Boot's actuator access
+ * properties (`management.endpoints.access.default` and per-endpoint
+ * `management.endpoint.<id>.access`) so application-local.yml can open
+ * actuator endpoints without code changes. Default remains secured:
+ * ADMIN/SYSTEM scope for everything except health/openapi/swagger.
+ */
+@RestController
+class FakeActuatorController {
+    @GetMapping("/actuator/health")
+    fun health(): String = "UP"
+
+    @GetMapping("/actuator/env")
+    fun env(): String = "env"
+
+    @GetMapping("/actuator/loggers")
+    fun loggers(): String = "loggers"
+}
+
+@TestConfiguration
+class ActuatorTestCacheConfig {
+    @Bean
+    fun cacheManager(): CacheManager = ConcurrentMapCacheManager()
+}
+
+abstract class ActuatorAccessBase {
+    @MockitoBean
+    lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    lateinit var context: WebApplicationContext
+
+    lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(springSecurity())
+                .build()
+    }
+
+    protected fun adminJwt() = jwt().authorities(SimpleGrantedAuthority(AuthConstants.SCOPE_ADMIN))
+}
+
+@EnableWebSecurity
+@WebMvcTest(FakeActuatorController::class, properties = ["auth.enabled=true"])
+@org.springframework.test.context.ContextConfiguration(
+    classes = [FakeActuatorController::class, WebAuthFilterConfig::class, ActuatorTestCacheConfig::class]
+)
+class ActuatorSecuredByDefaultTest : ActuatorAccessBase() {
+    @Test
+    fun `health is anonymous by default`() {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `actuator endpoints require a scoped token by default`() {
+        mockMvc.perform(get("/actuator/env")).andExpect(status().isUnauthorized)
+        mockMvc.perform(get("/actuator/env").with(adminJwt())).andExpect(status().isOk)
+    }
+}
+
+@EnableWebSecurity
+@WebMvcTest(
+    FakeActuatorController::class,
+    properties = ["auth.enabled=true", "management.endpoints.access.default=unrestricted"]
+)
+@org.springframework.test.context.ContextConfiguration(
+    classes = [FakeActuatorController::class, WebAuthFilterConfig::class, ActuatorTestCacheConfig::class]
+)
+class ActuatorDefaultUnrestrictedTest : ActuatorAccessBase() {
+    @Test
+    fun `access default unrestricted opens all actuator endpoints anonymously`() {
+        mockMvc.perform(get("/actuator/env")).andExpect(status().isOk)
+        mockMvc.perform(get("/actuator/loggers")).andExpect(status().isOk)
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk)
+    }
+}
+
+@EnableWebSecurity
+@WebMvcTest(
+    FakeActuatorController::class,
+    properties = ["auth.enabled=true", "management.endpoint.env.access=unrestricted"]
+)
+@org.springframework.test.context.ContextConfiguration(
+    classes = [FakeActuatorController::class, WebAuthFilterConfig::class, ActuatorTestCacheConfig::class]
+)
+class ActuatorPerEndpointUnrestrictedTest : ActuatorAccessBase() {
+    @Test
+    fun `unrestricted endpoint is anonymous while the rest stay secured`() {
+        mockMvc.perform(get("/actuator/env")).andExpect(status().isOk)
+        mockMvc.perform(get("/actuator/loggers")).andExpect(status().isUnauthorized)
+    }
+}


### PR DESCRIPTION
## What
`WebAuthFilterConfig` now respects Spring Boot's actuator access properties instead of unconditionally requiring ADMIN/SYSTEM scope for `/actuator/**`:

- `management.endpoints.access.default: unrestricted` → whole actuator surface anonymous (intended for `application-local.yml`)
- `management.endpoint.<id>.access: unrestricted` → opens just that endpoint
- Default unchanged: health/openapi/swagger-ui anonymous, everything else ADMIN/SYSTEM — kauri's public management NodePorts stay locked.

## Tests
`ActuatorAccessTest`: secured-by-default baseline, default-unrestricted, per-endpoint-unrestricted (MockMvc against the real filter chain). Full testSmart + formatKotlin + lintKotlin green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)