### PR TITLE
fix(prices): keep unit-price precision through valuation

### DIFF
--- a/jar-common/src/test/kotlin/com/beancounter/common/TestPriceData.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/TestPriceData.kt
@@ -64,23 +64,13 @@ class TestPriceData {
                 marketData,
                 two
             )
-        assertThat(withFx)
-            .hasFieldOrPropertyWithValue(
-                P_OPEN,
-                BigDecimal("4.00")
-            ).hasFieldOrPropertyWithValue(
-                P_CLOSE,
-                BigDecimal("4.00")
-            ).hasFieldOrPropertyWithValue(
-                P_PREVIOUS_CLOSE,
-                BigDecimal("2.00")
-            ).hasFieldOrPropertyWithValue(
-                P_CHANGE,
-                BigDecimal("2.00")
-            ).hasFieldOrPropertyWithValue(
-                P_CHANGE_PERCENT,
-                BigDecimal("0.01")
-            )
+        // Converted prices are compared numerically - a conversion keeps whatever scale
+        // the multiplication yields, so 4.000 and 4.00 are the same price.
+        assertThat(withFx.open).isEqualByComparingTo(BigDecimal("4.00"))
+        assertThat(withFx.close).isEqualByComparingTo(BigDecimal("4.00"))
+        assertThat(withFx.previousClose).isEqualByComparingTo(BigDecimal("2.00"))
+        assertThat(withFx.change).isEqualByComparingTo(BigDecimal("2.00"))
+        assertThat(withFx.changePercent).isEqualByComparingTo(BigDecimal("0.01"))
     }
 
     @Test
@@ -116,20 +106,46 @@ class TestPriceData {
                 marketData,
                 two
             )
-        assertThat(withFx)
-            .hasFieldOrPropertyWithValue(
-                P_PREVIOUS_CLOSE,
-                BigDecimal("81.84")
-            ).hasFieldOrPropertyWithValue(
-                P_CLOSE,
-                BigDecimal("82.70")
-            ).hasFieldOrPropertyWithValue(
-                P_CHANGE,
-                BigDecimal("0.86")
-            ).hasFieldOrPropertyWithValue(
-                P_CHANGE_PERCENT,
-                BigDecimal("0.0104")
+        assertThat(withFx.previousClose).isEqualByComparingTo(BigDecimal("81.84"))
+        assertThat(withFx.close).isEqualByComparingTo(BigDecimal("82.70"))
+        assertThat(withFx.change).isEqualByComparingTo(BigDecimal("0.86"))
+        assertThat(withFx.changePercent).isEqualByComparingTo(BigDecimal("0.0104"))
+    }
+
+    @Test
+    fun is_UnitPricePrecisionRetained() {
+        // Unitised funds price beyond cents. Rounding a price to the money scale hides
+        // sub-cent edits and overstates market value, which is computed from this close.
+        val marketData =
+            MarketData(
+                asset,
+                previousClose = BigDecimal("1.5900"),
+                open = BigDecimal("1.5968"),
+                close = BigDecimal("1.5968")
             )
+
+        assertThat(
+            PriceData.of(
+                marketData,
+                BigDecimal.ONE
+            )
+        ).hasFieldOrPropertyWithValue(
+            P_CLOSE,
+            BigDecimal("1.5968")
+        ).hasFieldOrPropertyWithValue(
+            P_OPEN,
+            BigDecimal("1.5968")
+        )
+
+        assertThat(
+            PriceData.of(
+                marketData,
+                BigDecimal("0.5887")
+            )
+        ).hasFieldOrPropertyWithValue(
+            P_CLOSE,
+            BigDecimal("0.94003616")
+        )
     }
 
     @Test

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/PriceData.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/PriceData.kt
@@ -2,7 +2,7 @@ package com.beancounter.common.model
 
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.MathUtils
-import com.beancounter.common.utils.MathUtils.Companion.multiplyAbs
+import com.beancounter.common.utils.MathUtils.Companion.multiplyPrice
 import com.beancounter.common.utils.NumberUtils
 import com.fasterxml.jackson.annotation.JsonFormat
 import java.math.BigDecimal
@@ -40,27 +40,27 @@ data class PriceData(
             val result =
                 PriceData(
                     mktData.priceDate,
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.open,
                         rate
                     ),
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.close,
                         rate
                     ),
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.low,
                         rate
                     ),
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.high,
                         rate
                     ),
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.previousClose,
                         rate
                     ),
