### PR TITLE
fix(fx): stop requesting rates a same-currency trade does not need

### DIFF
--- a/jar-common/src/main/kotlin/com/beancounter/client/ingest/FxTransactions.kt
+++ b/jar-common/src/main/kotlin/com/beancounter/client/ingest/FxTransactions.kt
@@ -3,6 +3,7 @@ package com.beancounter.client.ingest
 import com.beancounter.client.FxService
 import com.beancounter.common.contracts.FxPairResults
 import com.beancounter.common.contracts.FxRequest
+import com.beancounter.common.contracts.FxResponse
 import com.beancounter.common.exception.BusinessException
 import com.beancounter.common.input.TrnInput
 import com.beancounter.common.model.Currency
@@ -122,10 +123,23 @@ class FxTransactions(
     ) {
         if (needsRates(trnInput)) {
             val fxRequest = getFxRequest(portfolio, trnInput)
-            val (data) = fxClientService.getRates(fxRequest)
+            val (data) = getRates(fxRequest)
             setRates(data, fxRequest, trnInput)
         }
     }
+
+    /**
+     * A request with no pairs has nothing to convert — trade, portfolio, base and cash
+     * all share one currency, so every rate is 1. Skip the round trip: the server
+     * resolves rates by date, so an empty request still fails when no rate is cached
+     * for that date, rejecting a trade that never needed FX.
+     */
+    private fun getRates(fxRequest: FxRequest): FxResponse =
+        if (fxRequest.pairs.isEmpty()) {
+            FxResponse(FxPairResults())
+        } else {
+            fxClientService.getRates(fxRequest)
+        }
 
     /**
      * Settle-time FX resolution. PROPOSED corporate-event trns (DIVI) are written with
@@ -139,7 +153,7 @@ class FxTransactions(
     ) {
         if (!needsRates(trn)) return
         val fxRequest = getFxRequest(portfolio, trn)
-        val (data) = fxClientService.getRates(fxRequest)
+        val (data) = getRates(fxRequest)
         // Resolve all three rates into locals first. If the provider returns an
         // incomplete response, throw before touching the managed entity so the
         // Trn is not left partially mutated in the JPA persistence context.

--- a/jar-common/src/test/kotlin/com/beancounter/client/ingest/FxTransactionsSameCurrencyTest.kt
+++ b/jar-common/src/test/kotlin/com/beancounter/client/ingest/FxTransactionsSameCurrencyTest.kt
@@ -1,0 +1,71 @@
+package com.beancounter.client.ingest
+
+import com.beancounter.client.FxService
+import com.beancounter.common.contracts.FxRequest
+import com.beancounter.common.contracts.FxResponse
+import com.beancounter.common.exception.SystemException
+import com.beancounter.common.input.TrnInput
+import com.beancounter.common.model.CallerRef
+import com.beancounter.common.model.Currency
+import com.beancounter.common.model.Portfolio
+import com.beancounter.common.model.TrnType
+import com.beancounter.common.utils.DateUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * A trade whose currency matches both the portfolio and its base needs no conversion —
+ * every pair resolves to null, so the request carries no pairs at all. Asking the FX
+ * service for nothing is not merely wasteful: the rate lookup is date-driven, so it
+ * fails whenever no rate happens to be cached for that date, and a trade that needed
+ * no FX is rejected because of FX.
+ */
+class FxTransactionsSameCurrencyTest {
+    private val usd = Currency("USD")
+
+    /**
+     * Stands in for a server that has no rate cached for the trade date — the state that
+     * makes this fail. Any call at all is the defect, so the fake refuses every one.
+     */
+    private val unreachableFxService =
+        object : FxService {
+            override fun getRates(
+                fxRequest: FxRequest,
+                token: String
+            ): FxResponse = throw SystemException("No rates found from EXCHANGE_RATES_API")
+        }
+
+    private val fxTransactions = FxTransactions(unreachableFxService)
+
+    private val portfolio =
+        Portfolio(
+            id = "same-ccy",
+            currency = usd,
+            base = usd
+        )
+
+    private val trnInput =
+        TrnInput(
+            callerRef = CallerRef(),
+            assetId = "asset-id",
+            trnType = TrnType.BUY,
+            quantity = BigDecimal("4"),
+            tradeCurrency = usd.code,
+            tradeDate = DateUtils().date,
+            price = BigDecimal("500.00"),
+            tradeAmount = BigDecimal("2000.00")
+        )
+
+    @Test
+    fun `should not consult the fx service when no currency pair needs converting`() {
+        fxTransactions.setRates(
+            portfolio,
+            trnInput
+        )
+
+        assertThat(trnInput.tradePortfolioRate).isEqualByComparingTo(BigDecimal.ONE)
+        assertThat(trnInput.tradeBaseRate).isEqualByComparingTo(BigDecimal.ONE)
+        assertThat(trnInput.tradeCashRate).isEqualByComparingTo(BigDecimal.ONE)
+    }
+}

