### PR TITLE
fix(dates): resolve today through DateUtils, guard the zone boundary

### DIFF
--- a/jar-common/build.gradle.kts
+++ b/jar-common/build.gradle.kts
@@ -9,6 +9,19 @@ version = "0.1.3-SNAPSHOT"
 
 extra["guavaVersion"] = "33.3.1-jre"
 
+// ZoneLeakGuardTest scans every module's production sources, which Gradle cannot
+// infer. Without declaring them the task stays UP-TO-DATE while another module
+// introduces a leak, and the guard silently passes.
+tasks.named<Test>("test") {
+    inputs
+        .files(
+            fileTree(rootDir) {
+                include("*/src/main/kotlin/**/*.kt")
+            }
+        ).withPropertyName("zoneGuardSources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 dependencies {
     // Boot-agnostic tier (contracts/model/input/exception types/utils/…).
     // `api` so all downstream consumers keep seeing these symbols transitively

--- a/jar-common/src/test/kotlin/com/beancounter/common/utils/DateUtilsOffsetNowZoneTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/utils/DateUtilsOffsetNowZoneTest.kt
@@ -1,0 +1,36 @@
+package com.beancounter.common.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.TimeZone
+
+/**
+ * Every other method on DateUtils reads the clock through the configured zone.
+ * `offsetNow` stamped the time-of-day from the JVM default zone instead, which is
+ * only correct while the two happen to agree.
+ *
+ * Kiritimati (UTC+14) and Midway (UTC-11) are 25 hours apart, so the two zones can
+ * never report the same time of day and the assertion cannot flake.
+ */
+class DateUtilsOffsetNowZoneTest {
+    private val serviceZone = ZoneId.of("Pacific/Kiritimati")
+
+    @Test
+    fun `offsetNow takes its time of day from the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val dateUtils = DateUtils(serviceZone.id)
+
+            val stamped = dateUtils.offsetNow("2020-11-11").toLocalTime()
+
+            assertThat(Duration.between(stamped, LocalTime.now(serviceZone)).abs())
+                .isLessThan(Duration.ofMinutes(1))
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+}

--- a/jar-common/src/test/kotlin/com/beancounter/common/utils/ZoneLeakGuardTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/common/utils/ZoneLeakGuardTest.kt
@@ -1,0 +1,88 @@
+package com.beancounter.common.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Guards the zone boundary across the mono-repo.
+ *
+ * Reading the clock with a bare `LocalDate.now()` resolves in the JVM default zone
+ * (UTC in the pods) rather than the configured `beancounter.zone` the users actually
+ * live in. That leak rejected same-day trade dates on the CSV import path for eight
+ * hours a day before anyone noticed, because the failure was swallowed by the
+ * consumer. Dates that reach a user, a ledger row, or a query bound must come from
+ * [DateUtils].
+ *
+ * The baseline resource lists the files that still leak. It only ever shrinks: a new
+ * leak fails this test, and so does a stale entry, so the list can't quietly rot into
+ * a permanent allowlist.
+ */
+class ZoneLeakGuardTest {
+    private val bannedCall =
+        Regex(
+            """\b(?:LocalDate|LocalDateTime|LocalTime|YearMonth|ZonedDateTime|OffsetDateTime)\.now\(\)""" +
+                """|ZoneId\.systemDefault\(\)"""
+        )
+    private val blockComment = Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL)
+    private val lineComment = Regex("""//[^\n]*""")
+
+    @Test
+    fun `no new zone leaks in production sources`() {
+        val leaking = leakingFiles()
+        val baseline = baseline()
+
+        assertThat(leaking - baseline)
+            .describedAs(
+                "These files read the clock in the JVM default zone. Inject DateUtils and " +
+                    "use dateUtils.date / dateUtils.today(), or LocalDate.now(dateUtils.zoneId)"
+            ).isEmpty()
+    }
+
+    @Test
+    fun `baseline lists no file that has already been fixed`() {
+        val leaking = leakingFiles()
+        val baseline = baseline()
+
+        assertThat(baseline - leaking)
+            .describedAs("Fixed — delete these lines from zone-leak-baseline.txt")
+            .isEmpty()
+    }
+
+    private fun baseline(): Set<String> =
+        javaClass
+            .getResourceAsStream("/zone-leak-baseline.txt")!!
+            .bufferedReader()
+            .readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .toSet()
+
+    /**
+     * Repo-relative paths of production sources containing a banned call, comments
+     * stripped so that documenting the pattern doesn't count as using it.
+     */
+    private fun leakingFiles(): Set<String> {
+        val root = repoRoot()
+        return root
+            .listFiles { file -> file.isDirectory }
+            .orEmpty()
+            .map { module -> File(module, "src/main/kotlin") }
+            .filter { it.isDirectory }
+            .flatMap { it.walkTopDown().filter { file -> file.extension == "kt" } }
+            .filter { file ->
+                val code = lineComment.replace(blockComment.replace(file.readText(), ""), "")
+                bannedCall.containsMatchIn(code)
+            }.map { it.relativeTo(root).path }
+            .toSet()
+    }
+
+    private fun repoRoot(): File {
+        var candidate: File? = File(System.getProperty("user.dir")).absoluteFile
+        while (candidate != null && !File(candidate, "settings.gradle.kts").isFile) {
+            candidate = candidate.parentFile
+        }
+        return candidate
+            ?: error("Could not locate the repository root from ${System.getProperty("user.dir")}")
+    }
+}

--- a/jar-common/src/test/resources/zone-leak-baseline.txt
+++ b/jar-common/src/test/resources/zone-leak-baseline.txt
@@ -1,0 +1,47 @@
+# Files under */src/main/kotlin that still read the clock through the JVM default
+# zone (bare LocalDate.now() / LocalDateTime.now() / ZoneId.systemDefault() etc.)
+# instead of the configured beancounter.zone via DateUtils.
+#
+# This is a SHRINKING baseline, not an allowlist to grow. ZoneLeakGuardTest fails if
+# a file not listed here starts leaking, and also fails if a listed file no longer
+# leaks — delete the line when you fix one.
+#
+# Why it matters: the pods run UTC while users are SGT (UTC+8). A bare now() dated a
+# same-day trade as "tomorrow" and the CSV import consumer rejected it silently (#1067,
+# fixed for the import guard in #1068).
+jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetClassification.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetExposure.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetHolding.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/FxRate.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/MarketData.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/PriceData.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/SystemUser.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/UserExplorerAction.kt
+jar-contracts/src/main/kotlin/com/beancounter/common/model/UserMilestone.kt
+svc-agent/src/main/kotlin/com/beancounter/agent/clients/RetireServiceClient.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/markets/MarketCalendarConfig.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/milestone/MilestoneService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializer.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackProxy.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarGateway.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarProxy.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRate.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
+svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
+svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
+svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotEntity.kt

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/utils/DateUtils.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/utils/DateUtils.kt
@@ -159,7 +159,7 @@ class DateUtils(
             OffsetDateTime.now(UTC)
         } else {
             OffsetDateTime.of(
-                getFormattedDate(date).atTime(LocalTime.now()),
+                getFormattedDate(date).atTime(LocalTime.now(zoneId)),
                 UTC
             )
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferContracts.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferContracts.kt
@@ -26,7 +26,10 @@ data class CashTransferRequest(
     val toAssetId: String,
     val sentAmount: BigDecimal,
     val receivedAmount: BigDecimal = sentAmount,
-    val tradeDate: LocalDate = LocalDate.now(),
+    // Null means "today", resolved by CashTransferService in the configured
+    // beancounter.zone. A LocalDate.now() default here would resolve in the JVM
+    // zone and back-date the settled legs for callers east of it.
+    val tradeDate: LocalDate? = null,
     val description: String? = null
 )
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashTransferService.kt
@@ -4,6 +4,7 @@ import com.beancounter.common.contracts.TrnRequest
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetService
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.trn.TrnService
@@ -26,7 +27,8 @@ import java.math.BigDecimal
 class CashTransferService(
     private val assetService: AssetService,
     private val portfolioService: PortfolioService,
-    private val trnService: TrnService
+    private val trnService: TrnService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(CashTransferService::class.java)
 
@@ -62,6 +64,7 @@ class CashTransferService(
             "Cannot transfer between different currencies: $fromCurrency and $toCurrency"
         }
 
+        val tradeDate = request.tradeDate ?: dateUtils.date
         val transactions = mutableListOf<Trn>()
 
         // Create WITHDRAWAL transaction (amount sent from source)
@@ -72,7 +75,7 @@ class CashTransferService(
                 trnType = TrnType.WITHDRAWAL,
                 amount = request.sentAmount,
                 currency = fromCurrency,
-                tradeDate = request.tradeDate,
+                tradeDate = tradeDate,
                 status = TrnStatus.SETTLED,
                 comments = request.description ?: "Transfer to ${toAsset.code}"
             )
@@ -95,7 +98,7 @@ class CashTransferService(
                 trnType = TrnType.DEPOSIT,
                 amount = request.receivedAmount,
                 currency = toCurrency,
-                tradeDate = request.tradeDate,
+                tradeDate = tradeDate,
                 status = TrnStatus.SETTLED,
                 comments = request.description ?: "Transfer from ${fromAsset.code}"
             )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
@@ -11,6 +11,7 @@ import com.beancounter.common.model.Portfolio
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.portfolio.PortfolioService
 import jakarta.transaction.Transactional
@@ -26,7 +27,8 @@ class PositionMoveService(
     private val portfolioService: PortfolioService,
     private val fxTransactions: FxTransactions,
     private val trnService: TrnService,
-    private val cacheInvalidationProducer: CacheInvalidationProducer
+    private val cacheInvalidationProducer: CacheInvalidationProducer,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(PositionMoveService::class.java)
 
@@ -71,7 +73,7 @@ class PositionMoveService(
 
         trnRepository.saveAll(transactions)
 
-        val earliestDate = transactions.minOfOrNull { it.tradeDate } ?: LocalDate.now()
+        val earliestDate = transactions.minOfOrNull { it.tradeDate } ?: dateUtils.date
         cacheInvalidationProducer.sendTransactionEvent(sourcePortfolio.id, earliestDate)
         cacheInvalidationProducer.sendTransactionEvent(targetPortfolio.id, earliestDate)
 
@@ -198,7 +200,7 @@ class PositionMoveService(
             trnType = trnType,
             amount = amount,
             currency = tradeCurrency,
-            tradeDate = LocalDate.now(),
+            tradeDate = dateUtils.date,
             status = TrnStatus.SETTLED,
             comments = comment,
             // Preserve historical behaviour: this call site never set price, so

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt
@@ -166,7 +166,7 @@ class TrnFinder(
         cashAssetId: String
     ): Collection<Trn> {
         val portfolio = portfolioService.find(portfolioId)
-        val today = LocalDate.now()
+        val today = dateUtils.date
         val results =
             trnRepository.findByPortfolioIdAndCashAssetId(
                 portfolio.id,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/cash/CashTransferZoneTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/cash/CashTransferZoneTest.kt
@@ -1,0 +1,88 @@
+package com.beancounter.marketdata.cash
+
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.Constants.Companion.usdCashBalance
+import com.beancounter.marketdata.assets.AssetService
+import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.trn.TrnService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
+
+/**
+ * `POST /cash/transfer` may omit tradeDate, in which case the transfer is dated
+ * "today". That day has to be resolved in the configured `beancounter.zone` — a
+ * DTO-level `LocalDate.now()` default resolves in the JVM zone and back-dates the
+ * settled legs for any caller east of it (the same defect as the CSV import guard).
+ *
+ * Kiritimati (UTC+14) is always at least a day ahead of Midway (UTC-11), so the
+ * assertion never depends on the wall clock or the host zone.
+ */
+class CashTransferZoneTest {
+    private val serviceZone = ZoneId.of("Pacific/Kiritimati")
+
+    private val portfolio =
+        Portfolio(
+            id = "zone-transfer",
+            code = "ZT",
+            currency = USD,
+            base = USD,
+            owner = SystemUser("zone-user", "zone@example.com")
+        )
+
+    @Test
+    fun `a transfer with no trade date is dated today in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val assetService = mock<AssetService>()
+            val portfolioService = mock<PortfolioService>()
+            val trnService = mock<TrnService>()
+
+            whenever(assetService.find(usdCashBalance.id)).thenReturn(usdCashBalance)
+            whenever(portfolioService.find(portfolio.id)).thenReturn(portfolio)
+            whenever(trnService.save(any<Portfolio>(), any<TrnRequest>())).thenReturn(emptyList())
+
+            val cashTransferService =
+                CashTransferService(
+                    assetService,
+                    portfolioService,
+                    trnService,
+                    DateUtils(serviceZone.id)
+                )
+
+            cashTransferService.transfer(
+                CashTransferRequest(
+                    fromPortfolioId = portfolio.id,
+                    fromAssetId = usdCashBalance.id,
+                    toPortfolioId = portfolio.id,
+                    toAssetId = usdCashBalance.id,
+                    sentAmount = BigDecimal("100")
+                )
+            )
+
+            val captor = argumentCaptor<TrnRequest>()
+            verify(trnService, times(2)).save(any<Portfolio>(), captor.capture())
+
+            val legDates = captor.allValues.flatMap { it.data }.map { it.tradeDate }
+            assertThat(legDates)
+                .isNotEmpty
+                .allMatch { it == LocalDate.now(serviceZone) }
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/PositionMoveZoneTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/PositionMoveZoneTest.kt
@@ -1,0 +1,121 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.client.ingest.FxTransactions
+import com.beancounter.common.contracts.PositionMoveRequest
+import com.beancounter.common.contracts.TrnRequest
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants.Companion.MSFT
+import com.beancounter.marketdata.Constants.Companion.USD
+import com.beancounter.marketdata.Constants.Companion.usdCashBalance
+import com.beancounter.marketdata.cache.CacheInvalidationProducer
+import com.beancounter.marketdata.portfolio.PortfolioService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
+
+/**
+ * Moving a position writes real SETTLED compensating cash legs. Their trade date has
+ * to be "today" in the configured `beancounter.zone` — dating them from the JVM
+ * default zone puts a wrong-day entry in the ledger for anyone east of the pod's zone.
+ *
+ * Kiritimati (UTC+14) is always at least a day ahead of Midway (UTC-11), so the
+ * assertion holds whatever the host clock and host zone are.
+ */
+class PositionMoveZoneTest {
+    private val owner = SystemUser("zone-user", "zone@example.com")
+
+    private val sourcePortfolio =
+        Portfolio(
+            id = "zone-source",
+            code = "ZSOURCE",
+            currency = USD,
+            base = USD,
+            owner = owner
+        )
+
+    private val targetPortfolio =
+        Portfolio(
+            id = "zone-target",
+            code = "ZTARGET",
+            currency = USD,
+            base = USD,
+            owner = owner
+        )
+
+    private val serviceZone = ZoneId.of("Pacific/Kiritimati")
+
+    @Test
+    fun `compensating cash legs are dated today in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val trnRepository = mock<TrnRepository>()
+            val portfolioService = mock<PortfolioService>()
+            val trnService = mock<TrnService>()
+            val positionMoveService =
+                PositionMoveService(
+                    trnRepository,
+                    portfolioService,
+                    mock<FxTransactions>(),
+                    trnService,
+                    mock<CacheInvalidationProducer>(),
+                    DateUtils(serviceZone.id)
+                )
+
+            whenever(portfolioService.find(sourcePortfolio.id)).thenReturn(sourcePortfolio)
+            whenever(portfolioService.find(targetPortfolio.id)).thenReturn(targetPortfolio)
+            whenever(trnRepository.findByPortfolioIdAndAssetId(sourcePortfolio.id, MSFT.id))
+                .thenReturn(listOf(buyTrn()))
+
+            positionMoveService.movePosition(
+                PositionMoveRequest(
+                    sourcePortfolioId = sourcePortfolio.id,
+                    targetPortfolioId = targetPortfolio.id,
+                    assetId = MSFT.id,
+                    maintainCashBalances = true
+                )
+            )
+
+            val captor = argumentCaptor<TrnRequest>()
+            verify(trnService).save(eq(sourcePortfolio), captor.capture())
+            verify(trnService).save(eq(targetPortfolio), captor.capture())
+
+            val cashLegDates = captor.allValues.flatMap { it.data }.map { it.tradeDate }
+            assertThat(cashLegDates)
+                .isNotEmpty
+                .allMatch { it == LocalDate.now(serviceZone) }
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+
+    private fun buyTrn(): Trn =
+        Trn(
+            id = "zone-trn",
+            trnType = TrnType.BUY,
+            asset = MSFT,
+            quantity = BigDecimal("100"),
+            tradeAmount = BigDecimal("5000"),
+            tradeCurrency = USD,
+            cashAsset = usdCashBalance,
+            cashCurrency = USD,
+            cashAmount = BigDecimal("-5000"),
+            portfolio = sourcePortfolio,
+            tradeDate = LocalDate.now(serviceZone).minusDays(10),
+            status = TrnStatus.SETTLED
+        )
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnFinderZoneTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/TrnFinderZoneTest.kt
@@ -1,0 +1,101 @@
+package com.beancounter.marketdata.trn
+
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.Trn
+import com.beancounter.common.model.TrnStatus
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.Constants.Companion.usdCashBalance
+import com.beancounter.marketdata.portfolio.PortfolioService
+import com.beancounter.marketdata.portfolio.PortfolioShareRepository
+import com.beancounter.marketdata.registration.SystemUserService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.TimeZone
+
+/**
+ * The cash ladder is bounded by "today". Which day that is has to come from the
+ * configured `beancounter.zone`, not the JVM default zone — the pods run UTC while
+ * the users are SGT, so a bare `LocalDate.now()` cutoff drops trades the user made
+ * today until UTC catches up.
+ *
+ * Kiritimati (UTC+14) is always at least a day ahead of Midway (UTC-11), so these
+ * assertions do not depend on the wall clock or on the host's zone.
+ */
+@ExtendWith(MockitoExtension::class)
+class TrnFinderZoneTest {
+    @Mock
+    private lateinit var trnRepository: TrnRepository
+
+    @Mock
+    private lateinit var portfolioService: PortfolioService
+
+    @Mock
+    private lateinit var systemUserService: SystemUserService
+
+    @Mock
+    private lateinit var portfolioShareRepository: PortfolioShareRepository
+
+    @Mock
+    private lateinit var trnPostProcessor: TrnPostProcessor
+
+    private val serviceZone = ZoneId.of("Pacific/Kiritimati")
+
+    @Test
+    fun `cash ladder includes a trade dated today in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val portfolio = Portfolio("ladder")
+            val today = LocalDate.now(serviceZone)
+            val todaysTrade =
+                Trn(
+                    trnType = TrnType.DEPOSIT,
+                    tradeDate = today,
+                    asset = usdCashBalance,
+                    cashAsset = usdCashBalance,
+                    portfolio = portfolio
+                )
+
+            whenever(portfolioService.find(portfolio.id)).thenReturn(portfolio)
+            // Stand in for the repository's `tradeDate <= asAt` bound so the cutoff
+            // the finder chooses decides what comes back.
+            whenever(
+                trnRepository.findByPortfolioIdAndCashAssetId(
+                    eq(portfolio.id),
+                    eq(usdCashBalance.id),
+                    any(),
+                    eq(TrnStatus.SETTLED)
+                )
+            ).thenAnswer { invocation ->
+                val asAt = invocation.getArgument<LocalDate>(2)
+                if (todaysTrade.tradeDate.isAfter(asAt)) emptyList() else listOf(todaysTrade)
+            }
+            whenever(trnPostProcessor.postProcess(any<List<Trn>>()))
+                .thenAnswer { it.getArgument<List<Trn>>(0) }
+
+            val trnFinder =
+                TrnFinder(
+                    trnRepository,
+                    portfolioService,
+                    systemUserService,
+                    portfolioShareRepository,
+                    DateUtils(serviceZone.id),
+                    trnPostProcessor
+                )
+
+            assertThat(trnFinder.getCashLadder(portfolio.id, usdCashBalance.id))
+                .containsExactly(todaysTrade)
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+}


### PR DESCRIPTION
## Why

#1068 fixed the import trade-date guard. Auditing the rest of the ecosystem for the same
leak turned up three more sites in svc-data that write or gate **real ledger data**, plus
one inside `DateUtils` itself. The pods run UTC while the users are SGT, so a bare
`LocalDate.now()` resolves to the wrong calendar day for eight hours every day.

`Instant.now()` is deliberately untouched — an `Instant` has no zone to leak.

## Fixed here

| Site | Defect |
|---|---|
| `TrnFinder.getCashLadder` | The `tradeDate <= today` bound dropped trades the user made today until UTC caught up. |
| `PositionMoveService` | Compensating cash legs are persisted SETTLED — a UTC date puts a wrong-day entry in the ledger. |
| `CashTransferRequest.tradeDate` | `LocalDate.now()` as a **DTO default**, so omitting the field on `POST /cash/transfer` resolved the day in the JVM zone. Same defect as #1068, one endpoint over. Field is now nullable; `CashTransferService` resolves it. |
| `DateUtils.offsetNow` | Stamped the time of day from the JVM zone while every other method on the class uses `zoneId` — zone-correct only by coincidence of the pods being UTC. |

Each fix has its own new test, red first. No existing test was modified: the two services
take `DateUtils` as a defaulted constructor parameter, so current call sites still compile.

## The guard

`ZoneLeakGuardTest` scans every module's `src/main/kotlin` and fails when a file outside
`zone-leak-baseline.txt` reads the clock in the JVM zone. It also fails when a baseline
entry *stops* leaking, so the list can only shrink — it can't rot into a permanent
allowlist.

`detekt` is declared in `settings.gradle.kts` but applied to no module (Codacy runs it
cloud-side with its own config), so a `ForbiddenMethodCall` rule wouldn't gate locally.
A test needs no new tooling and runs inside `testSmart`.

One subtlety worth flagging for review: the guard's inputs live outside its own module, so
`jar-common`'s test task declares them explicitly. Without that Gradle happily keeps the
task `UP-TO-DATE` while another module introduces a leak and the guard passes without
running — which is exactly how it behaved before I caught it. Verified both ways by
planting a leak in `TrnFinder`:

```
ZoneLeakGuardTest > no new zone leaks in production sources() FAILED
    Expecting empty but was: ["svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnFinder.kt"]
```

The 36 files still on the baseline are triaged by tier in #1069 — reachable user-visible
stamps (`SystemUser.since`, `UserMilestone.earnedAt`, `UserExplorerAction.recordedAt`)
first, then batch-window drift, then dead entity defaults.

## Determinism

Every new test pins a zone pair 25 hours apart — `Pacific/Kiritimati` (UTC+14) against a
JVM default forced to `Pacific/Midway` (UTC-11). The two can never agree on the date, so
no assertion depends on the wall clock or on the host's zone, and the JVM default is
always restored in a `finally`.

## Gates

`./gradlew testSmart` + `formatKotlin` + `lintKotlin` green. `ocr review` — 0 findings.

## Companion changes

- **bc-deploy** (pushed to main, `62da554`): sets `TZ` **and** `BEANCOUNTER_ZONE` to
  `Asia/Singapore` on every service. Both are needed — `TZ` fixes the JVM default zone
  that bare `now()` reads, `BEANCOUNTER_ZONE` fixes the zone `DateUtils` reads. Previously
  only bc-data and bc-position set the latter and nothing set the former. **Needs a rollout.**
- **svc-rebalance #36**: `ExecutionService` posted trades to svc-data with a UTC
  `LocalDate.now()` — silent backdating of early-morning SGT rebalances.
- **svc-retire #177 / #178**: svc-retire uses no `DateUtils` at all, and its age
  derivation ignores birth month (disagrees with `bc-view/age.ts` by up to a year).
  Filed, not fixed here.