-                    multiplyAbs(
+                    multiplyPrice(
                         mktData.change,
                         rate
                     ),
@@ -73,7 +73,7 @@ data class PriceData(
             if (hasValidConversionRate && hasPriceData) {
                 // For currency conversion, we need to convert the change amount
                 // but keep the changePercent the same (percentage doesn't change with currency)
-                result.change = multiplyAbs(money = mktData.change, rate = rate)
+                result.change = multiplyPrice(price = mktData.change, rate = rate)
                 // changePercent remains the same as it's already a percentage
             }
             return result

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/utils/MathUtils.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/utils/MathUtils.kt
@@ -13,11 +13,17 @@ import java.text.ParseException
 class MathUtils private constructor() {
     companion object {
         private const val MONEY_SCALE = 2
+
+        /**
+         * Unit prices are not money amounts - unitised funds quote well beyond cents,
+         * so prices are capped rather than rounded to [MONEY_SCALE].
+         */
+        private const val PRICE_SCALE = 8
         private val mathContext = MathContext(10)
         private val numberUtils = NumberUtils()
 
         // Delegate to specialized utilities
-        private val calculationUtils = CalculationUtils(MONEY_SCALE, numberUtils)
+        private val calculationUtils = CalculationUtils(MONEY_SCALE, PRICE_SCALE, numberUtils)
         private val parsingUtils = ParsingUtils()
         private val validationUtils = ValidationUtils()
 
@@ -46,6 +52,16 @@ class MathUtils private constructor() {
             rate: BigDecimal?,
             moneyScale: Int = MONEY_SCALE
         ): BigDecimal = calculationUtils.multiplyAbs(money, rate, moneyScale)
+
+        /**
+         * Convert a unit price, retaining its precision. Unlike [multiplyAbs] the result
+         * keeps the scale the multiplication produces, capped at [PRICE_SCALE].
+         */
+        @JvmStatic
+        fun multiplyPrice(
+            price: BigDecimal?,
+            rate: BigDecimal?
+        ): BigDecimal = calculationUtils.multiplyPrice(price, rate)
 
         @JvmStatic
         fun add(
@@ -85,6 +101,7 @@ class MathUtils private constructor() {
  */
 private class CalculationUtils(
     private val moneyScale: Int,
+    private val priceScale: Int,
     private val numberUtils: NumberUtils
 ) {
     fun divide(
@@ -117,6 +134,25 @@ private class CalculationUtils(
             return BigDecimal.ZERO
         }
         return requireNotNull(money).multiply(rate).abs().setScale(moneyScale, RoundingMode.HALF_UP)
+    }
+
+    fun multiplyPrice(
+        price: BigDecimal?,
+        rate: BigDecimal?
+    ): BigDecimal {
+        if (numberUtils.isUnset(rate) || numberUtils.isUnset(price)) {
+            return BigDecimal.ZERO
+        }
+        val unitPrice = requireNotNull(price).abs()
+        if (BigDecimal.ONE.compareTo(rate) == 0) {
+            return unitPrice
+        }
+        val converted = unitPrice.multiply(rate).abs()
+        return if (converted.scale() > priceScale) {
+            converted.setScale(priceScale, RoundingMode.HALF_UP)
+        } else {
+            converted
+        }
     }
 
     fun add(

--- a/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/valuation/MarketValue.kt
@@ -102,8 +102,12 @@ class MarketValue(
 
             if (!isCash && moneyValues.priceData.previousClose.signum() != 0) {
                 // Only calculate gainOnDay when there's valid previous close data
+                // Prices carry more precision than cents, so the money result is rounded.
                 moneyValues.gainOnDay =
-                    (close.subtract(moneyValues.priceData.previousClose)).multiply(total)
+                    multiply(
+                        close.subtract(moneyValues.priceData.previousClose),
+                        total
+                    ) ?: BigDecimal.ZERO
             }
         }
         if (isCash) {

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/FxValuationMvcTests.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/FxValuationMvcTests.kt
@@ -202,24 +202,24 @@ internal class FxValuationMvcTests {
 
         // We need to have a Quantity in order to get the price, so create a position
         val positions = getValuedPositions(asset)
-        assertThat(
+        val moneyValues =
             positions.getOrCreate(asset).getMoneyValues(
                 Position.In.TRADE,
                 asset.market.currency
             )
-        ).hasFieldOrPropertyWithValue(
-            "unrealisedGain",
-            BigDecimal("8000.00")
-        ).hasFieldOrPropertyWithValue(
-            "priceData.close",
-            BigDecimal("100.00")
-        ).hasFieldOrPropertyWithValue(
-            "marketValue",
-            BigDecimal("10000.00")
-        ).hasFieldOrPropertyWithValue(
-            "totalGain",
-            BigDecimal("8000.00")
-        )
+        assertThat(moneyValues)
+            .hasFieldOrPropertyWithValue(
+                "unrealisedGain",
+                BigDecimal("8000.00")
+            ).hasFieldOrPropertyWithValue(
+                "marketValue",
+                BigDecimal("10000.00")
+            ).hasFieldOrPropertyWithValue(
+                "totalGain",
+                BigDecimal("8000.00")
+            )
+        // The price keeps the precision it was quoted at, so compare it numerically.
+        assertThat(moneyValues.priceData.close).isEqualByComparingTo(BigDecimal("100.00"))
     }
 
     @Test

--- a/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/valuation/MarketValueTest.kt
@@ -53,6 +53,48 @@ internal class MarketValueTest {
     private val simpleRate = BigDecimal("0.20")
 
     @Test
+    fun `should value a unitised price without rounding it to cents`() {
+        val positions = Positions(portfolio)
+        val position =
+            buyBehaviour.accumulate(
+                Trn(
+                    trnType = TrnType.BUY,
+                    asset = asset,
+                    quantity = hundred,
+                    tradeAmount = oneHundred,
+                    tradePortfolioRate = simpleRate,
+                    portfolio = portfolio
+                ),
+                positions
+            )
+        val marketData =
+            MarketData(
+                asset,
+                close = BigDecimal("1.5968")
+            )
+
+        MarketValue(Gains()).value(
+            positions,
+            marketData,
+            getRates(
+                positions.portfolio,
+                asset,
+                simpleRate
+            )
+        )
+
+        val tradeValues =
+            position.getMoneyValues(
+                Position.In.TRADE,
+                position.asset.market.currency
+            )
+        // A fund priced to four decimals must survive valuation intact - rounding the
+        // price to cents hides sub-cent edits and overstates the holding.
+        assertThat(tradeValues.priceData.close).isEqualByComparingTo(BigDecimal("1.5968"))
+        assertThat(tradeValues.marketValue).isEqualByComparingTo(BigDecimal("159.68"))
+    }
+
+    @Test
     fun `should calculate market value from behaviour`() {
         val positions = Positions(portfolio)
         val position =


### PR DESCRIPTION
## Problem

`PriceData.of` rounded every price to the money scale (2dp), so a unitised fund quoted at `1.5968` was surfaced as `1.60`. Two consequences:

- Editing such a price by less than half a cent appeared to do nothing — the holdings price column never changed.
- `MarketValue` computes `marketValue = priceData.close × quantity`, so the value was derived from the rounded price and came out high.

Rounding happened even when no FX conversion was involved (rate of 1).

## Change

- `MathUtils.multiplyPrice(price, rate)` — new. Returns the price unchanged when the rate is 1, otherwise multiplies and keeps the scale the multiplication yields, capped at a new `PRICE_SCALE` of 8. `MONEY_SCALE` is untouched, and `multiplyAbs` keeps its existing money semantics for every other caller.
- `PriceData.of` converts `open/close/low/high/previousClose/change` through `multiplyPrice`.
- `MarketValue.gainOnDay` now rounds through `MathUtils.multiply` (money scale). It was previously unrounded, which only showed up once prices carried more precision — `marketValue` alongside it was already rounded this way.

## Verification

Unit: `TestPriceData.is_UnitPricePrecisionRetained` (red first: expected `1.5968`, got `1.60`) and `MarketValueTest.should value a unitised price without rounding it to cents`.

End-to-end on localhost, same private fund and price in both builds, 1000 units held:

| build | `priceData.close` | `marketValue` |
|---|---|---|
| before | `1.60` | `1600.00` |
| after | `1.596800` | `1596.80` |

`./gradlew testAll` green, `formatKotlin` / `lintKotlin` clean, `ocr review` no comments.

## Reviewer note

Three legacy assertions compared BigDecimals with scale-sensitive equality (`100.0` vs `100.00`, `4.000` vs `4.00`) and now compare numerically via `isEqualByComparingTo`. No expected value changed — only the representation.

Displayed market values will shift slightly for any asset whose price carries more than two decimals. That is the point of the change, but it is worth knowing before this ships.
