### PR TITLE
fix(position): weigh every position in one common currency

### DIFF
--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionCalculationSupport.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionCalculationSupport.kt
@@ -47,42 +47,51 @@ class PositionCalculationSupport {
     private val roiCalculator = RoiCalculator()
 
     /**
-     * Calculates trade money values and sets the weight based on reference totals.
+     * The position's money values in the asset's own trade currency.
      */
-    fun calculateTradeMoneyValues(
-        position: Position,
-        refTotals: Totals
-    ): MoneyValues {
-        val tradeMoneyValues = position.getMoneyValues(Position.In.TRADE, position.asset.market.currency)
-        tradeMoneyValues.weight = percentUtils.percent(tradeMoneyValues.marketValue, refTotals.marketValue)
-        return tradeMoneyValues
-    }
+    fun calculateTradeMoneyValues(position: Position): MoneyValues =
+        position.getMoneyValues(Position.In.TRADE, position.asset.market.currency)
 
     /**
-     * Calculates base money values and sets the weight based on base totals.
+     * The position's money values in the owner's base currency.
      */
     fun calculateBaseMoneyValues(
         position: Position,
-        baseTotals: Totals,
         baseCurrency: Currency
-    ): MoneyValues {
-        val baseMoneyValues = position.getMoneyValues(Position.In.BASE, baseCurrency)
-        baseMoneyValues.weight = percentUtils.percent(baseMoneyValues.marketValue, baseTotals.marketValue)
-        return baseMoneyValues
-    }
+    ): MoneyValues = position.getMoneyValues(Position.In.BASE, baseCurrency)
 
     /**
-     * Calculates portfolio money values and sets the weight based on trade totals.
+     * The position's money values in the portfolio's reporting currency.
      */
     fun calculatePortfolioMoneyValues(
         position: Position,
-        tradeMoneyValues: MoneyValues,
-        tradeTotals: Totals,
         portfolioCurrency: Currency
-    ): MoneyValues {
-        val portfolioMoneyValues = position.getMoneyValues(Position.In.PORTFOLIO, portfolioCurrency)
-        portfolioMoneyValues.weight = percentUtils.percent(tradeMoneyValues.marketValue, tradeTotals.marketValue)
-        return portfolioMoneyValues
+    ): MoneyValues = position.getMoneyValues(Position.In.PORTFOLIO, portfolioCurrency)
+
+    /**
+     * A weight is dimensionless: the fraction of the portfolio a position
+     * represents is the same number whichever currency you value it in. So it
+     * is computed once — in the base currency, the one currency every position
+     * converts to — and stamped on every bucket.
+     *
+     * Both sides of the ratio must share a currency. A trade-currency market
+     * value over the trade-currency totals is not a ratio at all: those totals
+     * sum values across every trade currency the portfolio holds, so the
+     * denominator has no currency. A foreign holding weighed that way comes out
+     * wrong by its own FX rate.
+     */
+    fun assignWeights(
+        moneyValuesGroup: MoneyValuesGroup,
+        baseTotals: Totals
+    ) {
+        val weight =
+            percentUtils.percent(
+                moneyValuesGroup.baseMoneyValues.marketValue,
+                baseTotals.marketValue
+            )
+        moneyValuesGroup.tradeMoneyValues.weight = weight
+        moneyValuesGroup.baseMoneyValues.weight = weight
+        moneyValuesGroup.portfolioMoneyValues.weight = weight
     }
 
     /**

--- a/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/service/PositionValuationService.kt
@@ -205,26 +205,20 @@ class PositionValuationService(
         positionContext: PositionContext,
         totalsGroup: TotalsGroup
     ) {
-        val tradeMoneyValues =
-            calculationSupport.calculateTradeMoneyValues(
-                positionContext.position,
-                totalsGroup.tradeTotals
-            )
+        val tradeMoneyValues = calculationSupport.calculateTradeMoneyValues(positionContext.position)
         val baseMoneyValues =
             calculationSupport.calculateBaseMoneyValues(
                 positionContext.position,
-                totalsGroup.baseTotals,
                 positionContext.positions.portfolio.base
             )
         val portfolioMoneyValues =
             calculationSupport.calculatePortfolioMoneyValues(
                 positionContext.position,
-                tradeMoneyValues,
-                totalsGroup.tradeTotals,
                 positionContext.positions.portfolio.currency
             )
 
         val moneyValuesGroup = MoneyValuesGroup(tradeMoneyValues, baseMoneyValues, portfolioMoneyValues)
+        calculationSupport.assignWeights(moneyValuesGroup, totalsGroup.baseTotals)
 
         if (!cashUtils.isCash(positionContext.position.asset)) {
             processNonCashPosition(positionContext, totalsGroup, moneyValuesGroup)

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionCalculationSupportTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionCalculationSupportTest.kt
@@ -2,6 +2,7 @@ package com.beancounter.position.service
 
 import com.beancounter.common.model.MoneyValues
 import com.beancounter.common.model.Totals
+import com.beancounter.position.Constants.Companion.SGD
 import com.beancounter.position.Constants.Companion.USD
 import com.beancounter.position.utils.TestHelpers
 import org.assertj.core.api.Assertions.assertThat
@@ -21,57 +22,100 @@ class PositionCalculationSupportTest {
     fun `should calculate trade money values correctly`() {
         // Given
         val position = TestHelpers.createTestPosition()
-        val refTotals = Totals(USD, marketValue = BigDecimal("1000.00"))
 
         // When
-        val result = calculationSupport.calculateTradeMoneyValues(position, refTotals)
+        val result = calculationSupport.calculateTradeMoneyValues(position)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.currency).isEqualTo(USD)
-        assertThat(result.weight).isNotNull()
     }
 
     @Test
     fun `should calculate base money values correctly`() {
         // Given
         val position = TestHelpers.createTestPosition()
-        val baseTotals = Totals(USD, marketValue = BigDecimal("1000.00"))
         val baseCurrency = USD
 
         // When
-        val result = calculationSupport.calculateBaseMoneyValues(position, baseTotals, baseCurrency)
+        val result = calculationSupport.calculateBaseMoneyValues(position, baseCurrency)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.currency).isEqualTo(USD)
-        assertThat(result.weight).isNotNull()
     }
 
     @Test
     fun `should calculate portfolio money values correctly`() {
         // Given
         val position = TestHelpers.createTestPosition()
-        val tradeMoneyValues =
-            MoneyValues(USD).apply {
-                marketValue = BigDecimal("500.00")
-            }
-        val tradeTotals = Totals(USD, marketValue = BigDecimal("1000.00"))
         val portfolioCurrency = USD
 
         // When
-        val result =
-            calculationSupport.calculatePortfolioMoneyValues(
-                position,
-                tradeMoneyValues,
-                tradeTotals,
-                portfolioCurrency
-            )
+        val result = calculationSupport.calculatePortfolioMoneyValues(position, portfolioCurrency)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.currency).isEqualTo(USD)
-        assertThat(result.weight).isNotNull()
+    }
+
+    /**
+     * A foreign holding: 5 VOO valued USD 3,482 in a portfolio whose base and
+     * reporting currency is SGD, where the same holding is SGD 4,462.53 of an
+     * SGD 248,065.03 portfolio.
+     */
+    private fun foreignHolding(): MoneyValuesGroup =
+        MoneyValuesGroup(
+            tradeMoneyValues = MoneyValues(USD).apply { marketValue = BigDecimal("3482.00") },
+            baseMoneyValues = MoneyValues(SGD).apply { marketValue = BigDecimal("4462.53") },
+            portfolioMoneyValues = MoneyValues(SGD).apply { marketValue = BigDecimal("4462.53") }
+        )
+
+    @Test
+    fun `weight is the same-currency ratio, not a trade value over a mixed-currency total`() {
+        // Given — the trade total sums market values across every trade currency
+        // the portfolio holds, so it is not a currency at all and cannot be a
+        // denominator.
+        val moneyValues = foreignHolding()
+        val baseTotals = Totals(SGD, marketValue = BigDecimal("248065.03"))
+
+        // When
+        calculationSupport.assignWeights(moneyValues, baseTotals)
+
+        // Then — 4,462.53 / 248,065.03 SGD, not 3,482 USD / 245,867.22 "SGD".
+        assertThat(moneyValues.baseMoneyValues.weight)
+            .isEqualByComparingTo(BigDecimal("0.017989"))
+    }
+
+    @Test
+    fun `every bucket carries the same weight because a weight is dimensionless`() {
+        // Given
+        val moneyValues = foreignHolding()
+        val baseTotals = Totals(SGD, marketValue = BigDecimal("248065.03"))
+
+        // When
+        calculationSupport.assignWeights(moneyValues, baseTotals)
+
+        // Then — viewing the position in USD does not change what fraction of
+        // the portfolio it is.
+        assertThat(moneyValues.tradeMoneyValues.weight)
+            .isEqualByComparingTo(moneyValues.baseMoneyValues.weight)
+        assertThat(moneyValues.portfolioMoneyValues.weight)
+            .isEqualByComparingTo(moneyValues.baseMoneyValues.weight)
+    }
+
+    @Test
+    fun `an empty portfolio weighs nothing rather than dividing by zero`() {
+        // Given
+        val moneyValues = foreignHolding()
+
+        // When
+        calculationSupport.assignWeights(moneyValues, Totals(SGD, marketValue = BigDecimal.ZERO))
+
+        // Then
+        assertThat(moneyValues.baseMoneyValues.weight).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(moneyValues.tradeMoneyValues.weight).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(moneyValues.portfolioMoneyValues.weight).isEqualByComparingTo(BigDecimal.ZERO)
     }
 
     @Test

