### PR TITLE
fix(classification): classify MUTUAL FUND assets, expose last-checked date

### DIFF
--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/Asset.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/Asset.kt
@@ -63,9 +63,12 @@ data class Asset(
     /**
      * Date this asset's sector/industry classification (or, for ETFs, its sector exposures) was
      * last *attempted*. Drives resume-aware classification refresh — see
-     * `ClassificationRefreshService`. Not part of the public API surface consumed by bc-view.
+     * `ClassificationRefreshService`. Serialized to bc-view so the sector-weightings UI can
+     * distinguish "never checked" from "checked, but the provider had no sector data" — an
+     * empty exposures list carries no `asOf` of its own, so this field is the only signal
+     * available in that case.
      */
-    @JsonIgnore
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     var classificationCheckedAt: LocalDate? = null
 ) {
     companion object {

--- a/jar-contracts/src/test/kotlin/com/beancounter/common/model/AssetJsonTest.kt
+++ b/jar-contracts/src/test/kotlin/com/beancounter/common/model/AssetJsonTest.kt
@@ -1,0 +1,48 @@
+package com.beancounter.common.model
+
+import com.beancounter.common.utils.BcJson.Companion.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+/**
+ * Verifies JSON (de)serialization behaviour of [Asset.classificationCheckedAt].
+ *
+ * bc-view's sector-weightings UI relies on this field being present when set, and
+ * absent (not `null`) when it has never been checked - it is the only signal available
+ * to distinguish "never checked" from "checked, provider had no data" once the
+ * exposures list is empty.
+ */
+class AssetJsonTest {
+    private fun asset(classificationCheckedAt: LocalDate?) =
+        Asset(
+            code = "MSFT",
+            market = Market("NASDAQ"),
+            classificationCheckedAt = classificationCheckedAt
+        )
+
+    @Test
+    fun `classificationCheckedAt is serialized when set`() {
+        val checkedAt = LocalDate.of(2026, 8, 1)
+        val json = objectMapper.writeValueAsString(asset(checkedAt))
+
+        assertThat(json).contains("\"classificationCheckedAt\":\"2026-08-01\"")
+    }
+
+    @Test
+    fun `classificationCheckedAt is omitted when null`() {
+        val json = objectMapper.writeValueAsString(asset(null))
+
+        assertThat(json).doesNotContain("classificationCheckedAt")
+    }
+
+    @Test
+    fun `classificationCheckedAt round-trips through serialization`() {
+        val checkedAt = LocalDate.of(2026, 8, 1)
+        val json = objectMapper.writeValueAsString(asset(checkedAt))
+
+        val result = objectMapper.readValue(json, Asset::class.java)
+
+        assertThat(result.classificationCheckedAt).isEqualTo(checkedAt)
+    }
+}


### PR DESCRIPTION
Two changes so fund sector data actually reaches the UI.

## 1. `MUTUAL FUND` assets were never classified

Reported: SMOT and EIMI have no "View Sectors" option. Root cause is not the UI.

kauri categorises all of these as `MUTUAL FUND`:

| Code | Market | Category |
|---|---|---|
| SMOT | US | MUTUAL FUND |
| SMOT | LON | MUTUAL FUND |
| SMOT | LSE | MUTUAL FUND |
| EIMI | LSE | MUTUAL FUND |

`SMOT` on **US** is a NASDAQ-listed ETF, and AlphaVantage returns its sector weights right now:

```
GET /query?function=ETF_PROFILE&symbol=SMOT
{"net_assets":"334400000", ..., "sectors":[{"sector":"HEALTHCARE", ...}]}
```

But `findActiveEtfs` filtered on `IN ('ETF','EXCHANGE TRADED FUND')`, so `MUTUAL FUND` assets were absent from the refresh population and never asked about. Not a provider coverage limit — a filter bug. Providers routinely type ETFs this way.

Added `MUTUAL FUND` to `ETF_CATEGORIES` and both repository queries.

Also: `AlphaClassificationEnricher` kept a **private copy** of the category sets which had already drifted from the shared ones. Pointed it at `ClassificationEnricher` so they cannot diverge again — that duplication is how the inconsistency arose.

Non-US listings (`EIMI.LSE`, `SMOT.LON`) still resolve to symbols AlphaVantage does not cover and return `NO_DATA`. Thanks to #1060 they are now stamped once and skipped for `stale-after-days` rather than retried every run, so the quota cost of including them is bounded.

This supersedes my earlier reasoning for keeping `MUTUAL FUND` out of the population — that argument assumed the excluded assets were all non-US and unservable. SMOT.US disproves it.

## 2. `classificationCheckedAt` is now serialized

Added by #1060 for resume-aware refresh, marked `@JsonIgnore`. The UI cannot distinguish "never checked" from "checked, and the provider had no data" — exposure rows carry `asOf`, but an empty list has nothing to date.

Switched to `@JsonInclude(NON_NULL)`, matching sibling nullable fields on `Asset`.

## Tests

- `a MUTUAL FUND is treated as fund-like and enriched from the ETF profile` — asserts `canEnrich`/`isEtf` and a real exposure write, modelled on SMOT
- New `AssetJsonTest` in `jar-contracts`: serialized when set, omitted when null, round-trips. Verified the new source set actually executes (`tests="3"` in the result XML)

`./gradlew testSmart && formatKotlin && lintKotlin` — all green.

## Pairs with

monowai/bc-view#1140 — surfaces the date and stops hiding the menu for fund-like categories.