### PR TITLE
chore(dates): drain the zone-leak baseline from 36 files to 11

### DIFF
--- a/jar-common/src/test/resources/zone-leak-baseline.txt
+++ b/jar-common/src/test/resources/zone-leak-baseline.txt
@@ -9,39 +9,57 @@
 # Why it matters: the pods run UTC while users are SGT (UTC+8). A bare now() dated a
 # same-day trade as "tomorrow" and the CSV import consumer rejected it silently (#1067,
 # fixed for the import guard in #1068).
+#
+# Dead entity defaults below (AssetClassification/AssetExposure/AssetHolding/FxRate/
+# PriceData): every current caller already passes an explicit date, so the default
+# itself is unreachable in practice — but these are plain JPA data classes with no DI,
+# so making the field required would only be safe after auditing every construction
+# site (including test fixtures) for a value that's silently relied upon. Left as a
+# smaller, safer diff; drain opportunistically.
 jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetClassification.kt
 jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetExposure.kt
 jar-contracts/src/main/kotlin/com/beancounter/common/model/AssetHolding.kt
 jar-contracts/src/main/kotlin/com/beancounter/common/model/FxRate.kt
+# MarketData.priceDate: when a price date matters, the correct authority is the
+# MARKET's zone (trading-day close), not the service zone — do not "fix" this by
+# wiring beancounter.zone through MarketData. Every current caller already passes an
+# explicit priceDate; the bare default is unreachable but left alone.
 jar-contracts/src/main/kotlin/com/beancounter/common/model/MarketData.kt
 jar-contracts/src/main/kotlin/com/beancounter/common/model/PriceData.kt
+# SystemUser.since: attempted the Tier 1 fix (SystemUserService.register /
+# registerSystemAccount passing dateUtils.date explicitly, TDD-covered by a
+# SystemUserServiceZoneTest) and reverted it. SystemUserService.register() sits on
+# the registration path exercised by nearly every MockMvc integration test's setup
+# across svc-data, svc-data's contractTest source set, and jar-client — many of them
+# @MockitoBean DateUtils without stubbing `.date`, so the mock's unstubbed null
+# return blew up SystemUser's non-null `since` constructor param (NPE at
+# SystemUserService.kt in ~6+ test classes). Fixing every call site's stub is exactly
+# the kind of test-touching ripple the brief asked to avoid for a field ("member
+# since") that is cosmetic at worst. Reverted; left in the baseline for a dedicated
+# follow-up that also updates the affected tests.
 jar-contracts/src/main/kotlin/com/beancounter/common/model/SystemUser.kt
-jar-contracts/src/main/kotlin/com/beancounter/common/model/UserExplorerAction.kt
-jar-contracts/src/main/kotlin/com/beancounter/common/model/UserMilestone.kt
-svc-agent/src/main/kotlin/com/beancounter/agent/clients/RetireServiceClient.kt
+# PrivateAssetConfig.createdDate/updatedDate: PrivateAssetConfigService (the one
+# production caller) now passes dateUtils.date explicitly for both. The entity
+# default itself is left in place — PrivateAssetConfigServiceTest alone has ~29
+# direct constructions that omit the dates and don't assert on them; touching all of
+# them for a field nobody observes isn't worth the diff.
 svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfig.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/markets/MarketCalendarConfig.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/milestone/MilestoneService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+# MarketDataPriceProvider.defaultBackfillFrom(): a companion-object function with no
+# DI, used as the default `fromDate` across 8+ MarketDataPriceProvider implementors'
+# backFill() overrides. Genuinely live (reached whenever a caller omits fromDate), but
+# fixing it means plumbing DateUtils through an interface implemented by every price
+# provider — out of proportion to this pass. Left for a dedicated follow-up.
 svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataPriceProvider.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializer.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackProxy.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarGateway.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarProxy.kt
+# TaxRate.createdDate/updatedDate: TaxRateService (the one production caller) now
+# passes dateUtils.date explicitly for both. The entity default itself is left in
+# place — it's a plain data-class fallback with no other caller.
 svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRate.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
-svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
-svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
-svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotEntity.kt
+# MorningstarProxy.getPrice: attempted (dateUtils.date.minusDays(7) default), then
+# reverted. MorningstarPriceServiceTest constructs MorningstarProxy via raw
+# Mockito `mock()`, which never runs the real constructor — the injected DateUtils
+# field is left null, and Kotlin evaluates the default `startDate` argument by
+# calling back into the real (non-mocked) default-value bridge method on that null
+# field before the stubbed 2-arg call is ever matched, throwing an NPE the
+# production try/catch swallows into a silent empty result. Reverted rather than
+# touch the test's mocking strategy.
+svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarProxy.kt

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/UserExplorerAction.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/UserExplorerAction.kt
@@ -32,6 +32,9 @@ data class UserExplorerAction(
     @JsonIgnore
     val owner: SystemUser,
     val actionId: String,
+    // No default: this is a JPA entity with no DI, so it cannot resolve "today" in
+    // the configured beancounter.zone itself. Callers must pass an explicit date —
+    // see MilestoneService.recordExplorerAction, which uses DateUtils.date.
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val recordedAt: LocalDate = LocalDate.now()
+    val recordedAt: LocalDate
 )

--- a/jar-contracts/src/main/kotlin/com/beancounter/common/model/UserMilestone.kt
+++ b/jar-contracts/src/main/kotlin/com/beancounter/common/model/UserMilestone.kt
@@ -33,6 +33,9 @@ data class UserMilestone(
     val owner: SystemUser,
     val milestoneId: String,
     var tier: Int = 1,
+    // No default: this is a JPA entity with no DI, so it cannot resolve "today" in
+    // the configured beancounter.zone itself. Callers must pass an explicit date —
+    // see MilestoneService, which uses DateUtils.date.
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    var earnedAt: LocalDate = LocalDate.now()
+    var earnedAt: LocalDate
 )

--- a/svc-agent/src/main/kotlin/com/beancounter/agent/clients/RetireServiceClient.kt
+++ b/svc-agent/src/main/kotlin/com/beancounter/agent/clients/RetireServiceClient.kt
@@ -3,6 +3,7 @@ package com.beancounter.agent.clients
 import com.beancounter.auth.TokenService
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.utils.BcJson
+import com.beancounter.common.utils.DateUtils
 import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -12,7 +13,6 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
 import tools.jackson.module.kotlin.readValue
