### PR TITLE
fix(classification): classify MUTUAL FUND assets

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/AssetRepository.kt
@@ -135,7 +135,7 @@ interface AssetRepository : JpaRepository<Asset, String> {
     @Query(
         "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
             "WHERE a.status = com.beancounter.common.model.Status.Active " +
-            "AND UPPER(a.category) IN ('ETF', 'EXCHANGE TRADED FUND') " +
+            "AND UPPER(a.category) IN ('ETF', 'EXCHANGE TRADED FUND', 'MUTUAL FUND') " +
             "AND a.code IS NOT NULL AND a.code <> ''"
     )
     fun findActiveEtfs(): List<Asset>
@@ -160,7 +160,7 @@ interface AssetRepository : JpaRepository<Asset, String> {
     @Query(
         "SELECT a FROM Asset a LEFT JOIN FETCH a.systemUser LEFT JOIN FETCH a.accountingType " +
             "WHERE a.status = com.beancounter.common.model.Status.Active " +
-            "AND UPPER(a.category) IN ('ETF', 'EXCHANGE TRADED FUND') " +
+            "AND UPPER(a.category) IN ('ETF', 'EXCHANGE TRADED FUND', 'MUTUAL FUND') " +
             "AND a.code IS NOT NULL AND a.code <> '' " +
             "AND (a.classificationCheckedAt IS NULL OR a.classificationCheckedAt < :cutoff) " +
             "ORDER BY a.classificationCheckedAt ASC NULLS FIRST"

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
@@ -244,8 +244,10 @@ class AlphaClassificationEnricher(
     }
 
     companion object {
-        private val EQUITY_CATEGORIES = setOf("EQUITY", "COMMON STOCK")
-        private val ETF_CATEGORIES = setOf("ETF", "EXCHANGE TRADED FUND")
+        // Category sets live on ClassificationEnricher - a local copy here silently drifted out of
+        // sync with the shared one, which is how MUTUAL FUND ended up handled inconsistently.
+        private val EQUITY_CATEGORIES = ClassificationEnricher.EQUITY_CATEGORIES
+        private val ETF_CATEGORIES = ClassificationEnricher.ETF_CATEGORIES
         private val PLACEHOLDER_SYMBOLS = setOf("N/A", "NA", "-", "--")
         private const val MAX_HOLDINGS = 10
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationEnricher.kt
@@ -24,7 +24,16 @@ interface ClassificationEnricher {
 
     companion object {
         val EQUITY_CATEGORIES = setOf("EQUITY", "COMMON STOCK")
-        val ETF_CATEGORIES = setOf("ETF", "EXCHANGE TRADED FUND")
+
+        /**
+         * Fund-like categories that can carry pooled sector exposures.
+         *
+         * `MUTUAL FUND` is included because providers routinely type exchange-traded funds that
+         * way — kauri categorises VanEck's US-listed `SMOT` (a NASDAQ ETF whose sector weights
+         * AlphaVantage serves today) as `MUTUAL FUND`, as well as `EIMI` and the LSE/LON `SMOT`
+         * listings. Excluding the category meant those funds were never even asked about.
+         */
+        val ETF_CATEGORIES = setOf("ETF", "EXCHANGE TRADED FUND", "MUTUAL FUND")
 
         fun categoryCanEnrich(asset: Asset): Boolean {
             val category = asset.category.uppercase()

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
@@ -107,6 +107,35 @@ class AlphaClassificationEnricherTest {
             status = Status.Active
         )
 
+    /**
+     * Providers routinely type exchange-traded funds as `MUTUAL FUND`. kauri categorises VanEck's
+     * US-listed SMOT that way — a NASDAQ ETF whose sector weights AlphaVantage serves today — so
+     * treating the category as non-fund meant it was never asked about at all.
+     */
+    @Test
+    fun `a MUTUAL FUND is treated as fund-like and enriched from the ETF profile`() {
+        val fund =
+            Asset(
+                id = "etf-1",
+                code = "SMOT",
+                name = "VANECK MORNINGSTAR SMID MOAT",
+                category = "MUTUAL FUND",
+                market = market,
+                priceSymbol = "SMOT",
+                status = Status.Active
+            )
+        val body = """{"sectors": [{"sector": "Health Care", "weight": "0.18"}]}"""
+        whenever(alphaProxy.getEtfProfile(eq("SMOT"), any())).thenReturn(body)
+
+        assertThat(enricher.canEnrich(fund)).isTrue()
+        assertThat(enricher.isEtf(fund)).isTrue()
+
+        val result = enricher.enrichClassification(fund)
+
+        assertThat(result).isEqualTo(EnrichmentResult.ENRICHED)
+        verify(classificationService).addExposure(any(), any(), any(), any(), any())
+    }
+
     @Test
     fun `enrichEtf skips placeholder and duplicate holding symbols but still writes sectors`() {
         val body =


### PR DESCRIPTION
Follow-on to #1063. Reported: SMOT and EIMI have no "View Sectors" option. Root cause is not the UI.

## The filter, not the provider

kauri categorises all of these as `MUTUAL FUND`:

| Code | Market | Category |
|---|---|---|
| SMOT | US | MUTUAL FUND |
| SMOT | LON | MUTUAL FUND |
| SMOT | LSE | MUTUAL FUND |
| EIMI | LSE | MUTUAL FUND |

`SMOT` on **US** is a NASDAQ-listed ETF, and AlphaVantage serves its sector weights today:

```
GET /query?function=ETF_PROFILE&symbol=SMOT
{"net_assets":"334400000", ..., "sectors":[{"sector":"HEALTHCARE", ...}]}
```

`findActiveEtfs` filtered on `IN ('ETF','EXCHANGE TRADED FUND')`, so `MUTUAL FUND` assets were absent from the refresh population and never asked about. Permanently unclassified — not a coverage limit, a filter bug. Providers routinely type ETFs this way.

Added `MUTUAL FUND` to `ETF_CATEGORIES` and both repository queries.

## Duplicate category sets

`AlphaClassificationEnricher` kept a **private copy** of `EQUITY_CATEGORIES` / `ETF_CATEGORIES` that had already drifted from the shared ones on `ClassificationEnricher`. That duplication is how the category came to be handled inconsistently. It now references the shared sets so they cannot diverge again.

## Quota

Non-US listings (`EIMI.LSE`, `SMOT.LON`) resolve to symbols AlphaVantage does not cover and return `NO_DATA`. Thanks to #1060 they are stamped once and skipped for `stale-after-days` rather than retried every run, so the cost of including them is bounded rather than recurring.

This supersedes the reasoning in #1063 for keeping `MUTUAL FUND` out of the population — that assumed everything excluded was non-US and unservable. SMOT.US disproves it.

## Test

`a MUTUAL FUND is treated as fund-like and enriched from the ETF profile` — asserts `canEnrich`/`isEtf` and a real exposure write, modelled on SMOT.

`./gradlew testSmart && formatKotlin && lintKotlin` — all green.

## Pairs with

monowai/bc-view#1140 — stops hiding the menu for fund-like categories and surfaces the as-at date.