### PR TITLE
fix(alpha): honour market alpha alias, surface no-data classification

### DIFF
--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricher.kt
@@ -7,6 +7,7 @@ import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.alpha.AlphaConfig
 import com.beancounter.marketdata.providers.alpha.AlphaEtfProfileResponse
 import com.beancounter.marketdata.providers.alpha.AlphaOverviewResponse
+import com.beancounter.marketdata.providers.alpha.AlphaPriceService
 import com.beancounter.marketdata.providers.alpha.AlphaProxy
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -78,14 +79,14 @@ class AlphaClassificationEnricher(
         }
 
         if (response.isBlank() || response.contains("Error")) {
-            log.debug("No overview data for $symbol")
+            logNoData(asset, symbol, "OVERVIEW returned an error or empty body")
             return EnrichmentResult.FAILED
         }
 
         val overview = objectMapper.readValue(response, AlphaOverviewResponse::class.java)
 
         if (overview.sector.isNullOrBlank()) {
-            log.debug("No sector in overview for $symbol")
+            logNoData(asset, symbol, "OVERVIEW carried no Sector")
             return EnrichmentResult.NO_DATA
         }
 
@@ -140,7 +141,7 @@ class AlphaClassificationEnricher(
         }
 
         if (response.isBlank() || response.contains("Error")) {
-            log.debug("No ETF profile data for $symbol")
+            logNoData(asset, symbol, "ETF_PROFILE returned an error or empty body")
             return EnrichmentResult.FAILED
         }
 
