### PR TITLE
fix(trn): validate import trade date against beancounter.zone

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/BcRowAdapter.kt
@@ -43,9 +43,15 @@ class BcRowAdapter(
         return createTrnInput(trustedTrnImportRequest, trnType, asset, cashAssetId)
     }
 
+    /**
+     * "Today" is the configured `beancounter.zone`, not the JVM default. Clients send
+     * their own local date; a service running behind that zone (UTC pod, SGT browser)
+     * would otherwise read a same-day trade as forward dated and reject an import
+     * that no user can see fail — the CSV consumer acks the message away.
+     */
     private fun validateTradeDate(dateString: String) {
         val tradeDate = dateUtils.getDate(dateString)
-        if (tradeDate.isAfter(LocalDate.now())) {
+        if (tradeDate.isAfter(LocalDate.now(dateUtils.zoneId))) {
             throw BusinessException("Rejecting the forward dated trade date of $tradeDate")
         }
     }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/BcRowAdapterTest.kt
@@ -9,6 +9,7 @@ import com.beancounter.common.model.AssetCategory
 import com.beancounter.common.model.Market
 import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.Constants.Companion.CASH_MARKET
 import com.beancounter.marketdata.Constants.Companion.NASDAQ
 import com.beancounter.marketdata.Constants.Companion.NZD
@@ -29,6 +30,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
 
 /**
  * BC Row Adapter tests for handling various assertions around transformations.
@@ -369,6 +373,75 @@ class BcRowAdapterTest {
         // Cash leg must resolve the sell currency (NZD), not self-settle to USD.
         assertThat(result.cashAssetId).isEqualTo(nzdCashBalance.id)
     }
+
+    /**
+     * A client east of the service's JVM zone sends its own "today". Rejecting on
+     * `LocalDate.now()` (JVM default) instead of the configured `beancounter.zone`
+     * silently killed async CSV imports for ~8h a day on kauri: the pod runs UTC,
+     * the browser sent the SGT date, the message failed and was acked away.
+     *
+     * Kiritimati (UTC+14) is always at least a day ahead of Midway (UTC-11), so
+     * the assertion holds whatever the clock says.
+     */
+    @Test
+    fun `accepts today from the configured zone when the JVM default zone lags`() {
+        val serviceZone = ZoneId.of("Pacific/Kiritimati")
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val today = LocalDate.now(serviceZone)
+            val adapter =
+                BcRowAdapter(
+                    ais,
+                    cashTrnServices,
+                    dateUtils = DateUtils(serviceZone.id)
+                )
+
+            val result = adapter.transform(trustedTrnImportRequest(buyRow(today.toString())))
+
+            assertThat(result.tradeDate).isEqualTo(today)
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+
+    @Test
+    fun `rejects a trade date beyond today in the configured zone`() {
+        val serviceZone = ZoneId.of("Pacific/Midway")
+        val adapter =
+            BcRowAdapter(
+                ais,
+                cashTrnServices,
+                dateUtils = DateUtils(serviceZone.id)
+            )
+        val tomorrow = LocalDate.now(serviceZone).plusDays(1)
+
+        assertThrows(BusinessException::class.java) {
+            adapter.transform(trustedTrnImportRequest(buyRow(tomorrow.toString())))
+        }
+    }
+
+    private fun buyRow(tradeDate: String): List<String> =
+        listOf(
+            BATCH_USX,
+            CALLER_ID,
+            "BUY",
+            NASDAQ.code,
+            assetCode,
+            ASSET_NAME,
+            USD.code,
+            USD.code,
+            tradeDate,
+            "200.000000",
+            "1.000000",
+            USD.code,
+            "77.780000",
+            "0.00",
+            "1.386674",
+            "2000.00",
+            "-2000.00",
+            ""
+        )
 
     private fun trustedTrnImportRequest(values: List<String>): TrustedTrnImportRequest =
         TrustedTrnImportRequest(


### PR DESCRIPTION
## Problem

"Set Balance" on a cash account produced no error and no transaction. Reported on
kauri; reproducible anywhere the service's JVM zone lags the client's.

`SetCashBalanceDialog` posts a row to `/api/trns/import`, which publishes to
`bc-trn-csv-demo`. bc-data's consumer rejected it:

```
BusinessException: Rejecting the forward dated trade date of 2026-08-05
  at TrnImportService.fromCsvImport(TrnImportService.kt:49)
Retry policy ... exhausted; aborting execution
```

`BcRowAdapter.validateTradeDate` compared the row's date to `LocalDate.now()` — the
**JVM default zone**. The kauri pod runs UTC; the browser sends its local (SGT) date.
Between 00:00 and 08:00 SGT a same-day trade looked forward dated, the message failed
its retries and was acked away. `BEANCOUNTER_ZONE: "Asia/Singapore"` is already set in
`bc-deploy/env/kauri.yaml` and `DateUtils.zoneId` honours it — this one call site just
bypassed it.

## Change

Validate against `LocalDate.now(dateUtils.zoneId)`.

## Tests

Two tests on `BcRowAdapterTest`, both clock- and host-zone-independent by fixing a zone
pair 25h apart (Pacific/Kiritimati +14, Pacific/Midway −11):

- `accepts today from the configured zone when the JVM default zone lags` — reproduced
  the exact production exception before the fix.
- `rejects a trade date beyond today in the configured zone` — the guard still rejects
  genuinely future dates, measured in the configured zone.

Gates: `./gradlew testSmart` + `formatKotlin` + `lintKotlin` all green. `ocr review` — 0 findings.

## Verified against kauri

The sync path was already correct: `POST /trns` with a `BALANCE` on the EUR cash asset
persisted and moved the position (test trn deleted afterwards). Only the async import
path rejected.

## Follow-up

The swallowing itself — failed import messages acked with no DLQ and no user-visible
error — is #1067, not fixed here.
