### PR TITLE
fix(prices): invalidate cached valuations on a private price write

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -105,9 +105,14 @@ class PriceService(
     /**
      * User-entered revaluation of a PRIVATE market asset (real estate, art, ...).
      *
-     * Emits the same PRICE cache-invalidation event as the provider path in [handle]
-     * so svc-position drops its cached `performance_snapshot` for [date]; without it
-     * a re-valued private asset kept being charted at its previous close.
+     * Emits a cache-invalidation event so svc-position drops its cached
+     * `performance_snapshot`; without it a re-valued private asset kept being charted
+     * at its previous close.
+     *
+     * The event sweeps forward from [date] rather than invalidating that day alone.
+     * A private asset has no daily feed - [PrivateMarketDataProvider] carries the
+     * nearest price on-or-before a date forward - so correcting a back-dated price
+     * changes every valuation after it, not just its own day.
      */
     private fun handlePrivateMarketPrice(
         asset: Asset,
@@ -131,7 +136,7 @@ class PriceService(
                 )
             }
         val saved = marketDataRepo.save(marketData)
-        cacheInvalidationProducer?.sendPriceEvent(date)
+        cacheInvalidationProducer?.sendPriceHistoryEvent(asset.id, date)
         return Optional.of(saved)
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceService.kt
@@ -102,6 +102,13 @@ class PriceService(
         return existing
     }
 
+    /**
+     * User-entered revaluation of a PRIVATE market asset (real estate, art, ...).
+     *
+     * Emits the same PRICE cache-invalidation event as the provider path in [handle]
+     * so svc-position drops its cached `performance_snapshot` for [date]; without it
+     * a re-valued private asset kept being charted at its previous close.
+     */
     private fun handlePrivateMarketPrice(
         asset: Asset,
         closePrice: BigDecimal,
@@ -123,7 +130,9 @@ class PriceService(
                     source = "USER"
                 )
             }
-        return Optional.of(marketDataRepo.save(marketData))
+        val saved = marketDataRepo.save(marketData)
+        cacheInvalidationProducer?.sendPriceEvent(date)
+        return Optional.of(saved)
     }
 
     /**

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
@@ -74,8 +74,11 @@ class PriceServiceTest {
             )
 
         assertThat(result).isPresent
+        val assetCaptor = argumentCaptor<String>()
         val dateCaptor = argumentCaptor<LocalDate>()
-        verify(cacheInvalidationProducer).sendPriceEvent(dateCaptor.capture())
+        verify(cacheInvalidationProducer)
+            .sendPriceHistoryEvent(assetCaptor.capture(), dateCaptor.capture())
+        assertThat(assetCaptor.firstValue).isEqualTo(privateAsset.id)
         assertThat(dateCaptor.firstValue).isEqualTo(priceDate)
     }
 
@@ -102,8 +105,11 @@ class PriceServiceTest {
 
         assertThat(result).isPresent
         assertThat(result.get().close).isEqualByComparingTo(BigDecimal("250000.00"))
+        val assetCaptor = argumentCaptor<String>()
         val dateCaptor = argumentCaptor<LocalDate>()
-        verify(cacheInvalidationProducer).sendPriceEvent(dateCaptor.capture())
+        verify(cacheInvalidationProducer)
+            .sendPriceHistoryEvent(assetCaptor.capture(), dateCaptor.capture())
+        assertThat(assetCaptor.firstValue).isEqualTo(privateAsset.id)
         assertThat(dateCaptor.firstValue).isEqualTo(priceDate)
     }
 
@@ -118,7 +124,7 @@ class PriceServiceTest {
 
         assertThat(result).isEmpty
         verify(marketDataRepo, never()).save(any<MarketData>())
-        verify(cacheInvalidationProducer, never()).sendPriceEvent(any())
+        verify(cacheInvalidationProducer, never()).sendPriceHistoryEvent(any(), any())
     }
 
     @Test

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/PriceServiceTest.kt
@@ -2,12 +2,15 @@ package com.beancounter.marketdata.providers
 
 import com.beancounter.common.contracts.PriceResponse
 import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
 import com.beancounter.common.model.MarketData
 import com.beancounter.common.utils.CashUtils
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.event.EventProducer
 import com.beancounter.marketdata.providers.alpha.AlphaEventService
+import com.beancounter.marketdata.providers.custom.PrivateMarketDataProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -19,6 +22,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.Optional
@@ -31,17 +37,88 @@ class PriceServiceTest {
     private lateinit var marketDataRepo: MarketDataRepo
     private lateinit var cashUtils: CashUtils
     private lateinit var eventProducer: EventProducer
+    private lateinit var cacheInvalidationProducer: CacheInvalidationProducer
     private val assetFinder = mock(AssetFinder::class.java)
     private val asset = Asset(code = "1", market = NASDAQ)
+    private val privateAsset =
+        Asset(
+            code = "HOUSE",
+            market = Market(PrivateMarketDataProvider.ID)
+        )
 
     @BeforeEach
     fun setUp() {
         marketDataRepo = mock(MarketDataRepo::class.java)
         cashUtils = mock(CashUtils::class.java)
         eventProducer = mock(EventProducer::class.java)
+        cacheInvalidationProducer = mock(CacheInvalidationProducer::class.java)
         priceService = PriceService(marketDataRepo, cashUtils, assetFinder)
         priceService.setEventWriter(eventProducer)
+        priceService.setCacheInvalidationProducer(cacheInvalidationProducer)
         `when`(assetFinder.find(asset.id)).thenReturn(asset)
+        `when`(assetFinder.find(privateAsset.id)).thenReturn(privateAsset)
+    }
+
+    @Test
+    fun `should invalidate the price cache when a new private market price is written`() {
+        val priceDate = LocalDate.of(2026, 3, 31)
+        `when`(marketDataRepo.findByAssetIdAndPriceDate(privateAsset.id, priceDate))
+            .thenReturn(Optional.empty())
+        `when`(marketDataRepo.save(any<MarketData>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            priceService.getMarketData(
+                privateAsset.id,
+                priceDate,
+                BigDecimal("250000.00")
+            )
+
+        assertThat(result).isPresent
+        val dateCaptor = argumentCaptor<LocalDate>()
+        verify(cacheInvalidationProducer).sendPriceEvent(dateCaptor.capture())
+        assertThat(dateCaptor.firstValue).isEqualTo(priceDate)
+    }
+
+    @Test
+    fun `should invalidate the price cache when an existing private market price is revalued`() {
+        val priceDate = LocalDate.of(2026, 3, 31)
+        val existing =
+            MarketData(
+                asset = privateAsset,
+                priceDate = priceDate,
+                close = BigDecimal("200000.00"),
+                source = "USER"
+            )
+        `when`(marketDataRepo.findByAssetIdAndPriceDate(privateAsset.id, priceDate))
+            .thenReturn(Optional.of(existing))
+        `when`(marketDataRepo.save(any<MarketData>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            priceService.getMarketData(
+                privateAsset.id,
+                priceDate,
+                BigDecimal("250000.00")
+            )
+
+        assertThat(result).isPresent
+        assertThat(result.get().close).isEqualByComparingTo(BigDecimal("250000.00"))
+        val dateCaptor = argumentCaptor<LocalDate>()
+        verify(cacheInvalidationProducer).sendPriceEvent(dateCaptor.capture())
+        assertThat(dateCaptor.firstValue).isEqualTo(priceDate)
+    }
+
+    @Test
+    fun `should not invalidate the price cache when a private market read writes nothing`() {
+        val priceDate = LocalDate.of(2026, 3, 31)
+        `when`(marketDataRepo.findByAssetIdAndPriceDate(privateAsset.id, priceDate))
+            .thenReturn(Optional.empty())
+
+        // No closePrice supplied — this is a plain read, not a revaluation.
+        val result = priceService.getMarketData(privateAsset.id, priceDate)
+
+        assertThat(result).isEmpty
+        verify(marketDataRepo, never()).save(any<MarketData>())
+        verify(cacheInvalidationProducer, never()).sendPriceEvent(any())
     }
 
     @Test


### PR DESCRIPTION
## Problem

`PriceService.handlePrivateMarketPrice` saved the row and returned without emitting anything, while the provider path in `handle` emits a cache-invalidation event. Setting a price on a private asset therefore never invalidated svc-position's `performance_snapshot`, so performance and growth views kept valuing that date with the old price.

## Change

Emit after a successful save, using the forward-sweeping event:

```kotlin
val saved = marketDataRepo.save(marketData)
cacheInvalidationProducer?.sendPriceHistoryEvent(asset.id, date)
```

`PRICE` maps to `cacheService.invalidateOnDate` — that single day. `PRICE_HISTORY` maps to `invalidateFromDate` (`CacheInvalidationConsumer.kt:41-53`). A private asset has no daily feed: `PrivateMarketDataProvider` carries the nearest price on-or-before a date forward, so correcting a back-dated price changes every valuation after it, not just its own day. Private price histories are typically sparse — a handful of points a year — which makes the forward sweep the common case rather than the exotic one.

## Tests

`PriceServiceTest`, three cases, red before the change:

- new private price written → event emitted
- existing private price revalued → event emitted
- plain read with no `closePrice` → nothing saved, nothing emitted

Assertions capture the asset id and date rather than only asserting the call happened.

`./gradlew testAll` green, `formatKotlin` / `lintKotlin` clean, `ocr review` no comments.
