### PR TITLE
fix(trn): dead-letter failed import messages instead of discarding them

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/PositionMoveService.kt
@@ -18,7 +18,6 @@ import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.time.LocalDate
 
 @Service
 @Transactional

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -160,6 +160,20 @@ spring:
       rabbit:
         binder:
           connection-name-prefix: bc-data
+        bindings:
+          # Writes that fail validation (bad trade date, unknown asset, closed
+          # portfolio) used to exhaust the retry policy and get acked away — the
+          # payload was gone and the caller saw success (#1067). Dead-letter them
+          # instead: republish-to-dlq keeps the original body and stamps the failure
+          # headers, so <destination>.bc-data.dlq holds a replayable message.
+          csvImportConsumer-in-0:
+            consumer:
+              auto-bind-dlq: true
+              republish-to-dlq: true
+          trnEventConsumer-in-0:
+            consumer:
+              auto-bind-dlq: true
+              republish-to-dlq: true
   rabbitmq:
     host: localhost
     port: 5672

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ImportDlqConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/ImportDlqConfigTest.kt
@@ -1,0 +1,52 @@
+package com.beancounter.marketdata.trn
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.env.YamlPropertySourceLoader
+import org.springframework.boot.origin.OriginTrackedValue
+import org.springframework.core.env.PropertySource
+import org.springframework.core.io.ClassPathResource
+
+/**
+ * A consumer that throws exhausts its retry policy and the message is acked away — the
+ * payload is gone and the user who triggered it sees a success dialog (#1067). Nothing
+ * about the trn consumers is idempotent enough to retry blindly later, so the payload has
+ * to survive somewhere a human can look: the binder's dead-letter queue.
+ *
+ * Asserting on the binding config is asserting the behaviour — the binder does the rest,
+ * and there is no way to observe a DLQ without a live broker.
+ */
+class ImportDlqConfigTest {
+    private val consumers =
+        listOf(
+            "csvImportConsumer-in-0",
+            "trnEventConsumer-in-0"
+        )
+
+    @Test
+    fun `trn consumers dead-letter a failed message instead of discarding it`() {
+        val config = applicationYaml()
+
+        consumers.forEach { binding ->
+            assertThat(config["spring.cloud.stream.rabbit.bindings.$binding.consumer.auto-bind-dlq"])
+                .describedAs("$binding must declare a DLQ")
+                .isEqualTo(true)
+            assertThat(config["spring.cloud.stream.rabbit.bindings.$binding.consumer.republish-to-dlq"])
+                .describedAs("$binding must republish the failed payload, keeping the failure headers")
+                .isEqualTo(true)
+        }
+    }
+
+    private fun applicationYaml(): Map<String, Any?> =
+        YamlPropertySourceLoader()
+            .load(
+                "application",
+                ClassPathResource("application.yml")
+            ).flatMap { source: PropertySource<*> ->
+                @Suppress("UNCHECKED_CAST")
+                (source.source as Map<String, Any?>).entries
+            }.associate { it.key to unwrap(it.value) }
+
+    /** The yaml loader wraps every value with its source origin. */
+    private fun unwrap(value: Any?): Any? = (value as? OriginTrackedValue)?.value ?: value
+}


### PR DESCRIPTION
## Problem

Part of #1067. A trn consumer that throws exhausts its retry policy and the delivery is
**acked** — the payload is gone. The caller already received a 200 from the publish, so
nothing anywhere tells the user their write failed. The only evidence was a stack trace in
the pod log, which is how the wrong-day trade-date rejection stayed invisible for eight
hours a day before #1068.

## Change

Declare a DLQ on both trn consumers and republish to it. `republish-to-dlq` keeps the
original body and stamps the failure headers, so `<destination>.bc-data.dlq` holds a
message that can be inspected and replayed instead of vanishing.

Keyed by binding name, so it applies to the `-dev` and `-demo` destinations alike.

## Test

`ImportDlqConfigTest` asserts both consumers declare and republish to a DLQ. Asserting the
binding config *is* asserting the behaviour here — the binder does the rest, and a DLQ
can't be observed without a live broker. Red first (`but was: null`).

## Also in here

`ocr review` caught a `java.time.LocalDate` import that **my own #1070 left unused** in
`PositionMoveService` — ktlint doesn't flag unused imports, so it slipped through the
gates. Removed as a separate commit.

## The other half of #1067

bc-view #1145: `SetCashBalanceDialog` now writes through the synchronous `/trns` endpoint,
so the user sees rejections directly. That is the fix for the reported symptom; this PR is
the safety net for the remaining genuinely-async path (dropped CSV files).

Gates: `./gradlew testSmart` + `formatKotlin` + `lintKotlin` green. `ocr review` — 0 findings.
