### PR TITLE
chore(build): drop testSmart/buildSmart, run contractTest in check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ reason; `validateDependencies` enforces the rule.
 # Build everything (clean checkout OK)
 ./gradlew build
 
-# Run all tests incl. contract tests (buildSmart/testSmart remain as aliases)
+# Run all tests incl. contract tests
 ./gradlew testAll
 
 # Code quality
@@ -203,8 +203,7 @@ To switch from RabbitMQ to Kafka:
 
 ## Development Workflow
 
-1. **Daily Development**: `./gradlew build` / `./gradlew testAll` (clean checkout OK;
-   `buildSmart`/`testSmart` remain as aliases)
+1. **Daily Development**: `./gradlew build` / `./gradlew testAll` (clean checkout OK)
 2. **Before Committing**: Run `./gradlew check` for code quality
 3. **Code Formatting**: Auto-format with `./gradlew formatKotlin`
 
@@ -293,7 +292,7 @@ guidance — it applies unchanged here.
 
 ## Pre-Commit Checklist (beancounter-specific)
 
-- [ ] All tests passing: `./gradlew testSmart` (alias of `testAll`)
+- [ ] All tests passing: `./gradlew testAll`
 - [ ] New functionality has tests
 - [ ] Code formatted: `./gradlew formatKotlin`
 - [ ] Linting passes: `./gradlew lintKotlin`

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ See [CONTRACT_TEST_ARCHITECTURE.md](CONTRACT_TEST_ARCHITECTURE.md) for detailed 
 
 ```bash
 # Run all tests
-./gradlew testSmart
+./gradlew testAll
 
 # Run specific module tests
 ./gradlew :jar-client:test
 ./gradlew :svc-data:test
 
 # Run with coverage
-./gradlew testSmart jacocoTestReport
+./gradlew testAll jacocoTestReport
 ```
 
 ### Code Quality

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -362,19 +362,6 @@ tasks.register("verifyDependencies") {
     description = "Verify all project dependencies"
 }
 
-// Legacy aliases: stubs are now wired as Gradle project artifacts, so the
-// old "verify stubs exist in ~/.m2 first" dance is gone. Kept so existing
-// muscle memory / scripts / docs keep working.
-tasks.register("buildSmart") {
-    dependsOn("buildAll")
-    description = "Alias for buildAll (stub ordering handled by Gradle)"
-}
-
-tasks.register("testSmart") {
-    dependsOn("testAll")
-    description = "Alias for testAll (stub ordering handled by Gradle)"
-}
-
 // Validate dependency order
 tasks.register("validateDependencies") {
     doLast {

--- a/svc-data/build.gradle.kts
+++ b/svc-data/build.gradle.kts
@@ -115,6 +115,13 @@ tasks.named<Test>("contractTest") {
     }
 }
 
+// `contractTest` is its own source set, so the spring-cloud-contract plugin does
+// not attach it to `check`. CI runs `./gradlew build --parallel`, which means
+// contract verification was never executed there — only locally, via `testAll`.
+tasks.named("check") {
+    dependsOn("contractTest")
+}
+
 tasks.register<Test>("testSuites") {
     include("**/suites/**")
     useJUnitPlatform()

--- a/svc-position/build.gradle.kts
+++ b/svc-position/build.gradle.kts
@@ -94,6 +94,13 @@ contracts {
     baseClassForTests.set("com.contracts.position.ContractVerifierBase")
 }
 
+// `contractTest` is its own source set, so the spring-cloud-contract plugin does
+// not attach it to `check`. CI runs `./gradlew build --parallel`, which means
+// contract verification was never executed there — only locally, via `testAll`.
+tasks.named("check") {
+    dependsOn("contractTest")
+}
+
 tasks.register("pubStubs") {
     dependsOn("build")
     dependsOn("publishToMavenLocal")


### PR DESCRIPTION
Two related build-task cleanups. The second was found by doing the first.

Closes #1076

## 1. Drop `testSmart` / `buildSmart`

They were bare aliases:

```kotlin
// Legacy aliases: stubs are now wired as Gradle project artifacts, so the
// old "verify stubs exist in ~/.m2 first" dance is gone. Kept so existing
// muscle memory / scripts / docs keep working.
tasks.register("buildSmart") { dependsOn("buildAll") }
tasks.register("testSmart")  { dependsOn("testAll") }
```

The stub-ordering problem they existed for is gone. Audit of what still referenced them:

- CI: nothing — `.circleci/config.yml:46` runs `./gradlew build --parallel`
- Hooks / `scripts/`: nothing
- Docs only: `README.md` ×2, `CLAUDE.md` ×3 — all repointed at the real tasks

## 2. `contractTest` now runs in `check` — it was never running in CI

Removing the alias exposed why it mattered. `contractTest` is its own source set, so the spring-cloud-contract plugin does not attach it to `check`, and the aggregate `testAll` task was the only thing that reached it:

```kotlin
tasks.register("testAll") {
    dependsOn(subprojects.map { "${it.path}:test" })
    dependsOn(":svc-data:contractTest")
    dependsOn(":svc-position:contractTest")
}
```

CI does not call `testAll`. `build` → `check` → `test`, and nothing in that graph reaches `contractTest`. Confirmed by dry-run on `origin/main`: `:svc-data:check` and `:svc-position:check` list no contract task.

So the 61 contract tests only ever ran on a developer machine that happened to invoke `testAll` — not the documented CI path.

Fix, in both stub producers:

```kotlin
tasks.named("check") {
    dependsOn("contractTest")
}
```

## Verification

Ran CI's exact command on this branch:

```
./gradlew build --parallel
  > Task :svc-data:contractTest
  > Task :svc-position:contractTest
BUILD SUCCESSFUL in 5m 36s
```

Result counts from `build/test-results/contractTest/`: svc-data 58 tests / 0 failures, svc-position 3 tests / 0 failures.

Nothing was being masked — the gap was coverage, not hidden breakage. CI wall-clock grows by roughly the contract-test time.

`formatKotlin`, `lintKotlin`, `ocr review` (0 findings) all clean.

## Risk

`gt`/local muscle memory typing `./gradlew testSmart` now gets "task not found". `testAll` is the replacement and is what the docs in this PR say.
