### PR TITLE
chore(fantail): opt the JVM services into hot reload

### DIFF
--- a/svc-data/fantail.yaml
+++ b/svc-data/fantail.yaml
@@ -7,6 +7,13 @@ health: http://localhost:9511/actuator/health
 env:                             # instance offsets reach the JVM via env
   SERVER_PORT: "${self.port}"
   MANAGEMENT_SERVER_PORT: "${self.health_port}"
+# `fantail start` launches this as a plain java process (not bootRun) so the
+# gradle daemon stays free to recompile while it runs, and `fantail reload`
+# can recompile + restart the app context via devtools in ~10s. Changes to
+# jar-common/jar-auth still need a full restart — they load as jars.
+reload:
+  gradle: ":svc-data"
+
 requires:
   - tcp: localhost:5432          # postgres (db: bc)
   - env: AUTH0_CLIENT_SECRET     # auth.client-secret in application-local.yml; M2M dead without

--- a/svc-event/fantail.yaml
+++ b/svc-event/fantail.yaml
@@ -7,6 +7,13 @@ health: http://localhost:9521/actuator/health
 env:                             # instance offsets reach the JVM via env
   SERVER_PORT: "${self.port}"
   MANAGEMENT_SERVER_PORT: "${self.health_port}"
+# `fantail start` launches this as a plain java process (not bootRun) so the
+# gradle daemon stays free to recompile while it runs, and `fantail reload`
+# can recompile + restart the app context via devtools in ~10s. Changes to
+# jar-common/jar-auth still need a full restart — they load as jars.
+reload:
+  gradle: ":svc-event"
+
 requires:
   - tcp: localhost:5432                # postgres (db: ev)
 wants:

--- a/svc-position/fantail.yaml
+++ b/svc-position/fantail.yaml
@@ -7,6 +7,13 @@ health: http://localhost:9501/actuator/health
 env:                             # instance offsets reach the JVM via env
   SERVER_PORT: "${self.port}"
   MANAGEMENT_SERVER_PORT: "${self.health_port}"
+# `fantail start` launches this as a plain java process (not bootRun) so the
+# gradle daemon stays free to recompile while it runs, and `fantail reload`
+# can recompile + restart the app context via devtools in ~10s. Changes to
+# jar-common/jar-auth still need a full restart — they load as jars.
+reload:
+  gradle: ":svc-position"
+
 requires:
   - tcp: localhost:5432          # postgres (db: position)
 wants:


### PR DESCRIPTION
Opts svc-data, svc-position and svc-event into fantail's new hot reload
(monowai/fantail `feat(reload)`). Config only — no source, build or runtime
change to the services themselves.

With a `reload:` block, `fantail start <svc>` launches the service as a plain
`java -cp @argfile <mainClass>` process instead of `./gradlew bootRun`. That
matters because bootRun holds the Gradle project lock for the life of the
service, so nothing can recompile beside it. With the daemon free,
`fantail reload <svc>` recompiles and touches a spring-boot-devtools trigger
file, restarting the app context in place.

Measured on svc-data: **~10s** (3.8s incremental Kotlin compile + 5.6s context
restart, same pid) against ~45s for a cold boot.

`spring-boot-devtools` is resolved by fantail at each project's own Boot
version and added to the **launch classpath only**, via a Gradle init script
applied with `-I`. Nothing is added to this repo's build files, and it cannot
reach a `bootJar`. `fantail start --no-dev` still runs the plain `command:`.

Caveats captured in the yaml comments and in bc-claude/FANTAIL.md:

- `jar-common` / `jar-auth` changes need a full restart — they load as jars in
  the base classloader, which devtools does not replace.
- Flyway re-runs on each reload (idempotent; a migration that fails mid-reload
  wants a restart, not a retry).

Not run: `testAll` / `formatKotlin` / `lintKotlin`. The diff is three YAML
files that no Gradle task reads; CI covers the repo regardless.
