### PR TITLE
fix(classification): resume-aware ETF refresh, honest failure reporting

### DIFF
--- a/jar-contracts/src/main/kotlin/com/beancounter/common/contracts/ClassificationContracts.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/contracts/ClassificationContracts.kt
@@ -52,12 +52,23 @@ data class AssetHoldingsResponse(
 ) : Payload<List<AssetHolding>>
 
 /**
- * Result of a backfill operation.
+ * Result of a backfill/refresh operation.
+ *
+ * @param processed count of assets successfully enriched (data was written)
+ * @param errors count of assets where enrichment failed (exception or provider error)
+ * @param total full candidate population considered for this run
+ * @param noData count of assets where the provider responded fine but had nothing for this asset
+ * @param rateLimited count of assets skipped because provider quota/rate limit was hit
+ * @param skipped count of assets not attempted this run (still within the staleness window, or
+ *                beyond the batch limit)
  */
 data class BackfillResult(
     val processed: Int = 0,
     val errors: Int = 0,
-    val total: Int = 0
+    val total: Int = 0,
+    val noData: Int = 0,
+    val rateLimited: Int = 0,
+    val skipped: Int = 0
 )
 
 /**

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/Asset.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/Asset.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.Transient
 import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
 
 /**
  * Persistent representation of an instrument traded on a market.
@@ -58,7 +59,14 @@ data class Asset(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     var industry: String? = null,
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    var expectedReturnRate: Double? = null
+    var expectedReturnRate: Double? = null,
+    /**
+     * Date this asset's sector/industry classification (or, for ETFs, its sector exposures) was
+     * last *attempted*. Drives resume-aware classification refresh — see
+     * `ClassificationRefreshService`. Not part of the public API surface consumed by bc-view.
+     */
+    @JsonIgnore
+    var classificationCheckedAt: LocalDate? = null
 ) {
     companion object {
         @JvmStatic

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.model.Asset
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 import java.util.Optional
 import java.util.stream.Stream
 
@@ -149,6 +150,40 @@ interface AssetRepository : JpaRepository<Asset, String> {
             "AND a.code IS NOT NULL AND a.code <> ''"
     )
     fun findActiveEquities(): List<Asset>
+
+    /**
+     * Find active ETF assets *due* for a classification refresh: never checked, or last checked
+     * before [cutoff]. Ordered so never-checked assets (NULL) and the longest-stale come first -
+     * this is what makes the refresh resume-aware instead of re-hammering the same head of the
+     * list every run. See `ClassificationRefreshService`.
+     */
+    @Query(
+        "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
+            "WHERE a.status = com.beancounter.common.model.Status.Active " +
+            "AND UPPER(a.category) IN ('ETF', 'EXCHANGE TRADED FUND') " +
+            "AND a.code IS NOT NULL AND a.code <> '' " +
+            "AND (a.classificationCheckedAt IS NULL OR a.classificationCheckedAt < :cutoff) " +
+            "ORDER BY a.classificationCheckedAt ASC NULLS FIRST"
+    )
+    fun findEtfsDueForClassification(
+        @Param("cutoff") cutoff: LocalDate
+    ): List<Asset>
+
+    /**
+     * Find active Equity assets *due* for a classification refresh. Mirrors
+     * [findEtfsDueForClassification] for the equity category set.
+     */
+    @Query(
+        "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
+            "WHERE a.status = com.beancounter.common.model.Status.Active " +
+            "AND UPPER(a.category) IN ('EQUITY', 'COMMON STOCK') " +
+            "AND a.code IS NOT NULL AND a.code <> '' " +
+            "AND (a.classificationCheckedAt IS NULL OR a.classificationCheckedAt < :cutoff) " +
+            "ORDER BY a.classificationCheckedAt ASC NULLS FIRST"
+    )
+    fun findEquitiesDueForClassification(
+        @Param("cutoff") cutoff: LocalDate
+    ): List<Asset>
 
     fun countByAccountingTypeId(id: String): Long
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
@@ -48,15 +48,14 @@ class AlphaClassificationEnricher(
     override fun isEquity(asset: Asset): Boolean = asset.category.uppercase() in EQUITY_CATEGORIES
 
     /**
-     * Enrich an asset with classification data.
-     * Returns true if enrichment was successful.
+     * Enrich an asset with classification data. See [EnrichmentResult].
      */
-    override fun enrichClassification(asset: Asset): Boolean =
+    override fun enrichClassification(asset: Asset): EnrichmentResult =
         try {
             when {
                 isEquity(asset) -> enrichEquity(asset)
                 isEtf(asset) -> enrichEtf(asset)
-                else -> false
+                else -> EnrichmentResult.NO_DATA
             }
         } catch (
             @Suppress("TooGenericExceptionCaught")
@@ -64,23 +63,28 @@ class AlphaClassificationEnricher(
         ) {
             // Gracefully handle API/parsing failures without propagating
             log.warn("Failed to enrich classification for ${asset.code}: ${e.message}")
-            false
+            EnrichmentResult.FAILED
         }
 
-    private fun enrichEquity(asset: Asset): Boolean {
+    private fun enrichEquity(asset: Asset): EnrichmentResult {
         val symbol = alphaConfig.getPriceCode(asset)
         val response = alphaProxy.getOverview(symbol, apiKey)
 
+        if (isRateLimited(response)) {
+            log.warn("AlphaVantage rate limit hit while enriching $symbol")
+            return EnrichmentResult.RATE_LIMITED
+        }
+
         if (response.isBlank() || response.contains("Error")) {
             log.debug("No overview data for $symbol")
-            return false
+            return EnrichmentResult.FAILED
         }
 
         val overview = objectMapper.readValue(response, AlphaOverviewResponse::class.java)
 
         if (overview.sector.isNullOrBlank()) {
             log.debug("No sector in overview for $symbol")
-            return false
+            return EnrichmentResult.NO_DATA
         }
 
         val standard = classificationService.getAlphaStandard()
@@ -121,16 +125,21 @@ class AlphaClassificationEnricher(
         }
 
         log.info("Classified ${asset.code} as ${overview.sector} / ${overview.industry ?: "N/A"}")
-        return true
+        return EnrichmentResult.ENRICHED
     }
 
-    private fun enrichEtf(asset: Asset): Boolean {
+    private fun enrichEtf(asset: Asset): EnrichmentResult {
         val symbol = alphaConfig.getPriceCode(asset)
         val response = alphaProxy.getEtfProfile(symbol, apiKey)
 
+        if (isRateLimited(response)) {
+            log.warn("AlphaVantage rate limit hit while enriching $symbol")
+            return EnrichmentResult.RATE_LIMITED
+        }
+
         if (response.isBlank() || response.contains("Error")) {
             log.debug("No ETF profile data for $symbol")
-            return false
+            return EnrichmentResult.FAILED
         }
 
         val profile = objectMapper.readValue(response, AlphaEtfProfileResponse::class.java)
@@ -140,7 +149,7 @@ class AlphaClassificationEnricher(
 
         if (!hasSectors && !hasHoldings) {
             log.debug("No sector allocations or holdings in ETF profile for $symbol")
-            return false
+            return EnrichmentResult.NO_DATA
         }
 
         val standard = classificationService.getAlphaStandard()
@@ -173,20 +182,34 @@ class AlphaClassificationEnricher(
             }
         }
 
-        // Process top 10 holdings
+        // Process top holdings - skip placeholder symbols (AlphaVantage returns literal "n/a"
+        // for unlisted positions) and de-duplicate within the batch, since two identical
+        // symbols for the same parent asset violate the asset_holding unique constraint and
+        // roll back the whole enrichment (including the sector exposures above).
         var holdingCount = 0
         if (hasHoldings) {
             classificationService.clearHoldings(asset.id)
 
-            for (holdingData in profile.holdings.take(MAX_HOLDINGS)) {
+            val seenSymbols = mutableSetOf<String>()
+            for (holdingData in profile.holdings) {
+                if (holdingCount >= MAX_HOLDINGS) {
+                    break
+                }
+
                 val weight = holdingData.weight?.toBigDecimalOrNull()
-                if (weight == null || weight.signum() <= 0 || holdingData.symbol.isNullOrBlank()) {
+                val rawSymbol = holdingData.symbol?.trim()
+                if (weight == null || weight.signum() <= 0 || rawSymbol.isNullOrBlank()) {
+                    continue
+                }
+
+                val normalizedSymbol = rawSymbol.uppercase()
+                if (normalizedSymbol in PLACEHOLDER_SYMBOLS || !seenSymbols.add(normalizedSymbol)) {
                     continue
                 }
 
                 classificationService.addHolding(
                     asset = asset,
-                    symbol = holdingData.symbol,
+                    symbol = rawSymbol,
                     name = holdingData.description,
                     weight = weight
                 )
@@ -195,12 +218,29 @@ class AlphaClassificationEnricher(
         }
 
         log.info("Added $sectorCount sector exposures and $holdingCount holdings for ${asset.code}")
-        return sectorCount > 0 || holdingCount > 0
+        return if (sectorCount > 0 || holdingCount > 0) EnrichmentResult.ENRICHED else EnrichmentResult.NO_DATA
     }
+
+    /**
+     * AlphaVantage signals quota exhaustion with a top-level `Information` or `Note` key returned
+     * over HTTP 200 - not the usual "Error Message" body. Must be checked before parsing: such a
+     * body deserializes cleanly into an empty response and would otherwise be indistinguishable
+     * from [EnrichmentResult.NO_DATA], which is precisely the bug that let a whole refresh run
+     * silently no-op.
+     *
+     * The wording is not stable - observed variants include "standard API rate limit is 25
+     * requests per day", "lift the free key rate limit", and "our standard API call frequency is
+     * 5 calls per minute". Rather than chase phrasing, treat the presence of either key as
+     * disqualifying: neither ever appears in a valid OVERVIEW or ETF_PROFILE payload. An invalid
+     * API key also lands here, and aborting the run is the right response to that too.
+     */
+    private fun isRateLimited(response: String): Boolean =
+        response.contains("\"Information\"") || response.contains("\"Note\"")
 
     companion object {
         private val EQUITY_CATEGORIES = setOf("EQUITY", "COMMON STOCK")
         private val ETF_CATEGORIES = setOf("ETF", "EXCHANGE TRADED FUND")
+        private val PLACEHOLDER_SYMBOLS = setOf("N/A", "NA", "-", "--")
         private const val MAX_HOLDINGS = 10
     }
 }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
@@ -207,9 +207,11 @@ class AlphaClassificationEnricher(
                     continue
                 }
 
+                // Persist the normalized form: the unique constraint is case-sensitive, so
+                // storing raw casing would let the same ticker land twice across runs.
                 classificationService.addHolding(
                     asset = asset,
-                    symbol = rawSymbol,
+                    symbol = normalizedSymbol,
                     name = holdingData.description,
                     weight = weight
                 )
@@ -234,8 +236,12 @@ class AlphaClassificationEnricher(
      * disqualifying: neither ever appears in a valid OVERVIEW or ETF_PROFILE payload. An invalid
      * API key also lands here, and aborting the run is the right response to that too.
      */
-    private fun isRateLimited(response: String): Boolean =
-        response.contains("\"Information\"") || response.contains("\"Note\"")
+    private fun isRateLimited(response: String): Boolean {
+        val root =
+            runCatching { objectMapper.readTree(response) }.getOrNull()
+                ?: return false
+        return root.has("Information") || root.has("Note")
+    }
 
     companion object {
         private val EQUITY_CATEGORIES = setOf("EQUITY", "COMMON STOCK")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationController.kt
@@ -86,11 +86,20 @@ class ClassificationController(
 
         var processed = 0
         var errors = 0
+        var noData = 0
+        var rateLimited = 0
 
         for (asset in assets) {
             try {
-                if (classificationEnricher.enrichClassification(asset)) {
-                    processed++
+                // Goes through the refresh service (not the enricher directly) so
+                // classificationCheckedAt gets stamped here too - otherwise a manually
+                // backfilled asset would still look "never checked" to the resume-aware
+                // scheduled refresh and get re-attempted for no reason.
+                when (classificationRefreshService.attempt(asset)) {
+                    EnrichmentResult.ENRICHED -> processed++
+                    EnrichmentResult.FAILED -> errors++
+                    EnrichmentResult.NO_DATA -> noData++
+                    EnrichmentResult.RATE_LIMITED -> rateLimited++
                 }
             } catch (
                 @Suppress("TooGenericExceptionCaught")
@@ -102,7 +111,14 @@ class ClassificationController(
             }
         }
 
-        val result = BackfillResult(processed = processed, errors = errors, total = assets.size)
+        val result =
+            BackfillResult(
+                processed = processed,
+                errors = errors,
+                total = assets.size,
+                noData = noData,
+                rateLimited = rateLimited
+            )
         log.info("Classification backfill complete: $result")
 
         return BackfillResponse(data = result)
@@ -285,10 +301,11 @@ class ClassificationController(
         @PathVariable assetId: String
     ): Map<String, Any> {
         log.info("Refreshing classification for asset: $assetId")
-        val success = classificationRefreshService.refreshAsset(assetId)
+        val result = classificationRefreshService.refreshAsset(assetId)
         return mapOf(
             "assetId" to assetId,
-            "refreshed" to success
+            "refreshed" to (result == EnrichmentResult.ENRICHED),
+            "result" to result.name
         )
     }
 
@@ -308,11 +325,12 @@ class ClassificationController(
         @PathVariable code: String
     ): Map<String, Any> {
         log.info("Refreshing classification for $market:$code")
-        val success = classificationRefreshService.refreshAssetByCode(market, code)
+        val result = classificationRefreshService.refreshAssetByCode(market, code)
         return mapOf(
             "market" to market,
             "code" to code,
-            "refreshed" to success
+            "refreshed" to (result == EnrichmentResult.ENRICHED),
+            "result" to result.name
         )
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationEnricher.kt
@@ -19,8 +19,8 @@ interface ClassificationEnricher {
     /** True when this asset is an equity (single sector/industry). */
     fun isEquity(asset: Asset): Boolean
 
-    /** Fetch and persist classification data. Returns true when anything was stored. */
-    fun enrichClassification(asset: Asset): Boolean
+    /** Fetch and persist classification data. See [EnrichmentResult] for the possible outcomes. */
+    fun enrichClassification(asset: Asset): EnrichmentResult
 
     companion object {
         val EQUITY_CATEGORIES = setOf("EQUITY", "COMMON STOCK")

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
@@ -2,53 +2,78 @@ package com.beancounter.marketdata.classification
 
 import com.beancounter.common.contracts.BackfillResult
 import com.beancounter.common.model.Asset
-import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 /**
  * Service for refreshing asset classification data.
- * Handles both on-demand and scheduled refresh of sector/industry classifications.
+ *
+ * Handles both on-demand and scheduled refresh of sector/industry classifications. The refresh is
+ * resume-aware: [Asset.classificationCheckedAt] records when an asset's classification was last
+ * *attempted*, so a run picks up never-checked / longest-stale assets first rather than
+ * re-processing the same head of the list every time - which previously meant a free-tier
+ * AlphaVantage key (25 requests/day) never got past the first ~15 assets.
+ *
+ * Two tunables bound provider quota usage per run:
+ *
+ * - `beancounter.classification.stale-after-days` (default `7`) - the recheck window. An asset
+ *   checked more recently than this is skipped.
+ * - `beancounter.classification.batch-limit` (default `20`) - max assets *attempted* per run,
+ *   sized to sit comfortably under AlphaVantage's 25 requests/day free-tier cap.
+ *
+ * A [EnrichmentResult.RATE_LIMITED] result aborts the run immediately - once the provider quota
+ * is exhausted, further calls in the same run cannot succeed, so continuing just burns
+ * wall-clock. Rate-limited assets are deliberately NOT stamped with `classificationCheckedAt`, so
+ * they are retried first on the next run rather than pushed to the back of the queue.
  */
 @Service
 class ClassificationRefreshService(
     private val assetRepository: AssetRepository,
-    private val assetFinder: AssetFinder,
-    private val classificationEnricher: ClassificationEnricher
+    private val classificationEnricher: ClassificationEnricher,
+    @Value("\${beancounter.classification.stale-after-days:7}")
+    private val staleAfterDays: Long = 7,
+    @Value("\${beancounter.classification.batch-limit:20}")
+    private val batchLimit: Int = 20
 ) {
     private val log = LoggerFactory.getLogger(ClassificationRefreshService::class.java)
 
     /**
-     * Refresh sector exposures for all ETF assets.
-     * This re-fetches data from AlphaVantage even if exposures already exist.
+     * Refresh sector exposures for ETF assets due a recheck.
      */
     fun refreshEtfSectors(): BackfillResult {
         log.info("Starting ETF sector refresh")
-        val etfs = assetRepository.findActiveEtfs()
-        return processAssets(etfs, "ETF sectors")
+        val cutoff = LocalDate.now().minusDays(staleAfterDays)
+        val totalActive = assetRepository.findActiveEtfs().size
+        val due = assetRepository.findEtfsDueForClassification(cutoff)
+        return processAssets(totalActive, due, "ETF sectors")
     }
 
     /**
-     * Refresh classifications for all Equity assets.
+     * Refresh classifications for Equity assets due a recheck.
      */
     fun refreshEquityClassifications(): BackfillResult {
         log.info("Starting Equity classification refresh")
-        val equities = assetRepository.findActiveEquities()
-        return processAssets(equities, "Equity classifications")
+        val cutoff = LocalDate.now().minusDays(staleAfterDays)
+        val totalActive = assetRepository.findActiveEquities().size
+        val due = assetRepository.findEquitiesDueForClassification(cutoff)
+        return processAssets(totalActive, due, "Equity classifications")
     }
 
     /**
-     * Refresh classification for a single asset by ID.
+     * Refresh classification for a single asset by ID. Always attempted regardless of the
+     * staleness window / batch limit - this is an explicit, on-demand call.
      */
-    fun refreshAsset(assetId: String): Boolean {
+    fun refreshAsset(assetId: String): EnrichmentResult {
         val asset = assetRepository.findById(assetId)
         if (asset.isEmpty) {
             log.warn("Asset not found: $assetId")
-            return false
+            return EnrichmentResult.FAILED
         }
 
-        return classificationEnricher.enrichClassification(asset.get())
+        return attempt(asset.get())
     }
 
     /**
@@ -57,41 +82,113 @@ class ClassificationRefreshService(
     fun refreshAssetByCode(
         marketCode: String,
         assetCode: String
-    ): Boolean {
+    ): EnrichmentResult {
         val asset = assetRepository.findByMarketCodeAndCode(marketCode, assetCode)
         if (asset.isEmpty) {
             log.warn("Asset not found: $marketCode:$assetCode")
-            return false
+            return EnrichmentResult.FAILED
         }
 
-        return classificationEnricher.enrichClassification(asset.get())
+        return attempt(asset.get())
+    }
+
+    /**
+     * Enrich a single asset and stamp `classificationCheckedAt` (unless rate-limited). Public so
+     * other on-demand entry points - e.g. [ClassificationController.backfillClassifications] -
+     * can share the same stamping behaviour instead of calling [ClassificationEnricher] directly
+     * and leaving `classificationCheckedAt` unset (which would make the resume-aware refresh
+     * queries treat an already-backfilled asset as never-checked and re-attempt it for no reason).
+     */
+    fun attempt(asset: Asset): EnrichmentResult {
+        val result = classificationEnricher.enrichClassification(asset)
+        stampIfAttempted(asset, result)
+        return result
+    }
+
+    /**
+     * Stamp `classificationCheckedAt` for every outcome except [EnrichmentResult.RATE_LIMITED] -
+     * a throttled asset was never really checked, so it must be retried next run rather than
+     * pushed behind assets that succeeded or genuinely had no data.
+     */
+    private fun stampIfAttempted(
+        asset: Asset,
+        result: EnrichmentResult
+    ) {
+        if (result == EnrichmentResult.RATE_LIMITED) {
+            return
+        }
+        asset.classificationCheckedAt = LocalDate.now()
+        assetRepository.save(asset)
     }
 
     private fun processAssets(
-        assets: List<Asset>,
+        totalActive: Int,
+        dueAssets: List<Asset>,
         description: String
     ): BackfillResult {
         var processed = 0
         var errors = 0
+        var noData = 0
+        var rateLimited = 0
+        // Assets outside the due list are still within the staleness window - already skipped.
+        var skipped = (totalActive - dueAssets.size).coerceAtLeast(0)
 
-        log.info("Processing ${assets.size} assets for $description")
+        log.info(
+            "Processing ${dueAssets.size} due of $totalActive active assets for $description " +
+                "(batch-limit=$batchLimit)"
+        )
 
-        for (asset in assets) {
-            try {
-                if (classificationEnricher.enrichClassification(asset)) {
+        for ((index, asset) in dueAssets.withIndex()) {
+            if (index >= batchLimit) {
+                skipped++
+                continue
+            }
+
+            val result =
+                try {
+                    classificationEnricher.enrichClassification(asset)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught")
+                    e: Exception
+                ) {
+                    // Continue processing other assets even if one fails
+                    log.warn("Failed to refresh classification for ${asset.code}: ${e.message}")
+                    EnrichmentResult.FAILED
+                }
+
+            stampIfAttempted(asset, result)
+
+            when (result) {
+                EnrichmentResult.ENRICHED -> {
                     processed++
                 }
-            } catch (
-                @Suppress("TooGenericExceptionCaught")
-                e: Exception
-            ) {
-                // Continue processing other assets even if one fails
-                errors++
-                log.warn("Failed to refresh classification for ${asset.code}: ${e.message}")
+                EnrichmentResult.NO_DATA -> {
+                    noData++
+                }
+                EnrichmentResult.FAILED -> {
+                    errors++
+                }
+                EnrichmentResult.RATE_LIMITED -> {
+                    rateLimited++
+                    log.warn(
+                        "$description refresh hit provider rate limit at ${asset.code}; " +
+                            "aborting run, remaining assets deferred to next run"
+                    )
+                    skipped += dueAssets.size - index - 1
+                    break
+                }
             }
         }
 
-        val result = BackfillResult(processed = processed, errors = errors, total = assets.size)
+        val result =
+            BackfillResult(
+                processed = processed,
+                errors = errors,
+                total = totalActive,
+                noData = noData,
+                rateLimited = rateLimited,
+                skipped = skipped
+            )
         log.info("$description refresh complete: $result")
 
         return result

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationSchedule.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationSchedule.kt
@@ -10,7 +10,9 @@ import java.time.LocalDateTime
 
 /**
  * Scheduled refresh of asset classification data.
- * Runs weekly to keep ETF sector exposures up to date.
+ * Runs daily to keep ETF sector exposures up to date. Each run only attempts a bounded batch of
+ * assets due a recheck (see `ClassificationRefreshService`), so a daily cadence - not weekly - is
+ * needed for the full population to cycle through in a reasonable time.
  */
 @Service
 @ConditionalOnProperty(
@@ -27,11 +29,11 @@ class ClassificationSchedule(
     }
 
     /**
-     * Refresh ETF sector exposures weekly.
-     * Runs every Sunday at 6:00 AM in the configured timezone.
+     * Refresh ETF sector exposures daily.
+     * Runs every day at 6:00 AM in the configured timezone.
      */
     @SentryTransaction(operation = "scheduled", name = "ClassificationSchedule.refreshEtfSectors")
-    @Scheduled(cron = "0 0 6 * * SUN", zone = "#{@scheduleZone}")
+    @Scheduled(cron = "0 0 6 * * *", zone = "#{@scheduleZone}")
     fun refreshEtfSectors() {
         log.info(
             "Scheduled ETF sector refresh starting {} - {}",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EnrichmentResult.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EnrichmentResult.kt
@@ -1,0 +1,26 @@
+package com.beancounter.marketdata.classification
+
+/**
+ * Outcome of a single [ClassificationEnricher.enrichClassification] attempt.
+ *
+ * Prior to this type the enricher returned a bare [Boolean], so a provider rate-limit response
+ * (HTTP 200 with an `Information`/`Note` throttle body) was indistinguishable from "nothing to
+ * classify" — both returned `false` without ever incrementing an error count. That let a refresh
+ * run silently no-op on the bulk of its candidates. Distinguishing the four outcomes lets
+ * [ClassificationRefreshService] report honestly and decide whether an asset's
+ * `classificationCheckedAt` should advance (it must not for [RATE_LIMITED] — the asset was never
+ * actually checked, so it must be retried first on the next run).
+ */
+enum class EnrichmentResult {
+    /** Provider returned usable data and it was persisted. */
+    ENRICHED,
+
+    /** Provider responded successfully but had nothing for this asset. */
+    NO_DATA,
+
+    /** An exception was thrown, or the provider returned an error response. */
+    FAILED,
+
+    /** Provider quota/rate limit was hit; the asset was not actually checked. */
+    RATE_LIMITED
+}

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
@@ -33,28 +33,31 @@ class EodhdClassificationEnricher(
 
     override fun isEquity(asset: Asset): Boolean = ClassificationEnricher.categoryIsEquity(asset)
 
-    override fun enrichClassification(asset: Asset): Boolean =
+    override fun enrichClassification(asset: Asset): EnrichmentResult =
         try {
             when {
                 isEquity(asset) -> enrichEquity(asset)
                 isEtf(asset) -> enrichEtf(asset)
-                else -> false
+                else -> EnrichmentResult.NO_DATA
             }
         } catch (
             @Suppress("TooGenericExceptionCaught")
             e: Exception
         ) {
+            // EODHD signals quota exhaustion via HTTP status (thrown as an exception by the
+            // REST client), not a 200-body throttle marker like AlphaVantage - map straight to
+            // FAILED rather than inventing EODHD-specific rate-limit parsing.
             log.warn("Failed to enrich classification for ${asset.code}: ${e.message}")
-            false
+            EnrichmentResult.FAILED
         }
 
-    private fun enrichEquity(asset: Asset): Boolean {
+    private fun enrichEquity(asset: Asset): EnrichmentResult {
         val symbol = eodhdConfig.getPriceCode(asset)
         val general = eodhdProxy.getFundamentals(symbol, eodhdConfig.apiKey).general
 
         if (general?.sector.isNullOrBlank()) {
             log.debug("No sector in fundamentals for $symbol")
-            return false
+            return EnrichmentResult.NO_DATA
         }
 
         val standard = classificationService.getEodhdStandard()
@@ -93,16 +96,16 @@ class EodhdClassificationEnricher(
         }
 
         log.info("Classified ${asset.code} as ${general.sector} / ${general.industry ?: "N/A"}")
-        return true
+        return EnrichmentResult.ENRICHED
     }
 
-    private fun enrichEtf(asset: Asset): Boolean {
+    private fun enrichEtf(asset: Asset): EnrichmentResult {
         val symbol = eodhdConfig.getPriceCode(asset)
         val sectorWeights = eodhdProxy.getFundamentals(symbol, eodhdConfig.apiKey).etfData?.sectorWeights
 
         if (sectorWeights.isNullOrEmpty()) {
             log.debug("No sector weights in fundamentals for $symbol")
-            return false
+            return EnrichmentResult.NO_DATA
         }
 
         val standard = classificationService.getEodhdStandard()
@@ -132,6 +135,6 @@ class EodhdClassificationEnricher(
         }
 
         log.info("Added $sectorCount sector exposures for ${asset.code}")
-        return sectorCount > 0
+        return if (sectorCount > 0) EnrichmentResult.ENRICHED else EnrichmentResult.NO_DATA
     }
 }

--- a/svc-data/src/main/resources/db/migration/V32__add_asset_classification_checked_at.sql
+++ b/svc-data/src/main/resources/db/migration/V32__add_asset_classification_checked_at.sql
@@ -1,0 +1,6 @@
+-- V32: resume-aware classification refresh (bc-claude fix/classification-refresh-resume).
+-- Records when an asset's classification/sector-exposure data was last attempted so successive
+-- refresh runs make forward progress instead of re-processing the same head of the list every
+-- time (and burning AlphaVantage's 25 requests/day free-tier quota on the same 15 assets).
+ALTER TABLE asset
+    ADD COLUMN IF NOT EXISTS classification_checked_at DATE;

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetsTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/assets/AssetsTest.kt
@@ -77,7 +77,8 @@ class AssetsTest {
                 "reportCategory",
                 "sector",
                 "industry",
-                "expectedReturnRate"
+                "expectedReturnRate",
+                "classificationCheckedAt"
             )
         assertThat(result.assets[1].resolvedAsset)
             .isNotNull
@@ -87,7 +88,8 @@ class AssetsTest {
                 "reportCategory",
                 "sector",
                 "industry",
-                "expectedReturnRate"
+                "expectedReturnRate",
+                "classificationCheckedAt"
             )
 
         // val byProviders = ProviderUtils().splitProviders(priceRequest.assets)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
@@ -120,8 +120,8 @@ class AlphaClassificationEnricherTest {
                 {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.07"},
                 {"symbol": "n/a", "description": "Unlisted", "weight": "0.02"},
                 {"symbol": "N/A", "description": "Unlisted 2", "weight": "0.02"},
-                {"symbol": "AAPL", "description": "Apple Inc dup", "weight": "0.07"},
-                {"symbol": "MSFT", "description": "Microsoft", "weight": "0.05"},
+                {"symbol": "aapl", "description": "Apple Inc dup, different casing", "weight": "0.07"},
+                {"symbol": " MSFT ", "description": "Microsoft, padded", "weight": "0.05"},
                 {"symbol": "--", "description": "Placeholder", "weight": "0.01"}
               ]
             }
@@ -137,7 +137,9 @@ class AlphaClassificationEnricherTest {
         // Sector exposures are written even though the holdings list contained junk rows.
         verify(classificationService, times(2)).addExposure(any(), any(), any(), any(), any())
 
-        // Only the two real, de-duplicated symbols are persisted.
+        // Only the two real symbols are persisted, de-duplicated case-insensitively and stored in
+        // normalized form - the asset_holding unique constraint is case-sensitive, so persisting
+        // raw casing would let "aapl" and "AAPL" both land for the same parent.
         val symbols = argumentCaptor<String>()
         verify(classificationService, times(2)).addHolding(any(), symbols.capture(), anyOrNull(), any(), any())
         assertThat(symbols.allValues).containsExactlyInAnyOrder("AAPL", "MSFT")

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
@@ -1,0 +1,271 @@
+package com.beancounter.marketdata.classification
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.ClassificationItem
+import com.beancounter.common.model.ClassificationLevel
+import com.beancounter.common.model.ClassificationStandard
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.Status
+import com.beancounter.marketdata.providers.alpha.AlphaConfig
+import com.beancounter.marketdata.providers.alpha.AlphaProxy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Unit tests for [AlphaClassificationEnricher].
+ *
+ * Regression coverage for two production bugs found on kauri (bc-claude
+ * fix/classification-refresh-resume):
+ *
+ * - Bug A: AlphaVantage's ETF_PROFILE returns placeholder holding symbols (literal `"n/a"`) for
+ *   unlisted positions. Two such rows for the same parent asset violate the `asset_holding`
+ *   unique constraint (`parent_asset_id`, `symbol`) and roll back the whole transaction,
+ *   including the sector exposures that were about to be written in the same call.
+ * - Bug B: a free-tier rate-limit response is HTTP 200 with an `Information`/`Note` body. The
+ *   old code treated that identically to "nothing to classify" (`false`, no error counted),
+ *   so a refresh run silently no-op'd on the bulk of its candidates.
+ *
+ * Uses a real [AlphaConfig] (its Jackson mapper is what production wires) with
+ * `Asset.priceSymbol` set directly so `getPriceCode` returns a fixed value without needing
+ * `AlphaConfig.markets` / market-code translation.
+ */
+class AlphaClassificationEnricherTest {
+    private val alphaConfig = AlphaConfig()
+    private lateinit var alphaProxy: AlphaProxy
+    private lateinit var classificationService: ClassificationService
+    private lateinit var enricher: AlphaClassificationEnricher
+
+    private val market = Market(code = "NASDAQ", name = "NASDAQ")
+    private val standard =
+        ClassificationStandard(
+            id = "std-alpha",
+            key = ClassificationStandard.ALPHA,
+            name = "AlphaVantage Sector Classification",
+            provider = ClassificationStandard.PROVIDER_ALPHA
+        )
+
+    private fun item(
+        code: String,
+        level: ClassificationLevel
+    ) = ClassificationItem(id = "item-$code", standard = standard, level = level, code = code, name = code)
+
+    @BeforeEach
+    fun setUp() {
+        alphaProxy = mock()
+        classificationService = mock()
+        enricher = AlphaClassificationEnricher(alphaConfig, alphaProxy, classificationService)
+
+        // apiKey field is set via @Value; not injected outside a Spring context, so it stays the
+        // Kotlin default-initialized empty lateinit - fine, alphaProxy is mocked and does not
+        // care what key it receives. Force-set to keep the mock call signatures obvious.
+        setApiKey(enricher, "demo")
+
+        whenever(classificationService.getAlphaStandard()).thenReturn(standard)
+        whenever(
+            classificationService.getOrCreateItem(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+        ).thenAnswer { item("X", it.getArgument(1)) }
+    }
+
+    private fun setApiKey(
+        target: AlphaClassificationEnricher,
+        key: String
+    ) {
+        val field = AlphaClassificationEnricher::class.java.getDeclaredField("apiKey")
+        field.isAccessible = true
+        field.set(target, key)
+    }
+
+    private fun etf(symbol: String = "VOO") =
+        Asset(
+            id = "etf-1",
+            code = symbol,
+            name = "ETF",
+            category = "ETF",
+            market = market,
+            priceSymbol = symbol,
+            status = Status.Active
+        )
+
+    private fun equity(symbol: String = "AAPL") =
+        Asset(
+            id = "eq-1",
+            code = symbol,
+            name = "Equity",
+            category = "EQUITY",
+            market = market,
+            priceSymbol = symbol,
+            status = Status.Active
+        )
+
+    @Test
+    fun `enrichEtf skips placeholder and duplicate holding symbols but still writes sectors`() {
+        val body =
+            """
+            {
+              "sectors": [
+                {"sector": "Technology", "weight": "0.35"},
+                {"sector": "Healthcare", "weight": "0.15"}
+              ],
+              "holdings": [
+                {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.07"},
+                {"symbol": "n/a", "description": "Unlisted", "weight": "0.02"},
+                {"symbol": "N/A", "description": "Unlisted 2", "weight": "0.02"},
+                {"symbol": "AAPL", "description": "Apple Inc dup", "weight": "0.07"},
+                {"symbol": "MSFT", "description": "Microsoft", "weight": "0.05"},
+                {"symbol": "--", "description": "Placeholder", "weight": "0.01"}
+              ]
+            }
+            """.trimIndent()
+        whenever(alphaProxy.getEtfProfile(eq("VOO"), any())).thenReturn(body)
+
+        val result = enricher.enrichClassification(etf("VOO"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
+        verify(classificationService).clearExposures("etf-1")
+        verify(classificationService).clearHoldings("etf-1")
+
+        // Sector exposures are written even though the holdings list contained junk rows.
+        verify(classificationService, times(2)).addExposure(any(), any(), any(), any(), any())
+
+        // Only the two real, de-duplicated symbols are persisted.
+        val symbols = argumentCaptor<String>()
+        verify(classificationService, times(2)).addHolding(any(), symbols.capture(), anyOrNull(), any(), any())
+        assertThat(symbols.allValues).containsExactlyInAnyOrder("AAPL", "MSFT")
+    }
+
+    @Test
+    fun `rate limit body returns RATE_LIMITED and does not clear existing data`() {
+        val body =
+            """{"Information": "We have detected your API key as XXXX and our standard API """ +
+                """rate limit is 25 requests per day. Please visit https://www.alphavantage.co"}"""
+        whenever(alphaProxy.getEtfProfile(eq("VOO"), any())).thenReturn(body)
+
+        val result = enricher.enrichClassification(etf("VOO"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.RATE_LIMITED)
+        verify(classificationService, never()).clearExposures(any())
+        verify(classificationService, never()).clearHoldings(any())
+        verify(classificationService, never()).addExposure(any(), any(), any(), any(), any())
+        verify(classificationService, never()).addHolding(any(), any(), anyOrNull(), any(), any())
+    }
+
+    @Test
+    fun `rate limit body on equity path also returns RATE_LIMITED`() {
+        val body =
+            """{"Note": "Thank you for using Alpha Vantage! Our standard API rate limit """ +
+                """is 25 requests per day."}"""
+        whenever(alphaProxy.getOverview(eq("AAPL"), any())).thenReturn(body)
+
+        val result = enricher.enrichClassification(equity("AAPL"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.RATE_LIMITED)
+        verify(classificationService, never()).classifyAsset(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `well-formed ETF response with no sectors and no holdings returns NO_DATA`() {
+        whenever(alphaProxy.getEtfProfile(eq("VOO"), any())).thenReturn("""{"net_assets": "1000"}""")
+
+        val result = enricher.enrichClassification(etf("VOO"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.NO_DATA)
+        verify(classificationService, never()).clearExposures(any())
+        verify(classificationService, never()).clearHoldings(any())
+    }
+
+    @Test
+    fun `well-formed equity response with no sector returns NO_DATA`() {
+        whenever(alphaProxy.getOverview(eq("AAPL"), any())).thenReturn("""{"Symbol": "AAPL"}""")
+
+        val result = enricher.enrichClassification(equity("AAPL"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.NO_DATA)
+        verify(classificationService, never()).classifyAsset(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `error response returns FAILED`() {
+        whenever(alphaProxy.getOverview(eq("AAPL"), any())).thenReturn("""{"Error Message": "Invalid API call"}""")
+
+        val result = enricher.enrichClassification(equity("AAPL"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
+    }
+
+    @Test
+    fun `blank response returns FAILED`() {
+        whenever(alphaProxy.getEtfProfile(eq("VOO"), any())).thenReturn("")
+
+        val result = enricher.enrichClassification(etf("VOO"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
+    }
+
+    @Test
+    fun `exception thrown by the proxy returns FAILED`() {
+        whenever(alphaProxy.getOverview(eq("AAPL"), any())).thenThrow(RuntimeException("boom"))
+
+        val result = enricher.enrichClassification(equity("AAPL"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
+    }
+
+    @Test
+    fun `enrichEquity classifies sector and industry`() {
+        val body = """{"Symbol": "AAPL", "Sector": "Technology", "Industry": "Consumer Electronics"}"""
+        whenever(alphaProxy.getOverview(eq("AAPL"), any())).thenReturn(body)
+
+        val result = enricher.enrichClassification(equity("AAPL"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
+        verify(classificationService, times(2)).classifyAsset(any(), any(), any(), any(), any())
+    }
+
+    /**
+     * AlphaVantage's throttle wording is not stable - this variant names a call frequency and
+     * never says "rate limit". Matching on the phrasing rather than the key would classify it as
+     * NO_DATA, stamping the asset as checked even though it was never really looked at.
+     */
+    @Test
+    fun `throttle body without the words rate limit still returns RATE_LIMITED`() {
+        val body =
+            """{"Note": "Thank you for using Alpha Vantage! Our standard API call frequency is """ +
+                """5 calls per minute and 500 calls per day."}"""
+        whenever(alphaProxy.getEtfProfile(eq("VOO"), any())).thenReturn(body)
+
+        val result = enricher.enrichClassification(etf("VOO"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.RATE_LIMITED)
+        verify(classificationService, never()).clearExposures(any())
+        verify(classificationService, never()).clearHoldings(any())
+    }
+
+    /**
+     * A non-US-listed ETF resolves to a suffixed symbol AlphaVantage does not cover (e.g.
+     * `NATO.LON`), which answers `{}`. It must read as NO_DATA - never as the US-listed namesake's
+     * profile, and never as a failure worth retrying immediately. kauri holds two distinct funds
+     * both coded NATO: THEMES TRANSATLANTIC DEFENSE on the US side and FUTURE OF DEFENCE UCITS on
+     * LON.
+     */
+    @Test
+    fun `ETF on a market AlphaVantage does not cover returns NO_DATA and writes nothing`() {
+        whenever(alphaProxy.getEtfProfile(eq("NATO.LON"), any())).thenReturn("{}")
+
+        val result = enricher.enrichClassification(etf("NATO.LON"))
+
+        assertThat(result).isEqualTo(EnrichmentResult.NO_DATA)
+        verify(classificationService, never()).clearExposures(any())
+        verify(classificationService, never()).addExposure(any(), any(), any(), any(), any())
+        verify(classificationService, never()).addHolding(any(), any(), anyOrNull(), any(), any())
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationControllerTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationControllerTest.kt
@@ -1,0 +1,110 @@
+package com.beancounter.marketdata.classification
+
+import com.beancounter.common.model.Asset
+import com.beancounter.common.model.Market
+import com.beancounter.common.model.Status
+import com.beancounter.marketdata.assets.AssetFinder
+import com.beancounter.marketdata.assets.AssetRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Unit tests for [ClassificationController].
+ *
+ * Covers the adjacent fix found alongside the resume-aware refresh work: `/backfill` used to call
+ * [ClassificationEnricher] directly, so a manually-backfilled asset never got its
+ * `classificationCheckedAt` stamped and would look "never checked" to the resume-aware scheduled
+ * refresh - wasting quota re-attempting it. `/backfill` now goes through
+ * [ClassificationRefreshService.attempt], which stamps it.
+ */
+class ClassificationControllerTest {
+    private lateinit var classificationEnricher: ClassificationEnricher
+    private lateinit var classificationService: ClassificationService
+    private lateinit var classificationRefreshService: ClassificationRefreshService
+    private lateinit var assetRepository: AssetRepository
+    private lateinit var assetFinder: AssetFinder
+    private lateinit var controller: ClassificationController
+
+    private val market = Market(code = "NASDAQ", name = "NASDAQ")
+
+    private fun etf(id: String) =
+        Asset(id = id, code = id, name = "ETF $id", category = "ETF", market = market, status = Status.Active)
+
+    @BeforeEach
+    fun setUp() {
+        classificationEnricher = mock()
+        classificationService = mock()
+        classificationRefreshService = mock()
+        assetRepository = mock()
+        assetFinder = mock()
+        controller =
+            ClassificationController(
+                classificationEnricher,
+                classificationService,
+                classificationRefreshService,
+                assetRepository,
+                assetFinder
+            )
+
+        whenever(classificationEnricher.canEnrich(any())).thenReturn(true)
+        whenever(classificationEnricher.isEtf(any())).thenReturn(true)
+        whenever(classificationService.hasExposures(any())).thenReturn(false)
+    }
+
+    @Test
+    fun `backfillClassifications delegates to the refresh service so checked-at is stamped`() {
+        val asset = etf("etf-1")
+        whenever(assetRepository.findAll()).thenReturn(listOf(asset))
+        whenever(classificationRefreshService.attempt(asset)).thenReturn(EnrichmentResult.ENRICHED)
+
+        val response = controller.backfillClassifications()
+
+        assertThat(response.data.processed).isEqualTo(1)
+        assertThat(response.data.errors).isEqualTo(0)
+        verify(classificationRefreshService).attempt(asset)
+        verify(classificationEnricher, never()).enrichClassification(any())
+    }
+
+    @Test
+    fun `backfillClassifications counts NO_DATA and RATE_LIMITED separately from processed and errors`() {
+        val noData = etf("etf-nodata")
+        val rateLimited = etf("etf-ratelimited")
+        whenever(assetRepository.findAll()).thenReturn(listOf(noData, rateLimited))
+        whenever(classificationRefreshService.attempt(noData)).thenReturn(EnrichmentResult.NO_DATA)
+        whenever(classificationRefreshService.attempt(rateLimited)).thenReturn(EnrichmentResult.RATE_LIMITED)
+
+        val response = controller.backfillClassifications()
+
+        assertThat(response.data.processed).isEqualTo(0)
+        assertThat(response.data.errors).isEqualTo(0)
+        assertThat(response.data.noData).isEqualTo(1)
+        assertThat(response.data.rateLimited).isEqualTo(1)
+    }
+
+    @Test
+    fun `refreshAsset reports both refreshed and result for a rate-limited outcome`() {
+        whenever(classificationRefreshService.refreshAsset("asset-1")).thenReturn(EnrichmentResult.RATE_LIMITED)
+
+        val response = controller.refreshAsset("asset-1")
+
+        assertThat(response["refreshed"]).isEqualTo(false)
+        assertThat(response["result"]).isEqualTo("RATE_LIMITED")
+    }
+
+    @Test
+    fun `refreshAssetByCode reports refreshed true and result ENRICHED on success`() {
+        whenever(classificationRefreshService.refreshAssetByCode("NASDAQ", "SCHG"))
+            .thenReturn(EnrichmentResult.ENRICHED)
+
+        val response = controller.refreshAssetByCode("NASDAQ", "SCHG")
+
+        assertThat(response["refreshed"]).isEqualTo(true)
+        assertThat(response["result"]).isEqualTo("ENRICHED")
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshServiceTest.kt
@@ -3,95 +3,87 @@ package com.beancounter.marketdata.classification
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.Status
-import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.assets.AssetRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Optional
 
 /**
- * Unit tests for ClassificationRefreshService.
+ * Unit tests for [ClassificationRefreshService].
+ *
+ * Covers the resume-aware refresh design (bc-claude fix/classification-refresh-resume): the
+ * staleness window, the per-run batch limit, aborting on the first [EnrichmentResult.RATE_LIMITED],
+ * `classificationCheckedAt` stamping, and honest [com.beancounter.common.contracts.BackfillResult]
+ * counts - specifically the regression that used to let [EnrichmentResult.FAILED] outcomes vanish
+ * silently instead of landing in `errors`.
  */
 class ClassificationRefreshServiceTest {
     private lateinit var assetRepository: AssetRepository
-    private lateinit var assetFinder: AssetFinder
     private lateinit var classificationEnricher: ClassificationEnricher
-    private lateinit var service: ClassificationRefreshService
 
     private val testMarket = Market(code = "NASDAQ", name = "NASDAQ")
+
+    private fun service(batchLimit: Int = 20) =
+        ClassificationRefreshService(
+            assetRepository,
+            classificationEnricher,
+            staleAfterDays = 7,
+            batchLimit = batchLimit
+        )
+
+    private fun etf(id: String) =
+        Asset(
+            id = id,
+            code = id,
+            name = "ETF $id",
+            category = "ETF",
+            market = testMarket,
+            status = Status.Active
+        )
 
     @BeforeEach
     fun setUp() {
         assetRepository = mock()
-        assetFinder = mock()
         classificationEnricher = mock()
-
-        service =
-            ClassificationRefreshService(
-                assetRepository,
-                assetFinder,
-                classificationEnricher
-            )
+        whenever(assetRepository.save(any<Asset>())).thenAnswer { it.getArgument<Asset>(0) }
     }
 
     @Test
-    fun `refreshEtfSectors processes all ETF assets`() {
-        val etf1 =
-            Asset(
-                id = "etf-1",
-                code = "VOO",
-                name = "Vanguard S&P 500 ETF",
-                category = "ETF",
-                market = testMarket,
-                status = Status.Active
-            )
-        val etf2 =
-            Asset(
-                id = "etf-2",
-                code = "SCHG",
-                name = "Schwab US Large-Cap Growth ETF",
-                category = "ETF",
-                market = testMarket,
-                status = Status.Active
-            )
+    fun `refreshEtfSectors processes all due ETF assets`() {
+        val etf1 = etf("etf-1")
+        val etf2 = etf("etf-2")
 
         whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf1, etf2))
-        whenever(assetFinder.hydrateAsset(etf1)).thenReturn(etf1)
-        whenever(assetFinder.hydrateAsset(etf2)).thenReturn(etf2)
-        whenever(classificationEnricher.enrichClassification(etf1)).thenReturn(true)
-        whenever(classificationEnricher.enrichClassification(etf2)).thenReturn(true)
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(etf1, etf2))
+        whenever(classificationEnricher.enrichClassification(etf1)).thenReturn(EnrichmentResult.ENRICHED)
+        whenever(classificationEnricher.enrichClassification(etf2)).thenReturn(EnrichmentResult.ENRICHED)
 
-        val result = service.refreshEtfSectors()
+        val result = service().refreshEtfSectors()
 
         assertThat(result.total).isEqualTo(2)
         assertThat(result.processed).isEqualTo(2)
         assertThat(result.errors).isEqualTo(0)
+        assertThat(result.skipped).isEqualTo(0)
     }
 
     @Test
-    fun `refreshEtfSectors handles enrichment failures`() {
-        val etf =
-            Asset(
-                id = "etf-1",
-                code = "VOO",
-                name = "Vanguard S&P 500 ETF",
-                category = "ETF",
-                market = testMarket,
-                status = Status.Active
-            )
+    fun `refreshEtfSectors handles enrichment exceptions as errors`() {
+        val etf1 = etf("etf-1")
 
-        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf))
-        whenever(assetFinder.hydrateAsset(etf)).thenReturn(etf)
-        whenever(classificationEnricher.enrichClassification(etf))
+        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf1))
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(etf1))
+        whenever(classificationEnricher.enrichClassification(etf1))
             .thenThrow(RuntimeException("API error"))
 
-        val result = service.refreshEtfSectors()
+        val result = service().refreshEtfSectors()
 
         assertThat(result.total).isEqualTo(1)
         assertThat(result.processed).isEqualTo(0)
@@ -99,7 +91,7 @@ class ClassificationRefreshServiceTest {
     }
 
     @Test
-    fun `refreshEquityClassifications processes all Equity assets`() {
+    fun `refreshEquityClassifications processes all due Equity assets`() {
         val equity =
             Asset(
                 id = "eq-1",
@@ -111,10 +103,10 @@ class ClassificationRefreshServiceTest {
             )
 
         whenever(assetRepository.findActiveEquities()).thenReturn(listOf(equity))
-        whenever(assetFinder.hydrateAsset(equity)).thenReturn(equity)
-        whenever(classificationEnricher.enrichClassification(equity)).thenReturn(true)
+        whenever(assetRepository.findEquitiesDueForClassification(any())).thenReturn(listOf(equity))
+        whenever(classificationEnricher.enrichClassification(equity)).thenReturn(EnrichmentResult.ENRICHED)
 
-        val result = service.refreshEquityClassifications()
+        val result = service().refreshEquityClassifications()
 
         assertThat(result.total).isEqualTo(1)
         assertThat(result.processed).isEqualTo(1)
@@ -122,68 +114,154 @@ class ClassificationRefreshServiceTest {
     }
 
     @Test
-    fun `refreshAsset returns false when asset not found`() {
+    fun `refreshAsset returns FAILED when asset not found`() {
         whenever(assetRepository.findById("unknown-id")).thenReturn(Optional.empty())
 
-        val result = service.refreshAsset("unknown-id")
+        val result = service().refreshAsset("unknown-id")
 
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
         verify(classificationEnricher, never()).enrichClassification(any())
     }
 
     @Test
-    fun `refreshAsset enriches found asset`() {
-        val asset =
-            Asset(
-                id = "asset-1",
-                code = "SCHG",
-                name = "Schwab Growth",
-                category = "ETF",
-                market = testMarket,
-                status = Status.Active
-            )
+    fun `refreshAsset enriches found asset and stamps checked-at`() {
+        val asset = etf("asset-1")
 
         whenever(assetRepository.findById("asset-1")).thenReturn(Optional.of(asset))
-        whenever(assetFinder.hydrateAsset(asset)).thenReturn(asset)
-        whenever(classificationEnricher.enrichClassification(asset)).thenReturn(true)
+        whenever(classificationEnricher.enrichClassification(asset)).thenReturn(EnrichmentResult.ENRICHED)
 
-        val result = service.refreshAsset("asset-1")
+        val result = service().refreshAsset("asset-1")
 
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
         verify(classificationEnricher).enrichClassification(asset)
+        assertThat(asset.classificationCheckedAt).isNotNull()
     }
 
     @Test
-    fun `refreshAssetByCode returns false when asset not found`() {
+    fun `refreshAssetByCode returns FAILED when asset not found`() {
         whenever(assetRepository.findByMarketCodeAndCode("NASDAQ", "UNKNOWN"))
             .thenReturn(Optional.empty())
 
-        val result = service.refreshAssetByCode("NASDAQ", "UNKNOWN")
+        val result = service().refreshAssetByCode("NASDAQ", "UNKNOWN")
 
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
         verify(classificationEnricher, never()).enrichClassification(any())
     }
 
     @Test
     fun `refreshAssetByCode enriches found asset`() {
-        val asset =
-            Asset(
-                id = "asset-1",
-                code = "SCHG",
-                name = "Schwab Growth",
-                category = "ETF",
-                market = testMarket,
-                status = Status.Active
-            )
+        val asset = etf("asset-1")
 
         whenever(assetRepository.findByMarketCodeAndCode("NASDAQ", "SCHG"))
             .thenReturn(Optional.of(asset))
-        whenever(assetFinder.hydrateAsset(asset)).thenReturn(asset)
-        whenever(classificationEnricher.enrichClassification(asset)).thenReturn(true)
+        whenever(classificationEnricher.enrichClassification(asset)).thenReturn(EnrichmentResult.ENRICHED)
 
-        val result = service.refreshAssetByCode("NASDAQ", "SCHG")
+        val result = service().refreshAssetByCode("NASDAQ", "SCHG")
 
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
         verify(classificationEnricher).enrichClassification(asset)
+    }
+
+    @Test
+    fun `assets inside the staleness window are skipped and not attempted`() {
+        val due = etf("etf-due")
+        val staleWindow1 = etf("etf-fresh-1")
+        val staleWindow2 = etf("etf-fresh-2")
+
+        // findActiveEtfs = full population (3); findEtfsDueForClassification = only the stale one.
+        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(due, staleWindow1, staleWindow2))
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(due))
+        whenever(classificationEnricher.enrichClassification(due)).thenReturn(EnrichmentResult.ENRICHED)
+
+        val result = service().refreshEtfSectors()
+
+        assertThat(result.total).isEqualTo(3)
+        assertThat(result.processed).isEqualTo(1)
+        assertThat(result.skipped).isEqualTo(2)
+        verify(classificationEnricher, never()).enrichClassification(staleWindow1)
+        verify(classificationEnricher, never()).enrichClassification(staleWindow2)
+    }
+
+    @Test
+    fun `attempts stop at the batch limit and the remainder is skipped`() {
+        val etf1 = etf("etf-1")
+        val etf2 = etf("etf-2")
+        val etf3 = etf("etf-3")
+
+        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf1, etf2, etf3))
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(etf1, etf2, etf3))
+        whenever(classificationEnricher.enrichClassification(etf1)).thenReturn(EnrichmentResult.ENRICHED)
+        whenever(classificationEnricher.enrichClassification(etf2)).thenReturn(EnrichmentResult.ENRICHED)
+
+        val result = service(batchLimit = 2).refreshEtfSectors()
+
+        assertThat(result.total).isEqualTo(3)
+        assertThat(result.processed).isEqualTo(2)
+        assertThat(result.skipped).isEqualTo(1)
+        verify(classificationEnricher, never()).enrichClassification(etf3)
+    }
+
+    @Test
+    fun `a RATE_LIMITED result aborts the run and later assets are not attempted`() {
+        val etf1 = etf("etf-1")
+        val etf2 = etf("etf-2")
+        val etf3 = etf("etf-3")
+
+        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf1, etf2, etf3))
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(etf1, etf2, etf3))
+        whenever(classificationEnricher.enrichClassification(etf1)).thenReturn(EnrichmentResult.ENRICHED)
+        whenever(classificationEnricher.enrichClassification(etf2)).thenReturn(EnrichmentResult.RATE_LIMITED)
+
+        val result = service().refreshEtfSectors()
+
+        assertThat(result.total).isEqualTo(3)
+        assertThat(result.processed).isEqualTo(1)
+        assertThat(result.rateLimited).isEqualTo(1)
+        assertThat(result.skipped).isEqualTo(1)
+        verify(classificationEnricher, never()).enrichClassification(etf3)
+    }
+
+    @Test
+    fun `FAILED results are counted in errors, not silently dropped`() {
+        val etf1 = etf("etf-1")
+
+        whenever(assetRepository.findActiveEtfs()).thenReturn(listOf(etf1))
+        whenever(assetRepository.findEtfsDueForClassification(any())).thenReturn(listOf(etf1))
+        whenever(classificationEnricher.enrichClassification(etf1)).thenReturn(EnrichmentResult.FAILED)
+
+        val result = service().refreshEtfSectors()
+
+        assertThat(result.errors).isEqualTo(1)
+        assertThat(result.processed).isEqualTo(0)
+        assertThat(result.rateLimited).isEqualTo(0)
+    }
+
+    @Test
+    fun `checked-at is stamped for ENRICHED, NO_DATA and FAILED but not RATE_LIMITED`() {
+        val enriched = etf("etf-enriched")
+        val noData = etf("etf-nodata")
+        val failed = etf("etf-failed")
+        val rateLimited = etf("etf-ratelimited")
+
+        whenever(assetRepository.findActiveEtfs())
+            .thenReturn(listOf(enriched, noData, failed, rateLimited))
+        whenever(assetRepository.findEtfsDueForClassification(any()))
+            .thenReturn(listOf(enriched, noData, failed, rateLimited))
+        whenever(classificationEnricher.enrichClassification(enriched)).thenReturn(EnrichmentResult.ENRICHED)
+        whenever(classificationEnricher.enrichClassification(noData)).thenReturn(EnrichmentResult.NO_DATA)
+        whenever(classificationEnricher.enrichClassification(failed)).thenReturn(EnrichmentResult.FAILED)
+        whenever(classificationEnricher.enrichClassification(rateLimited)).thenReturn(EnrichmentResult.RATE_LIMITED)
+
+        service().refreshEtfSectors()
+
+        assertThat(enriched.classificationCheckedAt).isNotNull()
+        assertThat(noData.classificationCheckedAt).isNotNull()
+        assertThat(failed.classificationCheckedAt).isNotNull()
+        assertThat(rateLimited.classificationCheckedAt).isNull()
+
+        val saved = argumentCaptor<Asset>()
+        verify(assetRepository, times(3)).save(saved.capture())
+        assertThat(saved.allValues.map { it.id })
+            .containsExactlyInAnyOrder("etf-enriched", "etf-nodata", "etf-failed")
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/EodhdClassificationApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/EodhdClassificationApiTest.kt
@@ -88,7 +88,7 @@ internal class EodhdClassificationApiTest {
 
         val enriched = enricher.enrichClassification(asset("VTI", "ETF"))
 
-        assertThat(enriched).isTrue()
+        assertThat(enriched).isEqualTo(EnrichmentResult.ENRICHED)
         verify(classificationService).clearExposures("VTI-id")
 
         // All 11 EODHD sector names reach getOrCreateItem verbatim (normalization is downstream).
@@ -126,7 +126,7 @@ internal class EodhdClassificationApiTest {
 
         val enriched = enricher.enrichClassification(asset("AAPL", "EQUITY"))
 
-        assertThat(enriched).isTrue()
+        assertThat(enriched).isEqualTo(EnrichmentResult.ENRICHED)
 
         val rawSector = argumentCaptor<String>()
         verify(

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricherTest.kt
@@ -101,7 +101,7 @@ class EodhdClassificationEnricherTest {
 
         val result = enricher.enrichClassification(etf())
 
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
         verify(classificationService).clearExposures("etf-1")
 
         val weights = argumentCaptor<BigDecimal>()
@@ -123,7 +123,7 @@ class EodhdClassificationEnricherTest {
 
         val result = enricher.enrichClassification(equity())
 
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
         val levels = argumentCaptor<ClassificationLevel>()
         verify(classificationService, times(2)).classifyAsset(
             any(),
@@ -136,13 +136,24 @@ class EodhdClassificationEnricherTest {
     }
 
     @Test
-    fun `returns false when no fundamentals data`() {
+    fun `returns NO_DATA when no fundamentals data`() {
         whenever(eodhdConfig.getPriceCode(any())).thenReturn("VTI.US")
         whenever(eodhdProxy.getFundamentals(any(), any())).thenReturn(EodhdFundamentals())
 
         val result = enricher.enrichClassification(etf())
 
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(EnrichmentResult.NO_DATA)
+        verify(classificationService, never()).addExposure(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `returns FAILED when the provider call throws`() {
+        whenever(eodhdConfig.getPriceCode(any())).thenReturn("VTI.US")
+        whenever(eodhdProxy.getFundamentals(any(), any())).thenThrow(RuntimeException("quota exceeded"))
+
+        val result = enricher.enrichClassification(etf())
+
+        assertThat(result).isEqualTo(EnrichmentResult.FAILED)
         verify(classificationService, never()).addExposure(any(), any(), any(), any(), any())
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/figi/FigiAssetApiTest.kt
@@ -213,7 +213,8 @@ class FigiAssetApiTest {
                 "reportCategory",
                 "sector",
                 "industry",
-                "expectedReturnRate"
+                "expectedReturnRate",
+                "classificationCheckedAt"
             ).isNotNull
     }
 


### PR DESCRIPTION
## Problem

`POST /api/classifications/refresh/etf` on kauri:

```json
{"processed":15, "errors":0, "total":60}
```

45 of 60 ETFs silently did nothing, and `errors` reported perfect health. Re-running once the daily quota was exhausted made it starker — 60 candidates, 0 processed, still **0 errors**:

```json
{"processed":0, "errors":0, "total":60}
```

Two independent causes.

### 1. Placeholder holding symbols roll back the whole enrichment

AlphaVantage `ETF_PROFILE` returns a literal `"n/a"` symbol for unlisted positions. The guard only rejected null/blank, so two `n/a` rows for one parent violated `asset_holding (parent_asset_id, symbol)`:

```
duplicate key value violates unique constraint "UK4l1wu507o3bullr7noc5gcgnc"
Detail: Key (parent_asset_id, symbol)=(iCeaFBPeTfWQLmcENvp1cg, n/a) already exists.
```

Sectors and holdings share a transaction, so a *holdings* collision discarded the sector exposures too. Hit `EXUS`, `IEMG`, `KARS`, `NATO`.

### 2. Rate limiting was indistinguishable from "no data"

A free-tier throttle is HTTP 200 with an `Information`/`Note` body. It parsed cleanly into an empty response, so the code read it as "nothing to classify" and returned `false` — no error counted, `log.debug` only.

Compounding it, the refresh restarted from the top of the list every run, spending the 25/day quota on the same head and never reaching the tail.

## Changes

- `enrichClassification` returns `EnrichmentResult` (`ENRICHED` / `NO_DATA` / `FAILED` / `RATE_LIMITED`) instead of `Boolean`
- Skip placeholder symbols, de-duplicate case-insensitively, persist the normalized form (the constraint is case-sensitive)
- Detect throttling by top-level `Information`/`Note` key — Alpha's phrasing varies ("rate limit is 25 requests per day", "call frequency is 5 calls per minute"), the keys don't. Matches `AlphaPriceDeserializer`
- `Asset.classificationCheckedAt` (**V32**) records the last *attempt*; refresh takes never-checked and longest-stale first, bounded by `stale-after-days` (7) and `batch-limit` (20, under Alpha's 25/day)
- `RATE_LIMITED` aborts the run and is deliberately **not** stamped — a throttled asset was never really checked, so it retries rather than going to the back of the queue
- `BackfillResult` gains `noData` / `rateLimited` / `skipped`; `errors` now actually populated
- Schedule weekly → daily; a batch limit only makes progress on a daily tick

`Asset.classificationCheckedAt` is `@JsonIgnore` — no change to the bc-view API surface.

## Tests

`AlphaClassificationEnricherTest` is **new** — the enricher running in production had no unit test at all, which is how the `n/a` case shipped.

- Placeholder + case-variant + padded duplicate holdings → only real, normalized symbols persisted; sectors still written; `ENRICHED`
- Throttle body → `RATE_LIMITED`, existing exposures/holdings **not** cleared
- Throttle variant without the words "rate limit" → still `RATE_LIMITED`
- ETF on a market Alpha doesn't cover (`NATO.LON` → `{}`) → `NO_DATA`, nothing written. kauri has two distinct funds coded `NATO`: THEMES TRANSATLANTIC DEFENSE (US) and FUTURE OF DEFENCE UCITS (LON)
- Refresh service: staleness skip, batch-limit cutoff, rate-limit abort, `FAILED` counted in `errors`, checked-at stamped for every outcome except `RATE_LIMITED`

## Verification

`./gradlew testSmart && formatKotlin && lintKotlin` — all green.

Note: one pre-existing flaky timing assertion in `svc-position` `BaseAccumulationStrategyTest` ("currency resolution optimization", wall-clock budget) fails under parallel load and passes in isolation on both this branch and pristine `main`. Unrelated to this change.

## Follow-ups (filed separately)

- Duplicate asset rows for one fund across the `US|NASDAQ|NYSE|AMEX` pseudo-markets — all resolve to the same bare Alpha symbol and would produce identical classification sets
- `GET /api/assets/{market}/{code}` is get-or-create, so a read-shaped request mints rows