-import java.time.LocalDate
 
 /**
  * A single phase in a composite (multi-plan) retirement projection.
@@ -50,7 +50,8 @@ data class CompositePhaseInput(
 class RetireServiceClient(
     @Qualifier("retireRestClient")
     private val restClient: RestClient,
-    private val tokenService: TokenService
+    private val tokenService: TokenService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     /**
      * `GET /settings` — the user's stored independence settings, including
@@ -79,7 +80,7 @@ class RetireServiceClient(
 
         // Compute current age from yearOfBirth (optionally using monthOfBirth)
         (raw["yearOfBirth"] as? Number)?.toInt()?.let { yob ->
-            val today = LocalDate.now()
+            val today = dateUtils.date
             val monthOfBirth = (raw["monthOfBirth"] as? Number)?.toInt()
             val age =
                 if (monthOfBirth != null && today.monthValue < monthOfBirth) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/assets/PrivateAssetConfigService.kt
@@ -3,13 +3,13 @@ package com.beancounter.marketdata.assets
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.ForbiddenException
 import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.registration.SystemUserService
 import com.beancounter.marketdata.trn.TrnRepository
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.time.LocalDate
 
 /**
  * Service for managing private asset configurations.
@@ -24,7 +24,8 @@ class PrivateAssetConfigService(
     private val assetRepository: AssetRepository,
     private val systemUserService: SystemUserService,
     private val trnRepository: TrnRepository,
-    private val accessControl: AssetAccessControl
+    private val accessControl: AssetAccessControl,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -170,7 +171,7 @@ class PrivateAssetConfigService(
                     monthlyRentalIncome = resolveRentalIncome(request, existing.monthlyRentalIncome),
                     rentalCurrency = request.rentalCurrency ?: existing.rentalCurrency,
                     countryCode = request.countryCode?.uppercase() ?: existing.countryCode,
-                    updatedDate = LocalDate.now()
+                    updatedDate = dateUtils.date
                 ).mergeExpenses(request)
                 .mergePropertyFlags(request)
                 .mergeTransactionSettings(request)
@@ -279,8 +280,8 @@ class PrivateAssetConfigService(
             employerMatchCapPercent = request.employerMatchCapPercent,
             withdrawalTaxRate = request.withdrawalTaxRate,
             subAccounts = toSubAccountEntities(assetId, request.subAccounts),
-            createdDate = LocalDate.now(),
-            updatedDate = LocalDate.now()
+            createdDate = dateUtils.date,
+            updatedDate = dateUtils.date
         )
 
     /**

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/cash/CashAutoSettleService.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.model.CallerRef
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.KeyGenUtils
 import com.beancounter.marketdata.portfolio.PortfolioService
 import com.beancounter.marketdata.trn.TrnInputMapper
@@ -13,7 +14,6 @@ import com.beancounter.marketdata.trn.cashLegInput
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.time.LocalDate
 
 /**
  * Emits a compensating cash transfer (WITHDRAWAL + DEPOSIT) when a
@@ -60,7 +60,8 @@ class CashAutoSettleService(
     private val portfolioService: PortfolioService,
     private val trnInputMapper: TrnInputMapper,
     private val trnRepository: TrnRepository,
-    private val keyGenUtils: KeyGenUtils
+    private val keyGenUtils: KeyGenUtils,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(CashAutoSettleService::class.java)
 
@@ -212,7 +213,7 @@ class CashAutoSettleService(
             .findByPortfolioIdAndCashAssetId(
                 portfolioId,
                 cashAssetId,
-                LocalDate.now(),
+                dateUtils.date,
                 TrnStatus.SETTLED
             ).isNotEmpty()
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.classification
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetClassification
 import com.beancounter.common.model.ClassificationLevel
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.alpha.AlphaConfig
 import com.beancounter.marketdata.providers.alpha.AlphaEtfProfileResponse
 import com.beancounter.marketdata.providers.alpha.AlphaOverviewResponse
@@ -21,7 +22,8 @@ import org.springframework.stereotype.Service
 class AlphaClassificationEnricher(
     private val alphaConfig: AlphaConfig,
     private val alphaProxy: AlphaProxy,
-    private val classificationService: ClassificationService
+    private val classificationService: ClassificationService,
+    private val dateUtils: DateUtils = DateUtils()
 ) : ClassificationEnricher {
     private val log = LoggerFactory.getLogger(AlphaClassificationEnricher::class.java)
     private val objectMapper = alphaConfig.getObjectMapper()
@@ -176,7 +178,8 @@ class AlphaClassificationEnricher(
                     asset = asset,
                     standard = standard,
                     item = sectorItem,
-                    weight = weight
+                    weight = weight,
+                    asOf = dateUtils.date
                 )
                 sectorCount++
             }
@@ -213,7 +216,8 @@ class AlphaClassificationEnricher(
                     asset = asset,
                     symbol = normalizedSymbol,
                     name = holdingData.description,
-                    weight = weight
+                    weight = weight,
+                    asOf = dateUtils.date
                 )
                 holdingCount++
             }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationRefreshService.kt
@@ -2,11 +2,11 @@ package com.beancounter.marketdata.classification
 
 import com.beancounter.common.contracts.BackfillResult
 import com.beancounter.common.model.Asset
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 /**
  * Service for refreshing asset classification data.
@@ -36,7 +36,8 @@ class ClassificationRefreshService(
     @Value("\${beancounter.classification.stale-after-days:7}")
     private val staleAfterDays: Long = 7,
     @Value("\${beancounter.classification.batch-limit:20}")
-    private val batchLimit: Int = 20
+    private val batchLimit: Int = 20,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(ClassificationRefreshService::class.java)
 
@@ -45,7 +46,7 @@ class ClassificationRefreshService(
      */
     fun refreshEtfSectors(): BackfillResult {
         log.info("Starting ETF sector refresh")
-        val cutoff = LocalDate.now().minusDays(staleAfterDays)
+        val cutoff = dateUtils.date.minusDays(staleAfterDays)
         val totalActive = assetRepository.findActiveEtfs().size
         val due = assetRepository.findEtfsDueForClassification(cutoff)
         return processAssets(totalActive, due, "ETF sectors")
@@ -56,7 +57,7 @@ class ClassificationRefreshService(
      */
     fun refreshEquityClassifications(): BackfillResult {
         log.info("Starting Equity classification refresh")
-        val cutoff = LocalDate.now().minusDays(staleAfterDays)
+        val cutoff = dateUtils.date.minusDays(staleAfterDays)
         val totalActive = assetRepository.findActiveEquities().size
         val due = assetRepository.findEquitiesDueForClassification(cutoff)
         return processAssets(totalActive, due, "Equity classifications")
@@ -117,7 +118,7 @@ class ClassificationRefreshService(
         if (result == EnrichmentResult.RATE_LIMITED) {
             return
         }
-        asset.classificationCheckedAt = LocalDate.now()
+        asset.classificationCheckedAt = dateUtils.date
         assetRepository.save(asset)
     }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/ClassificationService.kt
@@ -8,6 +8,7 @@ import com.beancounter.common.model.AssetHolding
 import com.beancounter.common.model.ClassificationItem
 import com.beancounter.common.model.ClassificationLevel
 import com.beancounter.common.model.ClassificationStandard
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.KeyGenUtils
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Service
@@ -28,7 +29,8 @@ class ClassificationService(
     private val holdingRepository: AssetHoldingRepository,
     private val sectorNormalizer: SectorNormalizer,
     private val keyGenUtils: KeyGenUtils,
-    private val entityManager: EntityManager
+    private val entityManager: EntityManager,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     /**
      * Get or create a classification standard.
@@ -150,7 +152,7 @@ class ClassificationService(
                 item = item,
                 level = level,
                 source = source,
-                asOf = LocalDate.now()
+                asOf = dateUtils.date
             )
         )
     }
@@ -163,7 +165,7 @@ class ClassificationService(
         standard: ClassificationStandard,
         item: ClassificationItem,
         weight: BigDecimal,
-        asOf: LocalDate = LocalDate.now()
+        asOf: LocalDate = dateUtils.date
     ): AssetExposure {
         // Use a managed reference to ensure proper FK handling
         val managedAsset = entityManager.getReference(Asset::class.java, asset.id)
@@ -195,7 +197,7 @@ class ClassificationService(
         symbol: String,
         name: String?,
         weight: BigDecimal,
-        asOf: LocalDate = LocalDate.now()
+        asOf: LocalDate = dateUtils.date
     ): AssetHolding {
         val managedAsset = entityManager.getReference(Asset::class.java, asset.id)
 
@@ -395,7 +397,7 @@ class ClassificationService(
                 item = sectorItem,
                 level = ClassificationLevel.SECTOR,
                 source = SOURCE_MANUAL,
-                asOf = LocalDate.now()
+                asOf = dateUtils.date
             )
         )
 
@@ -416,7 +418,7 @@ class ClassificationService(
                     item = industryItem,
                     level = ClassificationLevel.INDUSTRY,
                     source = SOURCE_MANUAL,
-                    asOf = LocalDate.now()
+                    asOf = dateUtils.date
                 )
             )
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
@@ -3,6 +3,7 @@ package com.beancounter.marketdata.classification
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.AssetClassification
 import com.beancounter.common.model.ClassificationLevel
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.eodhd.EodhdConfig
 import com.beancounter.marketdata.providers.eodhd.EodhdProxy
 import org.slf4j.LoggerFactory
@@ -23,7 +24,8 @@ import org.springframework.stereotype.Service
 class EodhdClassificationEnricher(
     private val eodhdConfig: EodhdConfig,
     private val eodhdProxy: EodhdProxy,
-    private val classificationService: ClassificationService
+    private val classificationService: ClassificationService,
+    private val dateUtils: DateUtils = DateUtils()
 ) : ClassificationEnricher {
     private val log = LoggerFactory.getLogger(EodhdClassificationEnricher::class.java)
 
@@ -129,7 +131,8 @@ class EodhdClassificationEnricher(
                 asset = asset,
                 standard = standard,
                 item = sectorItem,
-                weight = weight
+                weight = weight,
+                asOf = dateUtils.date
             )
             sectorCount++
         }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/markets/MarketCalendarConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/markets/MarketCalendarConfig.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.markets
 
+import com.beancounter.common.utils.DateUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -19,13 +20,14 @@ import java.time.LocalDate
 class MarketCalendarConfig
     @Autowired
     constructor(
-        val values: List<MarketHolidayAnnual>
+        val values: List<MarketHolidayAnnual>,
+        private val dateUtils: DateUtils = DateUtils()
     ) {
         private val map: MutableMap<String, List<LocalDate>> = mutableMapOf()
 
         @Cacheable("market.holidays")
         fun marketHolidays(
-            year: Int = LocalDate.now().year,
+            year: Int = dateUtils.date.year,
             market: String
         ): List<LocalDate> =
             map.getOrPut(cacheKey(market, year)) {
@@ -36,7 +38,7 @@ class MarketCalendarConfig
             }
 
         fun buildMarketHolidays(
-            year: Int = LocalDate.now().year,
+            year: Int = dateUtils.date.year,
             market: String
         ): List<LocalDate> {
             return values

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/milestone/MilestoneService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/milestone/MilestoneService.kt
@@ -4,11 +4,11 @@ import com.beancounter.common.model.MilestoneMode
 import com.beancounter.common.model.SystemUser
 import com.beancounter.common.model.UserExplorerAction
 import com.beancounter.common.model.UserMilestone
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.registration.UserPreferencesService
 import jakarta.transaction.Transactional
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 /**
  * Service for managing user milestones and explorer actions.
@@ -18,7 +18,8 @@ import java.time.LocalDate
 class MilestoneService(
     private val milestoneRepository: UserMilestoneRepository,
     private val explorerActionRepository: UserExplorerActionRepository,
-    private val userPreferencesService: UserPreferencesService
+    private val userPreferencesService: UserPreferencesService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     fun getEarnedMilestones(owner: SystemUser): List<UserMilestone> = milestoneRepository.findByOwner(owner)
 
@@ -35,7 +36,7 @@ class MilestoneService(
             val milestone = existing.get()
             if (tier > milestone.tier) {
                 milestone.tier = tier
-                milestone.earnedAt = LocalDate.now()
+                milestone.earnedAt = dateUtils.date
                 return milestoneRepository.save(milestone)
             }
             return milestone
@@ -45,7 +46,8 @@ class MilestoneService(
                 UserMilestone(
                     owner = owner,
                     milestoneId = milestoneId,
-                    tier = tier
+                    tier = tier,
+                    earnedAt = dateUtils.date
                 )
             )
         } catch (_: DataIntegrityViolationException) {
@@ -57,7 +59,7 @@ class MilestoneService(
                     }
             if (tier > raced.tier) {
                 raced.tier = tier
-                raced.earnedAt = LocalDate.now()
+                raced.earnedAt = dateUtils.date
                 return milestoneRepository.save(raced)
             }
             raced
@@ -77,7 +79,8 @@ class MilestoneService(
             explorerActionRepository.save(
                 UserExplorerAction(
                     owner = owner,
-                    actionId = actionId
+                    actionId = actionId,
+                    recordedAt = dateUtils.date
                 )
             )
         } catch (_: DataIntegrityViolationException) {

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/MarketDataBackfillService.kt
@@ -1,6 +1,7 @@
 package com.beancounter.marketdata.providers
 
 import com.beancounter.common.model.Asset
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.cache.CacheInvalidationProducer
 import com.beancounter.marketdata.providers.MarketDataPriceProvider.Companion.MAX_BACKFILL_YEARS
@@ -50,7 +51,8 @@ class MarketDataBackfillService(
     private val marketDataRepo: MarketDataRepo,
     private val trnRepository: TrnRepository,
     @Suppress("unused") private val cacheInvalidationProducer: CacheInvalidationProducer? = null,
-    private val maxBackfillYears: Long = MAX_BACKFILL_YEARS
+    private val maxBackfillYears: Long = MAX_BACKFILL_YEARS,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(MarketDataBackfillService::class.java)
 
@@ -65,7 +67,7 @@ class MarketDataBackfillService(
         asset: Asset,
         fromDate: LocalDate = defaultBackfillFrom()
     ) {
-        val today = LocalDate.now()
+        val today = dateUtils.date
         val anchored = anchorFromDate(asset.id, fromDate, today)
         val priorDbMin = marketDataRepo.findEarliestPriceDateByAssetId(asset.id)
         val priorDbMax = marketDataRepo.findLatestPriceDateByAssetId(asset.id)
@@ -92,7 +94,7 @@ class MarketDataBackfillService(
     internal fun anchorFromDate(
         assetId: String,
         fromDate: LocalDate,
-        today: LocalDate = LocalDate.now()
+        today: LocalDate = dateUtils.date
     ): LocalDate {
         val earliestHeld = trnRepository.findEarliestTradeDateByAssetId(assetId)
         val widened =

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/PriceController.kt
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 
 /**
  * Market Data MVC for price management operations.
@@ -336,7 +335,7 @@ class PriceController(
         val fromDate = dateUtils.getFormattedDate(from)
         val toDate = dateUtils.getFormattedDate(to)
         val initial = priceService.getPriceHistory(assetId, fromDate, toDate)
-        val targetFrom = fromDate.coerceAtLeast(LocalDate.now().minusYears(MAX_BACKFILL_YEARS))
+        val targetFrom = fromDate.coerceAtLeast(dateUtils.date.minusYears(MAX_BACKFILL_YEARS))
 
         if (initial.prices.isEmpty()) {
             // Nothing cached at all — block briefly so the chart isn't empty.
@@ -432,7 +431,7 @@ class PriceController(
     fun ensureHistory(
         @RequestBody request: EnsureHistoryRequest
     ): EnsureHistoryResponse {
-        val targetFrom = request.fromDate.coerceAtLeast(LocalDate.now().minusYears(MAX_BACKFILL_YEARS))
+        val targetFrom = request.fromDate.coerceAtLeast(dateUtils.date.minusYears(MAX_BACKFILL_YEARS))
         // Trim and de-duplicate so a sloppy caller (e.g. a portfolio with the same asset across
         // currencies) doesn't blow the per-asset cooldown budget on phantom IDs, and so the
         // returned `scheduled` count reflects what we actually queued.

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaNewsService.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.alpha
 
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.NewsProvider
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -32,7 +33,8 @@ class AlphaNewsService(
     private val alphaGateway: AlphaGateway,
     private val alphaConfig: AlphaConfig,
     private val objectMapper: ObjectMapper,
-    private val newsProperties: NewsProperties
+    private val newsProperties: NewsProperties,
+    private val dateUtils: DateUtils = DateUtils()
 ) : NewsProvider {
     private val log = LoggerFactory.getLogger(AlphaNewsService::class.java)
 
@@ -219,7 +221,7 @@ class AlphaNewsService(
             .toSet()
 
     private fun businessDaysAgo(days: Int): LocalDate {
-        var date = LocalDate.now()
+        var date = dateUtils.date
         var remaining = days
         while (remaining > 0) {
             date = date.minusDays(1)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializer.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaPriceDeserializer.kt
@@ -152,7 +152,7 @@ class AlphaPriceDeserializer : ValueDeserializer<PriceResponse>() {
 
     private fun getPrice(
         asset: Asset,
-        priceDate: LocalDate = LocalDate.now(),
+        priceDate: LocalDate = dateUtils.date,
         data: Map<String, Any> = mapOf()
     ): MarketData {
         val price: MarketData?

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsService.kt
@@ -2,6 +2,7 @@ package com.beancounter.marketdata.providers.eodhd
 
 import com.beancounter.common.input.AssetInput
 import com.beancounter.common.telemetry.runBlockingTraced
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetFinder
 import com.beancounter.marketdata.providers.NewsProvider
 import com.beancounter.marketdata.providers.eodhd.model.EodhdNewsArticle
@@ -45,7 +46,8 @@ class EodhdNewsService(
     private val newsProperties: EodhdNewsProperties,
     private val newsArticleRepo: NewsArticleRepo,
     private val newsFetchRepo: NewsFetchRepo,
-    private val assetFinder: AssetFinder
+    private val assetFinder: AssetFinder,
+    private val dateUtils: DateUtils = DateUtils()
 ) : NewsProvider {
     private val log = LoggerFactory.getLogger(EodhdNewsService::class.java)
 
@@ -84,10 +86,10 @@ class EodhdNewsService(
     ): Map<String, Any> {
         if (symbols.isEmpty()) return emptyMap()
 
-        val refreshCutoff = LocalDateTime.now().minusHours(newsProperties.refreshAfterHours)
+        val refreshCutoff = LocalDateTime.now(dateUtils.zoneId).minusHours(newsProperties.refreshAfterHours)
         refreshStaleSymbols(symbols.filter { shouldRefresh(it, refreshCutoff) })
 
-        val retentionStart = LocalDateTime.now().minusDays(newsProperties.retentionDays)
+        val retentionStart = LocalDateTime.now(dateUtils.zoneId).minusDays(newsProperties.retentionDays)
         val stored = newsArticleRepo.findByTickersAfter(symbols, retentionStart)
         val ranked =
             stored
@@ -164,15 +166,18 @@ class EodhdNewsService(
         when (outcome) {
             is FetchResult.Success -> {
                 upsertAll(symbol, outcome.articles)
-                newsFetchRepo.save(NewsFetch(symbol, LocalDateTime.now(), outcome.articles.size))
+                newsFetchRepo.save(NewsFetch(symbol, LocalDateTime.now(dateUtils.zoneId), outcome.articles.size))
             }
             FetchResult.Failure -> {
                 // Burn the refresh cooldown even on failure — otherwise a transient EODHD outage
                 // or 429 turns every subsequent request into a quota-amplifying retry storm. Next
                 // attempt waits `refresh-after-hours`, matching the success-path backoff. Articles
                 // already in the DB keep serving in the meantime.
-                val existing = newsFetchRepo.findById(symbol).orElseGet { NewsFetch(symbol) }
-                existing.lastFetchedAt = LocalDateTime.now()
+                val existing =
+                    newsFetchRepo
+                        .findById(symbol)
+                        .orElseGet { NewsFetch(ticker = symbol, lastFetchedAt = LocalDateTime.now(dateUtils.zoneId)) }
+                existing.lastFetchedAt = LocalDateTime.now(dateUtils.zoneId)
                 newsFetchRepo.save(existing)
             }
         }
@@ -209,7 +214,13 @@ class EodhdNewsService(
         incoming: EodhdNewsArticle
     ) {
         val existing = newsArticleRepo.findByExternalId(externalId).orElse(null)
-        val article = existing ?: NewsArticle(externalId = externalId)
+        val article =
+            existing ?: NewsArticle(
+                externalId = externalId,
+                // Placeholder — applyIncoming() overwrites both stamps immediately below.
+                published = LocalDateTime.now(dateUtils.zoneId),
+                fetchedAt = LocalDateTime.now(dateUtils.zoneId)
+            )
         applyIncoming(article, externalId, symbol, incoming)
         try {
             newsArticleRepo.save(article)
@@ -238,7 +249,7 @@ class EodhdNewsService(
             article.sentimentNeu = s.neu
         }
         article.source = "EODHD"
-        article.fetchedAt = LocalDateTime.now()
+        article.fetchedAt = LocalDateTime.now(dateUtils.zoneId)
 
         // Refresh the tag set — EODHD can revise tags between fetches.
         article.tags.clear()

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsArticle.kt
@@ -33,8 +33,11 @@ import java.time.LocalDateTime
 data class NewsArticle(
     @Column(name = "external_id", nullable = false, length = 2048)
     var externalId: String = "",
+    // No default: the one call site that omits it (EodhdNewsService.saveOrMerge, for
+    // a brand-new row) immediately overwrites both this and fetchedAt via
+    // applyIncoming() before the entity is ever saved.
     @Column(nullable = false)
-    var published: LocalDateTime = LocalDateTime.now(),
+    var published: LocalDateTime,
     @Column(nullable = false, length = 1024)
     var title: String = "",
     @Column(nullable = false, columnDefinition = "TEXT")
@@ -54,7 +57,7 @@ data class NewsArticle(
     @Column(nullable = false, length = 16)
     var source: String = "EODHD",
     @Column(name = "fetched_at", nullable = false)
-    var fetchedAt: LocalDateTime = LocalDateTime.now(),
+    var fetchedAt: LocalDateTime,
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "news_article_tag",

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsFetch.kt
@@ -17,8 +17,11 @@ data class NewsFetch(
     @Id
     @Column(nullable = false, length = 32)
     var ticker: String = "",
+    // No default: the one call site that omits it (EodhdNewsService's failure path)
+    // immediately overwrites it with an explicit LocalDateTime.now(dateUtils.zoneId)
+    // before saving.
     @Column(name = "last_fetched_at", nullable = false)
-    var lastFetchedAt: LocalDateTime = LocalDateTime.now(),
+    var lastFetchedAt: LocalDateTime,
     @Column(name = "articles_found", nullable = false)
     var articlesFound: Int = 0
 )

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/eodhd/news/NewsRetentionSchedule.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.eodhd.news
 
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.eodhd.EodhdNewsProperties
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
@@ -14,6 +15,10 @@ import java.time.LocalDateTime
  *
  * Gated on `schedule.enabled=true` — same pattern as [com.beancounter.marketdata.providers.PriceSchedule]
  * so the prune doesn't fire in tests or local dev unless explicitly turned on.
+ *
+ * The cron trigger is already pinned to the configured schedule zone via `@scheduleZone`, but
+ * "N days ago" must be measured in that same zone too — otherwise the retention window is
+ * internally inconsistent (fires on schedule, then measures age against the JVM's UTC clock).
  */
 @Service
 @ConditionalOnProperty(
@@ -23,12 +28,13 @@ import java.time.LocalDateTime
 )
 class NewsRetentionSchedule(
     private val newsArticleRepo: NewsArticleRepo,
-    private val newsProperties: EodhdNewsProperties
+    private val newsProperties: EodhdNewsProperties,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     @Scheduled(cron = "0 0 3 * * *", zone = "#{@scheduleZone}")
     @Transactional
     fun prune() {
-        val cutoff = LocalDateTime.now().minusDays(newsProperties.retentionDays)
+        val cutoff = LocalDateTime.now(dateUtils.zoneId).minusDays(newsProperties.retentionDays)
         val deleted = newsArticleRepo.deleteByPublishedBefore(cutoff)
         log.info("Pruned {} news articles older than {}", deleted, cutoff)
     }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackAdapter.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackAdapter.kt
@@ -114,19 +114,26 @@ class MarketStackAdapter {
 
     fun getMsDefault(
         asset: String,
-        exchange: String,
-        date: LocalDateTime
+        exchange: String
     ): MarketStackData {
         log.trace(
             "{} - unable to locate a price",
             asset
         )
+        // A default/missing-price stub always has close == ZERO, so toMarketData()
+        // always takes the getDefault() branch for it and never reads this date —
+        // it's a placeholder to satisfy MarketStackData's non-null field, not a
+        // real timestamp. See MarketStackAdapter.toMarketData / getMarketData.
         return MarketStackData(
             symbol = asset,
             exchange = exchange,
-            date = date,
+            date = MISSING_PRICE_PLACEHOLDER_DATE,
             close = BigDecimal.ZERO
         )
+    }
+
+    companion object {
+        private val MISSING_PRICE_PLACEHOLDER_DATE: LocalDateTime = LocalDateTime.MIN
     }
 
     fun getDefault(

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackProxy.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/marketstack/MarketStackProxy.kt
@@ -4,7 +4,6 @@ import com.beancounter.marketdata.providers.ProviderArguments
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackData
 import com.beancounter.marketdata.providers.marketstack.model.MarketStackResponse
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 
 /**
  * Async proxy to obtain MarketData.
@@ -39,8 +38,7 @@ class MarketStackProxy(
                 missingPrices.add(
                     marketStackAdapter.getMsDefault(
                         assetCode,
-                        "",
-                        LocalDateTime.now()
+                        ""
                     )
                 )
             }

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarGateway.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/morningstar/MorningstarGateway.kt
@@ -1,5 +1,6 @@
 package com.beancounter.marketdata.providers.morningstar
 
+import com.beancounter.common.utils.DateUtils
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -16,7 +17,9 @@ import java.time.format.DateTimeFormatter
  * The API is publicly accessible without authentication.
  */
 @Component
-class MorningstarGateway {
+class MorningstarGateway(
+    private val dateUtils: DateUtils = DateUtils()
+) {
     private val restTemplate = RestTemplate()
 
     companion object {
@@ -35,7 +38,7 @@ class MorningstarGateway {
     fun getPrice(
         securityId: String,
         currencyId: String = "GBP",
-        startDate: LocalDate = LocalDate.now().minusDays(7)
+        startDate: LocalDate = dateUtils.date.minusDays(7)
     ): String? =
         try {
             // Determine if it's a Morningstar ID or ISIN

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/tax/TaxRateService.kt
@@ -2,12 +2,12 @@ package com.beancounter.marketdata.tax
 
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.exception.NotFoundException
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.registration.SystemUserService
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.time.LocalDate
 
 /**
  * Service for managing user-defined tax rates by country.
@@ -19,7 +19,8 @@ import java.time.LocalDate
 @Transactional
 class TaxRateService(
     private val taxRateRepository: TaxRateRepository,
-    private val systemUserService: SystemUserService
+    private val systemUserService: SystemUserService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -88,15 +89,15 @@ class TaxRateService(
             if (existing != null) {
                 existing.copy(
                     rate = request.rate,
-                    updatedDate = LocalDate.now()
+                    updatedDate = dateUtils.date
                 )
             } else {
                 TaxRate(
                     owner = user,
                     countryCode = normalizedCode,
                     rate = request.rate,
-                    createdDate = LocalDate.now(),
-                    updatedDate = LocalDate.now()
+                    createdDate = dateUtils.date,
+                    updatedDate = dateUtils.date
                 )
             }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/InvestmentWindow.kt
@@ -12,13 +12,17 @@ const val DEFAULT_INVESTMENT_WINDOW_DAYS = 30
 /**
  * Resolve the rolling investment window: a trailing [days]-day span ending today.
  *
+ * No default for [today]: this is a top-level function with no DI, so it cannot
+ * resolve "today" in the configured beancounter.zone itself — the caller
+ * (TrnAnalysisController) must pass an explicit date via DateUtils.date.
+ *
  * @param days trailing window length; values < 1 fall back to [DEFAULT_INVESTMENT_WINDOW_DAYS].
- * @param today window end (inclusive); defaults to the current date.
+ * @param today window end (inclusive).
  * @return (startDate, endDate) where startDate = today - days and endDate = today.
  */
 fun investmentWindow(
     days: Int,
-    today: LocalDate = LocalDate.now()
+    today: LocalDate
 ): Pair<LocalDate, LocalDate> {
     val span = if (days < 1) DEFAULT_INVESTMENT_WINDOW_DAYS else days
     return today.minusDays(span.toLong()) to today

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisController.kt
@@ -2,6 +2,7 @@ package com.beancounter.marketdata.trn
 
 import com.beancounter.auth.model.AuthConstants
 import com.beancounter.common.contracts.TrnResponse
+import com.beancounter.common.utils.DateUtils
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -35,7 +36,8 @@ import java.time.YearMonth
             "including summaries, monthly investments, and income"
 )
 class TrnAnalysisController(
-    var trnAnalysisService: TrnAnalysisService
+    var trnAnalysisService: TrnAnalysisService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     @GetMapping(
         value = ["/summary"],
@@ -154,7 +156,7 @@ class TrnAnalysisController(
             example = "portfolio-1,portfolio-2"
         ) @RequestParam(required = false) portfolioIds: String?
     ): MonthlyInvestmentResponse {
-        val (startDate, endDate) = investmentWindow(days)
+        val (startDate, endDate) = investmentWindow(days, dateUtils.date)
 
         val portfolioIdList = portfolioIds?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
 
@@ -202,7 +204,7 @@ class TrnAnalysisController(
             example = "30"
         ) @RequestParam(required = false, defaultValue = "$DEFAULT_INVESTMENT_WINDOW_DAYS") days: Int
     ): TrnResponse {
-        val (startDate, endDate) = investmentWindow(days)
+        val (startDate, endDate) = investmentWindow(days, dateUtils.date)
         return TrnResponse(trnAnalysisService.getMonthlyInvestmentTransactions(startDate, endDate))
     }
 
@@ -288,7 +290,7 @@ class TrnAnalysisController(
             if (endMonth != null) {
                 YearMonth.parse(endMonth)
             } else {
-                YearMonth.now()
+                YearMonth.now(dateUtils.zoneId)
             }
         val portfolioIdList = portfolioIds?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
         return trnAnalysisService.getMonthlyIncome(months, end, portfolioIdList, groupBy)

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/trn/TrnAnalysisService.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.model.IsoCurrencyPair
 import com.beancounter.common.model.Trn
 import com.beancounter.common.model.TrnStatus
 import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.assets.AssetRepository
 import com.beancounter.marketdata.classification.ClassificationService
 import com.beancounter.marketdata.fx.FxRateService
@@ -26,7 +27,8 @@ class TrnAnalysisService(
     private val systemUserService: SystemUserService,
     private val fxRateService: FxRateService,
     private val assetRepository: AssetRepository,
-    private val classificationService: ClassificationService
+    private val classificationService: ClassificationService,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val log = LoggerFactory.getLogger(TrnAnalysisService::class.java)
 
@@ -149,7 +151,7 @@ class TrnAnalysisService(
         weeks: Int,
         targetCurrency: String
     ): TransactionSummary {
-        val endDate = LocalDate.now()
+        val endDate = dateUtils.date
         val startDate = endDate.minusWeeks(weeks.toLong())
 
         val user = systemUserService.getOrThrow()
@@ -226,7 +228,7 @@ class TrnAnalysisService(
      */
     fun getMonthlyIncome(
         months: Int = 12,
-        endMonth: YearMonth = YearMonth.now(),
+        endMonth: YearMonth = YearMonth.now(dateUtils.zoneId),
         portfolioIds: List<String> = emptyList(),
         groupBy: String = "assetClass"
     ): MonthlyIncomeResponse {

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/milestone/MilestoneServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/milestone/MilestoneServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.LocalDate
 import java.util.Optional
 
 class MilestoneServiceTest {
@@ -23,6 +24,11 @@ class MilestoneServiceTest {
     private lateinit var milestoneService: MilestoneService
 
     private val user = SystemUser(id = "user-123", email = "test@test.com")
+
+    // Fixed, arbitrary date — these tests assert on tier/milestoneId/actionId, never
+    // on the stamp itself. Zone-correctness of the stamp is covered separately by
+    // MilestoneServiceZoneTest.
+    private val someDate = LocalDate.of(2026, 1, 1)
 
     @BeforeEach
     fun setUp() {
@@ -41,8 +47,8 @@ class MilestoneServiceTest {
     fun `getEarnedMilestones returns all milestones for user`() {
         val milestones =
             listOf(
-                UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 1),
-                UserMilestone(owner = user, milestoneId = "first-steps", tier = 2)
+                UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 1, earnedAt = someDate),
+                UserMilestone(owner = user, milestoneId = "first-steps", tier = 2, earnedAt = someDate)
             )
         whenever(milestoneRepository.findByOwner(user)).thenReturn(milestones)
 
@@ -71,7 +77,7 @@ class MilestoneServiceTest {
     @Test
     fun `earnMilestone upgrades tier when new tier is higher`() {
         val existing =
-            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 1)
+            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 1, earnedAt = someDate)
         whenever(
             milestoneRepository.findByOwnerAndMilestoneId(user, "portfolio-builder")
         ).thenReturn(Optional.of(existing))
@@ -88,7 +94,7 @@ class MilestoneServiceTest {
     @Test
     fun `earnMilestone does not downgrade tier`() {
         val existing =
-            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 3)
+            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 3, earnedAt = someDate)
         whenever(
             milestoneRepository.findByOwnerAndMilestoneId(user, "portfolio-builder")
         ).thenReturn(Optional.of(existing))
@@ -102,7 +108,7 @@ class MilestoneServiceTest {
     @Test
     fun `earnMilestone does not change tier when same`() {
         val existing =
-            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 2)
+            UserMilestone(owner = user, milestoneId = "portfolio-builder", tier = 2, earnedAt = someDate)
         whenever(
             milestoneRepository.findByOwnerAndMilestoneId(user, "portfolio-builder")
         ).thenReturn(Optional.of(existing))
@@ -117,8 +123,8 @@ class MilestoneServiceTest {
     fun `getExplorerActions returns all actions for user`() {
         val actions =
             listOf(
-                UserExplorerAction(owner = user, actionId = "view:heatmap"),
-                UserExplorerAction(owner = user, actionId = "view:table")
+                UserExplorerAction(owner = user, actionId = "view:heatmap", recordedAt = someDate),
+                UserExplorerAction(owner = user, actionId = "view:table", recordedAt = someDate)
             )
         whenever(explorerActionRepository.findByOwner(user)).thenReturn(actions)
 

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/milestone/MilestoneServiceZoneTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/milestone/MilestoneServiceZoneTest.kt
@@ -1,0 +1,108 @@
+package com.beancounter.marketdata.milestone
+
+import com.beancounter.common.model.SystemUser
+import com.beancounter.common.model.UserExplorerAction
+import com.beancounter.common.model.UserMilestone
+import com.beancounter.common.utils.DateUtils
+import com.beancounter.marketdata.registration.UserPreferencesService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Optional
+import java.util.TimeZone
+
+/**
+ * Milestone/explorer-action stamps have to be resolved in the configured
+ * `beancounter.zone`, not the JVM default — the pods run UTC while users are SGT, so
+ * a bare `LocalDate.now()` earnedAt/recordedAt can be dated a day behind what the
+ * user actually earned it on.
+ *
+ * Kiritimati (UTC+14) is always at least a day ahead of Midway (UTC-11), so these
+ * assertions do not depend on the wall clock or on the host's zone.
+ */
+@ExtendWith(MockitoExtension::class)
+class MilestoneServiceZoneTest {
+    @Mock
+    private lateinit var milestoneRepository: UserMilestoneRepository
+
+    @Mock
+    private lateinit var explorerActionRepository: UserExplorerActionRepository
+
+    @Mock
+    private lateinit var userPreferencesService: UserPreferencesService
+
+    private val serviceZone = ZoneId.of("Pacific/Kiritimati")
+    private val user = SystemUser(id = "user-123", email = "test@test.com")
+
+    private fun serviceWithZone(): MilestoneService =
+        MilestoneService(
+            milestoneRepository,
+            explorerActionRepository,
+            userPreferencesService,
+            DateUtils(serviceZone.id)
+        )
+
+    @Test
+    fun `earnMilestone stamps a new milestone in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            whenever(
+                milestoneRepository.findByOwnerAndMilestoneId(user, "portfolio-builder")
+            ).thenReturn(Optional.empty())
+            whenever(milestoneRepository.save(any<UserMilestone>())).thenAnswer { it.arguments[0] }
+
+            val result = serviceWithZone().earnMilestone(user, "portfolio-builder", 1)
+
+            assertThat(result.earnedAt).isEqualTo(LocalDate.now(serviceZone))
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+
+    @Test
+    fun `earnMilestone stamps an upgraded tier in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            val existing =
+                UserMilestone(
+                    owner = user,
+                    milestoneId = "portfolio-builder",
+                    tier = 1,
+                    earnedAt = LocalDate.now(serviceZone).minusDays(1)
+                )
+            whenever(
+                milestoneRepository.findByOwnerAndMilestoneId(user, "portfolio-builder")
+            ).thenReturn(Optional.of(existing))
+            whenever(milestoneRepository.save(any<UserMilestone>())).thenAnswer { it.arguments[0] }
+
+            val result = serviceWithZone().earnMilestone(user, "portfolio-builder", 2)
+
+            assertThat(result.earnedAt).isEqualTo(LocalDate.now(serviceZone))
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+
+    @Test
+    fun `recordExplorerAction stamps in the configured zone`() {
+        val jvmDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Midway"))
+        try {
+            whenever(explorerActionRepository.save(any<UserExplorerAction>())).thenAnswer { it.arguments[0] }
+
+            val result = serviceWithZone().recordExplorerAction(user, "view:heatmap")
+
+            assertThat(result.recordedAt).isEqualTo(LocalDate.now(serviceZone))
+        } finally {
+            TimeZone.setDefault(jvmDefault)
+        }
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/eodhd/EodhdNewsServiceTest.kt
@@ -374,6 +374,8 @@ internal class EodhdNewsServiceTest {
         val winner =
             NewsArticle(
                 externalId = "https://example.com/news/race",
+                published = LocalDateTime.now(),
+                fetchedAt = LocalDateTime.now(),
                 title = "winner inserted first"
             )
         whenever(articleRepo.findByExternalId(eq("https://example.com/news/race")))
@@ -404,6 +406,8 @@ internal class EodhdNewsServiceTest {
         val existing =
             NewsArticle(
                 externalId = "https://example.com/news/123",
+                published = LocalDateTime.now(),
+                fetchedAt = LocalDateTime.now(),
                 title = "old title",
                 content = "old"
             )
@@ -454,6 +458,7 @@ internal class EodhdNewsServiceTest {
         NewsArticle(
             externalId = "ext-${title.hashCode()}",
             published = LocalDateTime.now().minusHours(1),
+            fetchedAt = LocalDateTime.now(),
             title = title,
             content = content,
             summary = summary,

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/utils/DateUtilsMocker.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/utils/DateUtilsMocker.kt
@@ -42,6 +42,10 @@ class DateUtilsMocker {
             Mockito
                 .`when`(dateUtils.getFormattedDate(TODAY))
                 .thenReturn(DateUtils().getFormattedDate())
+
+            Mockito
+                .`when`(dateUtils.date)
+                .thenReturn(DateUtils().date)
         }
     }
 }

--- a/svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
+++ b/svc-event/src/main/kotlin/com/beancounter/event/service/EventLoader.kt
@@ -27,7 +27,8 @@ import java.util.concurrent.Executors
 class EventLoader(
     config: EventLoaderConfig,
     @Value("\${beancounter.events.dividend.days-to-add:10}")
-    private val daysToAdd: Long = 10
+    private val daysToAdd: Long = 10,
+    private val dateUtils: DateUtils = DateUtils()
 ) {
     private val portfolioService = config.sharedConfig.portfolioService
     private val positionService = config.serviceConfig.positionService
@@ -134,7 +135,7 @@ class EventLoader(
      */
     fun loadEventsForAsset(
         assetId: String,
-        date: LocalDate = LocalDate.now()
+        date: LocalDate = dateUtils.date
     ): Int {
         var eventCount = 0
         val events = priceService.getEvents(assetId)

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/JpaPerformanceCacheService.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/JpaPerformanceCacheService.kt
@@ -1,16 +1,19 @@
 package com.beancounter.position.cache
 
+import com.beancounter.common.utils.DateUtils
 import com.beancounter.common.utils.KeyGenUtils
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 @Primary
 class JpaPerformanceCacheService(
-    private val repository: PerformanceSnapshotRepository
+    private val repository: PerformanceSnapshotRepository,
+    private val dateUtils: DateUtils = DateUtils()
 ) : PerformanceCacheService {
     private val log = LoggerFactory.getLogger(JpaPerformanceCacheService::class.java)
     private val keyGen = KeyGenUtils()
@@ -60,7 +63,8 @@ class JpaPerformanceCacheService(
                     marketValue = snapshot.marketValue,
                     externalCashFlow = snapshot.externalCashFlow,
                     netContributions = snapshot.netContributions,
-                    cumulativeDividends = snapshot.cumulativeDividends
+                    cumulativeDividends = snapshot.cumulativeDividends,
+                    createdAt = LocalDateTime.now(dateUtils.zoneId)
                 )
             }
         repository.saveAll(toSave)

--- a/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotEntity.kt
+++ b/svc-position/src/main/kotlin/com/beancounter/position/cache/PerformanceSnapshotEntity.kt
@@ -35,6 +35,9 @@ data class PerformanceSnapshotEntity(
     val netContributions: BigDecimal = BigDecimal.ZERO,
     @Column(name = "cumulative_dividends", nullable = false, precision = 19, scale = 4)
     val cumulativeDividends: BigDecimal = BigDecimal.ZERO,
+    // No default: this is a JPA entity with no DI, so it cannot resolve "now" in the
+    // configured beancounter.zone itself. The one caller (JpaPerformanceCacheService)
+    // passes an explicit LocalDateTime.now(dateUtils.zoneId).
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    val createdAt: LocalDateTime
 )


### PR DESCRIPTION
## What

Drains the `ZoneLeakGuardTest` baseline added in #1070 from **36 files to 11**. Every fixed
site now resolves "today" through the configured `beancounter.zone` rather than the pod's
JVM zone. Addresses the bulk of #1069.

## Reachable and user-visible

`UserMilestone.earnedAt` and `UserExplorerAction.recordedAt` were stamped by the *entity
default* because `MilestoneService` never passed a date — so an "earned on" date shown back
to the user could read a day behind. The service now passes `dateUtils.date` and the entity
defaults are gone. Covered by a new `MilestoneServiceZoneTest`.

## The rest

Batch windows and audit stamps: classification staleness cutoffs and `asOf`, price backfill
floors, news retention and fetch cooldowns, the dashboard summary window and current-month
income, the corporate-action match window, tax-rate and private-asset stamps, the
performance-snapshot timestamp. `InvestmentWindow` (a top-level function, no DI) now takes
the date from its caller. `MarketStackProxy`'s `date` argument was genuinely dead — deleted.

## Two landmines worth knowing about

**Injecting `DateUtils` and then reading it from a Kotlin default argument is a trap.** Any
test that builds the class with a raw Mockito `mock()` never runs the constructor, so the
field is null — and Kotlin evaluates the default by calling back into the real bridge
method on that null field. `AlphaClassificationEnricher` and `EodhdClassificationEnricher`
hit this, and production's `try/catch` swallowed the NPE into a **silent empty result** (4
tests reporting `FAILED` classifications rather than erroring). Both now pass `asOf`
explicitly. `MorningstarProxy` hit the same trap and is reverted into the baseline rather
than restructure its test's mocking strategy.

**`SystemUser.since` is reverted.** `register()` runs in nearly every MockMvc `@BeforeEach`
across svc-data, its contractTest suite and jar-client; several of those classes
`@MockitoBean DateUtils` without stubbing `.date`, which would push null into a non-null
parameter. It needs its own pass with the test-fixture work that implies.

## The 11 that remain

Each carries an inline reason in `zone-leak-baseline.txt` — mostly dead JPA entity defaults
whose callers all pass an explicit date, where removing the default means auditing many
fixtures. `MarketData.priceDate` is deliberately *not* routed through `beancounter.zone`: a
price date's correct authority is the **market's** zone.

## Test edits

Three existing test files changed: mechanical fixture updates forced by removing an entity
default (`earnedAt = someDate` etc.), plus one stubbing gap in the shared `DateUtilsMocker`
helper. No assertion was altered.

## Gates

`./gradlew testSmart` + `formatKotlin` + `lintKotlin` green — testSmart re-run independently
on top of the agent's run.

`ocr review` raised two findings, **both rejected after checking**:

1. *"Unused `java.time.LocalDate` import in `PositionMoveService`"* — correct, but it is a
   leftover from #1070 on `main`, already fixed in #1071. Left alone here to avoid a conflict.
2. *"Removing entity defaults breaks Hibernate's no-arg constructor requirement — `kotlin-jpa`
   plugin not found in build files"* (flagged **bug/high**) — false. The plugin is applied to
   every subproject at `build.gradle.kts:33` via `apply(plugin = "org.jetbrains.kotlin.plugin.jpa")`
   inside `subprojects {}`; ocr only looked for a `plugins {}` declaration. The synthetic
   no-arg constructor is generated.

Addresses #1069 (11 entries remain — keeping the issue open to track them).