--- a/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/RebalanceTrnTest.kt
+++ b/svc-data/src/test/kotlin/com/beancounter/marketdata/trn/RebalanceTrnTest.kt
@@ -20,12 +20,17 @@ import com.beancounter.marketdata.assets.DefaultEnricher
 import com.beancounter.marketdata.assets.EnrichmentFactory
 import com.beancounter.marketdata.assets.figi.FigiProxy
 import com.beancounter.marketdata.currency.CurrencyService
+import com.beancounter.marketdata.fx.fxrates.ExRatesResponse
+import com.beancounter.marketdata.fx.fxrates.FxGateway
 import com.beancounter.marketdata.utils.BcMvcHelper
 import com.beancounter.marketdata.utils.RegistrationUtils
 import com.beancounter.marketdata.utils.TRNS_ROOT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.oauth2.jwt.Jwt
@@ -47,11 +52,16 @@ import java.math.BigDecimal
 class RebalanceTrnTest {
     private val dateUtils = DateUtils()
 
+    private val usdSgd = BigDecimal("1.35")
+
     @MockitoBean
     private lateinit var jwtDecoder: JwtDecoder
 
     @MockitoBean
     private lateinit var figiProxy: FigiProxy
+
+    @MockitoBean
+    private lateinit var fxGateway: FxGateway
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -80,6 +90,32 @@ class RebalanceTrnTest {
         bcMvcHelper = BcMvcHelper(mockMvc, token)
 
         RegistrationUtils.registerUser(mockMvc, token)
+        mockFxRates()
+    }
+
+    /**
+     * FX rates are looked up by date against a database that all `@SpringMvcDbTest`
+     * classes share, so a trade priced today resolves — or fails — according to whatever
+     * ran before it (#1075). Stub the provider so this class supplies the one rate it
+     * needs and the outcome no longer depends on execution order.
+     */
+    private fun mockFxRates() {
+        `when`(
+            fxGateway.getRatesForSymbols(
+                any(),
+                eq(USD.code),
+                eq(currencyService.currenciesAs())
+            )
+        ).thenReturn(
+            ExRatesResponse(
+                USD.code,
+                dateUtils.date,
+                mapOf(
+                    USD.code to BigDecimal.ONE,
+                    SGD.code to usdSgd
+                )
+            )
+        )
     }
 
     @Test
@@ -227,7 +263,9 @@ class RebalanceTrnTest {
         assertThat(response.data.trns).hasSize(1)
         val createdTrn = response.data.trns.first()
         assertThat(createdTrn.tradeCurrencyCode).isEqualTo(USD.code)
-        // FX rates should be populated by svc-data
-        assertThat(createdTrn.tradeBaseRate).isNotNull()
+        // USD trade into an SGD portfolio: svc-data resolves the stubbed USD:SGD rate.
+        // Base is USD, so the trade needs no conversion to it.
+        assertThat(createdTrn.tradePortfolioRate).isEqualByComparingTo(usdSgd)
+        assertThat(createdTrn.tradeBaseRate).isEqualByComparingTo(BigDecimal.ONE)
     }
 }


### PR DESCRIPTION
Closes #1075.

### What was wrong

A trade whose currency matches the portfolio **and** its base needs no conversion — `FxTransactions.pair()` returns null for all three legs, so the `FxRequest` goes out with an empty `pairs` set. The server does not treat that as "nothing to do": `FxRateService.getRates` resolves the trade date, looks for a cached rate on it, asks the provider when there is none, and throws `SystemException("No rates found from …")` when the provider returns empty. A trade that needed no FX was rejected because of FX.

### Why it looked intermittent

All 61 `@SpringMvcDbTest` classes share one H2 instance (`DB_CLOSE_DELAY=-1`), so whether a rate happened to be cached for today depended on which class ran first. `RebalanceTrnTest` registers no FX stub of its own, so it inherited that state — the failure in #1075.

It is not only a test defect. The same path fails in a live deployment whose `fx_rate` table has nothing for the trade date: a fresh environment, or a Monday before the schedule has run.

### The change

- `FxTransactions` answers an empty request itself — no pairs, no round trip. Rates default to `ONE`, exactly as before. Applies to both the `TrnInput` (create) and `Trn` (settle-time) paths.
- `RebalanceTrnTest` stubs `FxGateway` so the SGD-portfolio case supplies the USD:SGD rate it needs, and now asserts the rate that actually lands on the trn (`tradePortfolioRate == 1.35`) instead of `isNotNull`.

### Tests

- `FxTransactionsSameCurrencyTest` (new, jar-common): an FX service that throws on any call. Fails on `main` with the exact production exception, passes with the fix — the assertion is the absence of the call, expressed through behaviour rather than mock verification.
- `./gradlew testAll` green; `formatKotlin`, `lintKotlin` clean; `ocr review --from main --to HEAD` returned no findings.

### Deliberately not in scope

The shared `DB_CLOSE_DELAY=-1` H2 instance is the reason this class of flake exists at all, and #1075 asks whether it is intentional. Changing it touches all 61 classes, so it is filed separately rather than bundled here.