### PR TITLE
fix(agent): drop coverage-narration preamble from AI answers

### DIFF
--- a/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/DomainSystemPrompts.kt
@@ -56,6 +56,13 @@ object DomainSystemPrompts {
           Bullets/short paragraphs are still the default; a table is fine
           when it genuinely compares things — keep it to 4 columns or
           fewer with short headers. Never dump raw tool output.
+        - **No preamble.** Open with the substance — a heading, the
+          sentiment line, or the first bullet. Never a lead-in sentence
+          restating the question, narrating what you are about to do, or
+          announcing that live data was unavailable ("No live news
+          coverage is available for X...", "Here's a summary instead").
+          A data caveat belongs as a short labelled line under the first
+          heading, not above it.
         - **Don't repeat what's on screen** — add analysis/outliers/
           observations instead of re-listing visible rows.
         - **Conclusions only, no workings.** Do arithmetic (weighted

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/tools/NewsTools.kt
@@ -96,7 +96,9 @@ class NewsTools(
                 "retail_wholesale, technology"
         const val NO_COVERAGE_MESSAGE =
             "No live news coverage available for this ticker. This is common for " +
-                "non-US listings. Provide a general-knowledge summary instead — do not retry."
+                "non-US listings. Provide a general-knowledge summary instead — do not retry. " +
+                "Do not announce the missing coverage: start the answer with the heading and " +
+                "carry the caveat as a short labelled line beneath it."
 
         const val MARKET_NEWS_DESC =
             "Get market-wide or sector-wide news and sentiment via index/sector proxies — the " +

--- a/svc-agent/src/test/kotlin/com/beancounter/agent/DomainSystemPromptsTest.kt
+++ b/svc-agent/src/test/kotlin/com/beancounter/agent/DomainSystemPromptsTest.kt
@@ -1,0 +1,38 @@
+package com.beancounter.agent
+
+import com.beancounter.agent.tools.NewsTools
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the shared output invariants that every domain prompt inherits.
+ *
+ * The no-preamble rule exists because the News & Sentiment popup renders the
+ * raw markdown in a narrow side panel — a "No live news coverage is available
+ * for X ... here's a summary instead" lead-in consumed the whole first screen
+ * before any content appeared.
+ */
+class DomainSystemPromptsTest {
+    private val allPrompts =
+        listOf(
+            DomainSystemPrompts.GENERAL,
+            DomainSystemPrompts.WEALTH,
+            DomainSystemPrompts.NEWS_SENTIMENT,
+            DomainSystemPrompts.ASSET_REVIEW,
+            DomainSystemPrompts.ASSET,
+            DomainSystemPrompts.INDEPENDENCE,
+            DomainSystemPrompts.REBALANCE
+        )
+
+    @Test
+    fun `every domain prompt forbids a lead-in preamble`() {
+        assertThat(allPrompts)
+            .allSatisfy { prompt -> assertThat(prompt).contains("No preamble") }
+    }
+
+    @Test
+    fun `no-coverage tool message tells the model not to narrate the fallback`() {
+        assertThat(NewsTools.NO_COVERAGE_MESSAGE)
+            .contains("Do not announce")
+    }
+}


### PR DESCRIPTION
Domain prompts allowed a lead-in sentence before the first heading. On
News & Sentiment the model opened with "No live news coverage is
available for X ... here's a general-knowledge summary instead", which
filled the popup's first screen before any content.

PREAMBLE now bans a lead-in outright and places any data caveat as a
short labelled line under the first heading; the getNews no_coverage
tool message carries the same instruction.