@@ -150,7 +151,7 @@ class AlphaClassificationEnricher(
         val hasHoldings = !profile.holdings.isNullOrEmpty()
 
         if (!hasSectors && !hasHoldings) {
-            log.debug("No sector allocations or holdings in ETF profile for $symbol")
+            logNoData(asset, symbol, "ETF_PROFILE carried no sector allocations or holdings")
             return EnrichmentResult.NO_DATA
         }
 
@@ -226,6 +227,29 @@ class AlphaClassificationEnricher(
         log.info("Added $sectorCount sector exposures and $holdingCount holdings for ${asset.code}")
         return if (sectorCount > 0 || holdingCount > 0) EnrichmentResult.ENRICHED else EnrichmentResult.NO_DATA
     }
+
+    /**
+     * A no-data outcome stamps `classificationCheckedAt` (see `ClassificationRefreshService`), so
+     * the asset drops behind the staleness window and is not reconsidered for a week. At DEBUG
+     * that left no trace in a normal deployment log — VUAA sat with zero sector exposures and
+     * nothing to grep for.
+     *
+     * The queried symbol is the payload that matters: it is composed from the market's `alpha`
+     * alias, so it distinguishes a mapping fault (a symbol the provider has never heard of) from
+     * genuine coverage absence (AlphaVantage serves no fundamentals for non-US listings at all).
+     */
+    private fun logNoData(
+        asset: Asset,
+        symbol: String,
+        reason: String
+    ) = log.warn(
+        "No classification data from {} for symbol {} ({}:{}) - {}",
+        AlphaPriceService.ID,
+        symbol,
+        asset.market.code,
+        asset.code,
+        reason
+    )
 
     /**
      * AlphaVantage signals quota exhaustion with a top-level `Information` or `Note` key returned

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/classification/EodhdClassificationEnricher.kt
@@ -5,6 +5,7 @@ import com.beancounter.common.model.AssetClassification
 import com.beancounter.common.model.ClassificationLevel
 import com.beancounter.common.utils.DateUtils
 import com.beancounter.marketdata.providers.eodhd.EodhdConfig
+import com.beancounter.marketdata.providers.eodhd.EodhdPriceService
 import com.beancounter.marketdata.providers.eodhd.EodhdProxy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -53,12 +54,30 @@ class EodhdClassificationEnricher(
             EnrichmentResult.FAILED
         }
 
+    /**
+     * See [AlphaClassificationEnricher.logNoData] — a NO_DATA outcome stamps the asset as checked
+     * and silences it for the staleness window, so it has to be visible at WARN with the exact
+     * symbol that was queried.
+     */
+    private fun logNoData(
+        asset: Asset,
+        symbol: String,
+        reason: String
+    ) = log.warn(
+        "No classification data from {} for symbol {} ({}:{}) - {}",
+        EodhdPriceService.ID,
+        symbol,
+        asset.market.code,
+        asset.code,
+        reason
+    )
+
     private fun enrichEquity(asset: Asset): EnrichmentResult {
         val symbol = eodhdConfig.getPriceCode(asset)
         val general = eodhdProxy.getFundamentals(symbol, eodhdConfig.apiKey).general
 
         if (general?.sector.isNullOrBlank()) {
-            log.debug("No sector in fundamentals for $symbol")
+            logNoData(asset, symbol, "fundamentals carried no General.Sector")
             return EnrichmentResult.NO_DATA
         }
 
@@ -106,7 +125,7 @@ class EodhdClassificationEnricher(
         val sectorWeights = eodhdProxy.getFundamentals(symbol, eodhdConfig.apiKey).etfData?.sectorWeights
 
         if (sectorWeights.isNullOrEmpty()) {
-            log.debug("No sector weights in fundamentals for $symbol")
+            logNoData(asset, symbol, "fundamentals carried no ETF_Data.Sector_Weights")
             return EnrichmentResult.NO_DATA
         }
 

--- a/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfig.kt
+++ b/svc-data/src/main/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfig.kt
@@ -69,9 +69,26 @@ class AlphaConfig(
 
     override fun getBatchSize() = 1
 
+    /**
+     * AlphaVantage symbol suffix for [market].
+     *
+     * The `alpha:` alias in `application.yml` wins — BC market codes are not AlphaVantage
+     * exchange codes and the two only coincide by accident. BC's `LSE` market (USD-settled
+     * London lines such as VUAA) is the case that made this matter: AlphaVantage suffixes
+     * London with `.LON` and has no `.LSE`, so the pass-through below composed `VUAA.LSE`
+     * and every fundamentals lookup answered `{}`.
+     *
+     * The hardcoded fallbacks stay for markets carrying no `alpha` alias, and for [Market]
+     * instances built without an alias map (test fixtures, and any caller holding a Market
+     * that did not come through `MarketService`).
+     */
     fun translateMarketCode(market: Market): String? {
         if (isNullMarket(market.code)) {
             return null
+        }
+        val alias = market.getAlias(AlphaPriceService.ID)
+        if (!alias.isNullOrBlank()) {
+            return alias
         }
         return when (market.code.uppercase()) {
             "ASX" -> "AX"

--- a/svc-data/src/main/resources/application.yml
+++ b/svc-data/src/main/resources/application.yml
@@ -542,6 +542,13 @@ beancounter:
         aliases:
           FIGI: "LN"
           eodhd: "LSE"
+          # AlphaVantage suffixes London listings ".LON" — SYMBOL_SEARCH for VUAA
+          # returns VUAA.LON (plus .FRK / .DEX). It has no ".LSE" suffix at all, so
+          # without this alias every Alpha call for a USD London line composes an
+          # unknown symbol. Note Alpha serves no fundamentals for non-US listings
+          # regardless (OVERVIEW/ETF_PROFILE answer "{}"), so this fixes the symbol,
+          # not the coverage.
+          alpha: "LON"
 
       - code: "AMS"
         name: "Euronext Amsterdam"

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/classification/AlphaClassificationEnricherTest.kt
@@ -1,5 +1,9 @@
 package com.beancounter.marketdata.classification
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.beancounter.common.model.Asset
 import com.beancounter.common.model.ClassificationItem
 import com.beancounter.common.model.ClassificationLevel
@@ -20,6 +24,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
 
 /**
  * Unit tests for [AlphaClassificationEnricher].
@@ -298,5 +303,50 @@ class AlphaClassificationEnricherTest {
         verify(classificationService, never()).clearExposures(any())
         verify(classificationService, never()).addExposure(any(), any(), any(), any(), any())
         verify(classificationService, never()).addHolding(any(), any(), anyOrNull(), any(), any())
+    }
+
+    /**
+     * NO_DATA stamps `classificationCheckedAt`, so the asset drops behind the staleness window
+     * and is not looked at again for a week. At DEBUG that outcome left no trace in a normal
+     * kauri log - VUAA sat with zero sector exposures for months with nothing to grep for. The
+     * warning has to name the provider and the exact symbol that was asked for: the symbol is
+     * composed from the market alias, so it is the one thing that identifies a mapping fault.
+     */
+    @Test
+    fun `an empty ETF profile warns with provider and the symbol that was queried`() {
+        whenever(alphaProxy.getEtfProfile(eq("VUAA.LON"), any())).thenReturn("{}")
+
+        val warnings = captureWarnings { enricher.enrichClassification(etf("VUAA.LON")) }
+
+        assertThat(warnings)
+            .describedAs("empty ETF profile must be visible at WARN")
+            .anySatisfy { message ->
+                assertThat(message).contains("ALPHA").contains("VUAA.LON")
+            }
+    }
+
+    @Test
+    fun `an overview carrying no sector warns with provider and the symbol that was queried`() {
+        whenever(alphaProxy.getOverview(eq("TSCO.LON"), any())).thenReturn("{}")
+
+        val warnings = captureWarnings { enricher.enrichClassification(equity("TSCO.LON")) }
+
+        assertThat(warnings)
+            .describedAs("empty overview must be visible at WARN")
+            .anySatisfy { message ->
+                assertThat(message).contains("ALPHA").contains("TSCO.LON")
+            }
+    }
+
+    private fun captureWarnings(block: () -> Unit): List<String> {
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        val logger = LoggerFactory.getLogger(AlphaClassificationEnricher::class.java) as Logger
+        logger.addAppender(appender)
+        try {
+            block()
+        } finally {
+            logger.detachAppender(appender)
+        }
+        return appender.list.filter { it.level == Level.WARN }.map { it.formattedMessage }
     }
 }

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/markets/MarketServiceTest.kt
@@ -83,6 +83,10 @@ class MarketServiceTest {
             .hasFieldOrPropertyWithValue("currency.code", USD.code)
             .hasFieldOrPropertyWithValue("timezone", TimeZone.getTimeZone("Europe/London"))
         assertThat(lse.getAlias("eodhd")).isEqualTo("LSE")
+        // AlphaVantage suffixes London listings `.LON` (SYMBOL_SEARCH: VUAA.LON) - it has no
+        // concept of an `LSE` suffix, so BC's USD-line market needs an explicit alpha alias or
+        // every Alpha call composes an unknown symbol.
+        assertThat(lse.getAlias("alpha")).isEqualTo("LON")
 
         val lon = marketService.getMarket("LON")
         assertThat(lon.currency.code).isEqualTo(GBP.code)

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfigTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/providers/alpha/AlphaConfigTest.kt
@@ -49,4 +49,59 @@ class AlphaConfigTest {
             )
         assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("AAPL")
     }
+
+    @Test
+    fun `getPriceCode honours the market's alpha alias`() {
+        // BC's LSE market (USD-settled London lines, e.g. VUAA) is not a symbol suffix
+        // AlphaVantage recognises - SYMBOL_SEARCH returns VUAA.LON. Without the alias the
+        // code composed VUAA.LSE and every fundamentals call came back empty.
+        val asset =
+            Asset(
+                code = "VUAA",
+                market =
+                    Market(
+                        code = "LSE",
+                        aliases = mapOf("alpha" to "LON")
+                    )
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("VUAA.LON")
+    }
+
+    @Test
+    fun `getPriceCode falls back to the market code when no alpha alias is configured`() {
+        val asset =
+            Asset(
+                code = "VUAA",
+                market = Market(code = "LSE")
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("VUAA.LSE")
+    }
+
+    @Test
+    fun `getPriceCode ignores a blank alpha alias`() {
+        val asset =
+            Asset(
+                code = "BHP",
+                market =
+                    Market(
+                        code = "ASX",
+                        aliases = mapOf("alpha" to "")
+                    )
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("BHP.AX")
+    }
+
+    @Test
+    fun `getPriceCode keeps US-aggregator markets suffix-free even with an alpha alias`() {
+        val asset =
+            Asset(
+                code = "AAPL",
+                market =
+                    Market(
+                        code = "NASDAQ",
+                        aliases = mapOf("alpha" to "NASDAQ")
+                    )
+            )
+        assertThat(alphaConfig.getPriceCode(asset)).isEqualTo("AAPL")
+    }
 }


### PR DESCRIPTION
## Why

VUAA (Vanguard S&P 500 UCITS ETF USD Acc, BC market `LSE`) has never had sector
data. Investigated provider-first rather than code-first.

`AlphaConfig.translateMarketCode` was a hardcoded `when` that passed the raw BC
market code through for anything other than ASX/TSX/the US aggregators. BC's
`LSE` market — the USD-settled London lines added so VUAA isn't priced as GBX —
therefore composed `VUAA.LSE`.

AlphaVantage has no `.LSE` suffix. `SYMBOL_SEARCH?keywords=VUAA` returns:

| symbol | region | currency |
|---|---|---|
| `VUAA.LON` | United Kingdom | USD |
| `VUAA.FRK` | Frankfurt | EUR |
| `VUAA.DEX` | XETRA | EUR |

The `alpha:` alias map in `application.yml` already existed for exactly this,
but nothing read it.

## What changed

1. **`translateMarketCode` resolves the market's `alpha` alias first.** The
   hardcoded ASX/TSX fallbacks stay for markets with no alias and for `Market`
   instances built without an alias map (test fixtures, and any caller holding a
   Market that didn't come through `MarketService`).
2. **`alpha: "LON"` added to the `LSE` market.**
3. **No-data classification outcomes raised from DEBUG to WARN** in both the
   Alpha and EODHD enrichers, carrying the provider, the exact symbol queried,
   and the `market:code` pair.

Side effect worth naming: `NZX` already carried an `alpha: "NZ"` alias that had
no effect. It now takes effect. Alpha is not routed for NZX
(`providers.alpha.markets` omits it, and kauri sets that property empty), so
this is dead config finally doing what it says.

## This does not restore VUAA's sector data

Verified against the live API before touching code — AlphaVantage serves no
fundamentals for non-US listings on this key tier:

| call | result |
|---|---|
| `ETF_PROFILE&symbol=VOO` | full sectors payload |
| `ETF_PROFILE&symbol=VUAA.LON` | `{}` |
| `OVERVIEW&symbol=VUAA.LON` | `{}` |
| `OVERVIEW&symbol=TSCO.LON` | `{}` |

`{}` rather than an `Information` body, so it is genuine absence, not throttling.

The `eodhd` classification provider is the alternative, but the current EODHD
key 403s on `/api/fundamentals` for every symbol including `AAPL.US` — the
EOD-Historical plan excludes fundamentals. Prices on the same key are fine.

Follow-up tracked in #1073 — this PR fixes the symbol, not the coverage.

## Why the gap survived so long

A `NO_DATA` outcome stamps `classificationCheckedAt`, hiding the asset behind
the staleness window for a week, and the only trace was at DEBUG. VUAA sat with
zero rows in `asset_exposure` with nothing to grep for.

## Testing

Red-Green-Refactor. New coverage:

- `AlphaConfigTest` — alias honoured; falls back to the market code when absent;
  blank alias ignored; US-aggregator markets stay suffix-free even with an alias.
- `MarketServiceTest` — asserts the `LSE` market resolves `alpha` → `LON` from
  the real `application.yml`.
- `AlphaClassificationEnricherTest` — a `{}` ETF profile and a `{}` overview each
  emit a WARN naming the provider and the queried symbol (logback `ListAppender`).

Gates: `./gradlew testSmart` (955 tests), `formatKotlin`, `lintKotlin`, `ocr
review` (0 findings).

**Live-verified** against a local `svc-data` on this branch —
`POST /api/classifications/refresh/LSE/VUAA`:

```
INFO  c.b.m.c.ClassificationController    : Refreshing classification for LSE:VUAA
WARN  c.b.m.c.AlphaClassificationEnricher : No classification data from ALPHA for symbol VUAA.LON (LSE:VUAA) - ETF_PROFILE carried no sector allocations or holdings
```

`VUAA.LON`, not `VUAA.LSE` — and the outcome is now visible.