--- a/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
+++ b/svc-position/src/test/kotlin/com/beancounter/position/service/PositionValuationServiceTest.kt
@@ -104,10 +104,10 @@ class PositionValuationServiceTest {
 
         // Mock calculation support methods to return proper MoneyValues
         val mockMoneyValues = MoneyValues(portfolio.currency)
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
         whenever(
-            calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any())
+            calculationSupport.calculatePortfolioMoneyValues(any(), any())
         ).thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(BigDecimal.ZERO)
         whenever(irrCalculator.calculate(any())).thenReturn(0.0)
@@ -175,9 +175,9 @@ class PositionValuationServiceTest {
 
         val expectedRoi = BigDecimal("0.38")
         val mockMoneyValues = MoneyValues(portfolio.currency)
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(expectedRoi)
         // IRR calculator returns different value - but for short holding period, ROI should be used
@@ -222,9 +222,9 @@ class PositionValuationServiceTest {
 
         val mockMoneyValues = MoneyValues(portfolio.currency)
         mockMoneyValues.costValue = BigDecimal("90312.5")
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(BigDecimal("0.38"))
         whenever(irrCalculator.calculate(any())).thenReturn(0.0)
@@ -269,9 +269,9 @@ class PositionValuationServiceTest {
 
         val expectedRoi = BigDecimal("0.38")
         val mockMoneyValues = MoneyValues(portfolio.currency)
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(expectedRoi)
         whenever(irrCalculator.calculate(any())).thenReturn(0.27)
@@ -320,9 +320,9 @@ class PositionValuationServiceTest {
 
         val expectedRoi = BigDecimal("0.20") // 20% ROI
         val mockMoneyValues = MoneyValues(portfolio.currency)
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(expectedRoi)
         whenever(irrCalculator.calculate(any())).thenReturn(0.18) // XIRR returns different value
@@ -360,9 +360,9 @@ class PositionValuationServiceTest {
 
         val expectedRoi = BigDecimal("0.15")
         val mockMoneyValues = MoneyValues(portfolio.currency)
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(expectedRoi)
         whenever(irrCalculator.calculate(any())).thenReturn(0.12)
@@ -421,9 +421,9 @@ class PositionValuationServiceTest {
         val mockMoneyValues = MoneyValues(portfolio.currency)
         mockMoneyValues.realisedGain = BigDecimal("500.00")
         mockMoneyValues.totalGain = BigDecimal("500.00")
-        whenever(calculationSupport.calculateTradeMoneyValues(any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculateBaseMoneyValues(any(), any(), any())).thenReturn(mockMoneyValues)
-        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any(), any(), any()))
+        whenever(calculationSupport.calculateTradeMoneyValues(any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculateBaseMoneyValues(any(), any())).thenReturn(mockMoneyValues)
+        whenever(calculationSupport.calculatePortfolioMoneyValues(any(), any()))
             .thenReturn(mockMoneyValues)
         whenever(calculationSupport.calculateRoi(any())).thenReturn(expectedRoi)
         whenever(irrCalculator.calculate(any())).thenReturn(0.55)


### PR DESCRIPTION
## Problem

One holding, three different weights. VOO in an SGD portfolio:

| Where | Weight | What it actually divided |
|---|---|---|
| holdings table (`PORTFOLIO.weight`) | 1.42% | USD 3,482 ÷ 245,867 mixed-currency total |
| `BASE.weight` | 1.80% | SGD 4,462.53 ÷ SGD 248,065.03 ✅ |
| trade dialog | 2.31% | an SGD price converted to SGD *again* |

`calculatePortfolioMoneyValues` set the PORTFOLIO bucket's weight from the
**trade** market value over the **trade** totals, then stamped that on a bucket
quoted in portfolio currency. `calculateTradeMoneyValues` did the same thing to
itself. Those totals sum market values across every trade currency the portfolio
holds, so the denominator has no currency at all — a foreign holding came out
wrong by its own FX rate, and a single-currency portfolio never noticed.

## Change

A weight is dimensionless: the fraction of the portfolio a position represents
is the same number whichever currency you value it in. It is now computed once,
in the base currency every position converts to, and stamped on all three
buckets by a new `assignWeights`.

The three `calculateXxxMoneyValues` functions become what their names say —
they fetch the bucket — and lose the totals they only took in order to weigh
against the wrong one.

## Verification

- Regression test pins the real numbers: the foreign holding above weighs
  0.017989, not the trade-over-mixed-total 0.014162.
- Tests that every bucket carries the same weight, and that an empty portfolio
  weighs nothing rather than dividing by zero.
- `./gradlew testAll && formatKotlin && lintKotlin` green.
- Verified live against a local SGD portfolio: all three buckets now report
  0.017989 = 4,462.53 ÷ 248,065.03.

## Downstream

bc-view #1141 stops the trade dialog re-deriving its own weight and shows this
one. Until this deploys, the holdings table's weight column stays wrong.
